### PR TITLE
fix #140 Remove ' Configuration' suffix from settings section title

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,7 +433,7 @@
       }
     ],
     "configuration": {
-      "title": "InterSystems ObjectScript Configuration",
+      "title": "InterSystems ObjectScript",
       "type": "object",
       "properties": {
         "objectscript.conn": {


### PR DESCRIPTION
Simply remove the anomalous suffix text.