### PR TITLE
Add more studio actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,10 @@
           "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:/"
         },
         {
+          "command": "vscode-objectscript.studio.contextActions",
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:/"
+        },
+        {
           "command": "vscode-objectscript.explorer.otherNamespace",
           "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:extra:).)*$/",
           "group": "inline"
@@ -410,6 +414,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.studio.actions",
         "title": "Studio actions"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.studio.contextActions",
+        "title": "Studio context actions"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -624,6 +624,11 @@
           "type": "boolean",
           "default": true,
           "description": "Show `Debug this method` action for ClassMethods"
+        },
+        "objectscript.studioActionDebugOutput": {
+          "type": "boolean",
+          "default": false,
+          "description": "Output the action that VSCode should perform as requested by the server in JSON format."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -413,12 +413,12 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.studio.actions",
-        "title": "Studio actions"
+        "title": "Studio Actions"
       },
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.studio.contextActions",
-        "title": "Studio context actions"
+        "title": "Studio Context Actions"
       }
     ],
     "keybindings": [

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -197,7 +197,11 @@ export class AtelierAPI {
               }
             }
             if (data.result.status && data.result.status !== "") {
-              outputChannel.appendLine(data.result.status);
+              const status: string = data.result.status;
+              outputChannel.appendLine(status);
+              if(status.endsWith("is marked as read only by source control hooks.")) {
+                vscode.window.showWarningMessage(status, { modal: true });
+              }
               throw new Error(data.result.status);
             }
             if (data.status.summary) {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -187,7 +187,14 @@ export class AtelierAPI {
               data.result.content = Buffer.from(data.result.content.join(""), "base64");
             }
             if (data.console) {
-              outputConsole(data.console);
+              // Let studio actions handle their console output
+              const isStudioAction = data.result.content != undefined
+                && data.result.content.length !== 0
+                && data.result.content[0] != undefined
+                && data.result.content[0].action != undefined;
+              if(!isStudioAction) {
+                outputConsole(data.console);
+              }
             }
             if (data.result.status && data.result.status !== "") {
               outputChannel.appendLine(data.result.status);

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -38,7 +38,7 @@ function updateOthers(others: string[]) {
   });
 }
 
-async function loadChanges(files: CurrentFile[]): Promise<any> {
+export async function loadChanges(files: CurrentFile[]): Promise<any> {
   if (!files.length) {
     return;
   }

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -104,8 +104,8 @@ async function compile(docs: CurrentFile[], flags?: string): Promise<any> {
     .then(loadChanges);
 }
 
-export async function importAndCompile(askFLags = false): Promise<any> {
-  const file = currentFile();
+export async function importAndCompile(askFLags = false, document?: vscode.TextDocument): Promise<any> {
+  const file = currentFile(document);
   if (!file) {
     return;
   }

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { config, FILESYSTEM_SCHEMA } from "../extension";
-import { outputChannel, outputConsole } from "../utils";
+import { outputChannel, outputConsole, currentFile } from "../utils";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { ClassNode } from "../explorer/models/classesNode";
 import { PackageNode } from "../explorer/models/packageNode";
 import { RoutineNode } from "../explorer/models/routineNode";
 import { NodeBase } from "../explorer/models/nodeBase";
-import { importAndCompile } from "./compile";
+import { importAndCompile, loadChanges } from "./compile";
 
 export let documentBeingProcessed: vscode.TextDocument = null;
 
@@ -54,6 +54,10 @@ class StudioActions {
     if (errorText !== "") {
       outputChannel.appendLine(errorText);
       outputChannel.show();
+    }
+    if(userAction.reload) {
+      const document = vscode.window.activeTextEditor.document;
+      loadChanges([currentFile(document)]);
     }
     if(config().studioActionDebugOutput) {
       outputChannel.appendLine(JSON.stringify(userAction));

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -156,7 +156,7 @@ class StudioActions {
           const filetype = splitClassname[splitClassname.length - 1];
           const isCorrectMethod = (text: string) => (filetype === "cls")
             ? text.match("Method " + method)
-            : text.startsWith(method)
+            : text.startsWith(method);
 
           const uri = DocumentContentProvider.getUri(classname);
           vscode.window.showTextDocument(uri, {"preview": false}).then(newEditor => {
@@ -331,7 +331,7 @@ class StudioActions {
     // Save all documents
     if(bitString.charAt(2) === "1") {
       for(const document of vscode.workspace.textDocuments) {
-        await saveAndCompile(document)
+        await saveAndCompile(document);
       }
     }
   }
@@ -380,7 +380,7 @@ function getOtherStudioActionLabel(action: OtherStudioAction): string {
     case OtherStudioAction.ConnectedToNewNamespace:
       label = "Changed Namespace";
     case OtherStudioAction.FirstTimeDocumentSave:
-      label = "Saved Document to Server for the First Time"
+      label = "Saved Document to Server for the First Time";
   }
   return label;
 }

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -292,22 +292,22 @@ class StudioActions {
   }
 
   public fireOtherStudioAction(action: OtherStudioAction) {
+    const actionObject = {
+      id: action.toString(),
+      label: getOtherStudioActionLabel(action)
+    };
     if(action === OtherStudioAction.AttemptedEdit) {
       const query = "select * from %Atelier_v1_Utils.Extension_GetStatus(?)";
       this.api.actionQuery(query, [this.name]).then(statusObj => {
         const docStatus = statusObj.result.content.pop();
         if(!docStatus.editable) {
           vscode.commands.executeCommand('undo');
-        } else {
-          return;
+          this.userAction(actionObject, false, "", "", 1);
         }
       });
+    } else {
+      this.userAction(actionObject, false, "", "", 1);
     }
-    const actionObject = {
-      id: action.toString(),
-      label: getOtherStudioActionLabel(action)
-    };
-    this.userAction(actionObject, false, "", "", 1);
   }
 
   private async processSaveFlag(saveFlag: number) {

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -2,6 +2,11 @@ import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { config, FILESYSTEM_SCHEMA } from "../extension";
 import { outputChannel } from "../utils";
+import { DocumentContentProvider } from "../providers/DocumentContentProvider";
+import { ClassNode } from "../explorer/models/classesNode";
+import { PackageNode } from "../explorer/models/packageNode";
+import { RoutineNode } from "../explorer/models/routineNode";
+import { NodeBase } from "../explorer/models/nodeBase";
 
 interface StudioAction extends vscode.QuickPickItem {
   name: string;
@@ -13,10 +18,19 @@ class StudioActions {
   private api: AtelierAPI;
   private name: string;
 
-  public constructor(uri: vscode.Uri) {
-    this.uri = uri;
-    this.name = this.uri.path.slice(1).replace(/\//g, ".");
-    this.api = new AtelierAPI(uri.authority);
+  public constructor(uriOrNode: vscode.Uri | PackageNode | ClassNode | RoutineNode) {
+    if(uriOrNode instanceof vscode.Uri) {
+      const uri: vscode.Uri = uriOrNode;
+      this.uri = uri;
+      this.name = this.uri.path.slice(1).replace(/\//g, ".");
+      this.api = new AtelierAPI(uri.authority);
+    } else {
+      const node: NodeBase = uriOrNode;
+      this.api = new AtelierAPI();
+      this.name = (node instanceof PackageNode)
+        ? node.fullName + ".PKG"
+        : node.fullName;
+    }
   }
 
   public processUserAction(userAction): Thenable<any> {
@@ -36,79 +50,133 @@ class StudioActions {
           .showWarningMessage(target, { modal: true }, "Yes", "No")
           .then(answer => (answer === "Yes" ? "1" : answer === "No" ? "0" : "2"));
       case 2: // Run a CSP page/Template. The Target is the full url to the CSP page/Template
-        // Open the target URL in a webview
-        const conn = config().conn;
-        const column = vscode.window.activeTextEditor
-          ? vscode.window.activeTextEditor.viewColumn
-          : undefined;
-        const panel = vscode.window.createWebviewPanel(
-          'studioactionwebview',
-          'CSP Page',
-          column || vscode.ViewColumn.One,
-          {
-            enableScripts: true,
-          }
-        );
-        panel.webview.html = `
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-            <style type="text/css">
-              body, html
-              {
-                margin: 0; padding: 0; height: 100%; overflow: hidden;
-              }
-              #content
-              {
-                position:absolute; left: 0; right: 0; bottom: 0; top: 0px;
-              }
-            </style>
-          </head>
-          <body>
-            <div id="content">
-              <iframe src="http://${conn.host}:${conn.port}${target}" onLoad="checkForCancelState()" width="100%" height="100%" frameborder="0"></iframe>
-            </div>
-            <script>
-              function checkForCancelState() {
-                var x = document.getElementsByTagName("BODY")[0];
-                console.log(x);
-              }
-            </script>
-          </body>
-          </html>
-          `;
-        panel.onDidDispose(
-          () => {
-            // fire a cancel answer if the user closes the webview
-            return "2";
-          }
-        );
-        // TODO: use panel.dispose() when the cancel text is sent back in the iframe
-        break;
-        // throw new Error("Not suppoorted");
+        return new Promise((resolve) => {
+          let answer = "2";
+          const conn = config().conn;
+          const column = vscode.window.activeTextEditor
+            ? vscode.window.activeTextEditor.viewColumn
+            : undefined;
+          const panel = vscode.window.createWebviewPanel(
+            "studioactionwebview",
+            "Studio Extension Page",
+            column || vscode.ViewColumn.One,
+            {
+              enableScripts: true,
+            }
+          );
+          panel.webview.onDidReceiveMessage(message => {
+            if(message.result && message.result === "done") {
+              answer = "1";
+              panel.dispose();
+            }
+          });
+          panel.onDidDispose(() => resolve(answer));
+
+          const url = new URL(`http://${conn.host}:${conn.port}${target}`);
+          const api = new AtelierAPI();
+          api.actionQuery("select %Atelier_v1_Utils.General_GetCSPToken(?) token", [url.toString()]).then(tokenObj => {
+            const csptoken = tokenObj.result.content[0].token;
+            url.searchParams.set('CSPCHD', csptoken);
+            url.searchParams.set('Namespace', conn.ns);
+            panel.webview.html = `
+              <!DOCTYPE html>
+              <html lang="en">
+              <head>
+                <style type="text/css">
+                  body, html {
+                    margin: 0; padding: 0; height: 100%; overflow: hidden;
+                    background-color: white;
+                  }
+                  #content {
+                    position:absolute; left: 0; right: 0; bottom: 0; top: 0px;
+                  }
+                </style>
+              </head>
+              <body>
+                <div id="content">
+                  <iframe src="${url.toString()}" width="100%" height="100%" frameborder="0"></iframe>
+                </div>
+                <script>
+                  const vscode = acquireVsCodeApi();
+                  window.addEventListener("message", receiveMessage, false);
+                  function receiveMessage(event) {
+                    vscode.postMessage(event.data);
+                  }
+                </script>
+              </body>
+              </html>
+              `;
+          });
+        });
       case 3: // Run an EXE on the client.
         throw new Error("Not suppoorted");
       case 4: // Insert the text in Target in the current document at the current selection point
-        throw new Error("Not suppoorted");
+        const editor = vscode.window.activeTextEditor;
+        if(editor) {
+          editor.edit(editBuilder => {
+            editBuilder.replace(editor.selection, target);
+          });
+        }
+        return;
       case 5: // Studio will open the documents listed in Target
-        throw new Error("Not suppoorted");
+        target.split(",").forEach(element => {
+          let classname = element;
+          let method: string;
+          let offset = 0;
+          if(element.includes(":")) {
+            [classname, method] = element.split(":");
+            if(method.includes("+")) {
+              offset = +method.split("+")[1];
+              method = method.split("+")[0];
+            }
+          }
+
+          const splitClassname = classname.split(".");
+          const filetype = splitClassname[splitClassname.length - 1];
+          const isCorrectMethod = (text: string) => (filetype === "cls")
+            ? text.match("Method " + method)
+            : text.startsWith(method)
+
+          const uri = DocumentContentProvider.getUri(classname);
+          vscode.window.showTextDocument(uri, {"preview": false}).then(newEditor => {
+            if(method) {
+              const document = newEditor.document;
+              for(let i = 0; i < document.lineCount; i++) {
+                const line = document.lineAt(i);
+                if(isCorrectMethod(line.text)) {
+                  if(!line.text.endsWith("{")) offset++;
+                  const cursor = newEditor.selection.active;
+                  const newPosition = cursor.with(i + offset, 0);
+                  newEditor.selection = new vscode.Selection(newPosition, newPosition);
+                  break;
+                }
+              }
+            }
+          });
+        });
+        return;
       case 6: // Display an alert dialog in Studio with the text from the Target variable.
         return vscode.window.showWarningMessage(target, { modal: true });
       case 7: // Display a dialog with a textbox and Yes/No/Cancel buttons.
         return vscode.window.showInputBox({
           prompt: target,
+        }).then(msg => {
+          return {
+            "msg": (msg ? msg : ""),
+            "answer": (msg ? 1 : 2)
+          }
         });
       default:
         throw new Error("Not suppoorted");
     }
   }
 
-  private userAction(action, afterUserAction = false, answer = "", msg = ""): Thenable<void> {
+  private userAction(action, afterUserAction = false, answer = "", msg = "", type = 0): Thenable<void> {
     if (!action) {
       return;
     }
-    const func = afterUserAction ? "AfterUserAction" : "UserAction";
-    const query = `select * from %Atelier_v1_Utils.Extension_${func}(?, ?, ?, ?)`;
+    const func = afterUserAction ? "AfterUserAction(?, ?, ?, ?, ?)" : "UserAction(?, ?, ?, ?)";
+    const query = `select * from %Atelier_v1_Utils.Extension_${func}`;
     let selectedText = "";
     const editor = vscode.window.activeTextEditor;
     if (!editor) {
@@ -118,8 +186,9 @@ class StudioActions {
     selectedText = editor.document.getText(selection);
 
     const parameters = afterUserAction
-      ? ["0", action.id, this.name, answer]
-      : ["0", action.id, this.name, selectedText];
+      ? [type.toString(), action.id, this.name, answer, msg]
+      : [type.toString(), action.id, this.name, selectedText];
+
     return vscode.window.withProgress(
       {
         cancellable: false,
@@ -129,34 +198,44 @@ class StudioActions {
       () =>
         this.api
           .actionQuery(query, parameters)
-          .then(data => data.result.content.pop())
+          .then(data => {
+            const actionInfo = data.result.content.pop();
+            actionInfo.save = action.save;
+            return actionInfo;
+          })
+          .then(this.processSaveFlag)
           .then(this.processUserAction)
           .then(answer => {
             if (answer) {
-              return this.userAction(action, true, answer);
+              return (answer.msg || answer.msg === "")
+                ? this.userAction(action, true, answer.answer, answer.msg, type)
+                : this.userAction(action, true, answer, "", type);
             }
           })
           .catch(err => {
+            console.log(err);
             outputChannel.appendLine(`Studio Action "${action.label}" not supported`);
             outputChannel.show();
           })
     );
   }
 
-  private constructMenu(menu): any[] {
+  private constructMenu(menu, contextOnly = false): any[] {
     return menu
+      .filter(menuGroup => !(contextOnly && menuGroup.type === "main"))
       .reduce(
         (list, sub) =>
           list.concat(
             sub.items
               .filter(el => el.id !== "" && el.separator == 0)
-              // .filter(el => el.enabled == 1)
+              .filter(el => el.enabled == 1)
               .map(el => ({
                 ...el,
                 id: `${sub.id},${el.id}`,
                 label: el.name.replace("&", ""),
                 itemId: el.id,
                 type: sub.type,
+                description: sub.name.replace("&", ""),
               }))
           ),
         []
@@ -170,18 +249,56 @@ class StudioActions {
       });
   }
 
-  public getMenu(menuType: string): Thenable<any> {
+  public getMenu(menuType: string, contextOnly = false): Thenable<any> {
+    let selectedText = "";
+    const editor = vscode.window.activeTextEditor;
+    if(this.uri && editor) {
+      const selection = editor.selection;
+      selectedText = editor.document.getText(selection);
+    }
+
     const query = "select * from %Atelier_v1_Utils.Extension_GetMenus(?,?,?)";
-    const parameters = [menuType, this.name, ""];
+    const parameters = [menuType, this.name, selectedText];
 
     return this.api
       .actionQuery(query, parameters)
       .then(data => data.result.content)
-      .then(this.constructMenu)
+      .then(menu => this.constructMenu(menu, contextOnly))
       .then(menuItems => {
         return vscode.window.showQuickPick<StudioAction>(menuItems, { canPickMany: false });
       })
       .then(action => this.userAction(action));
+  }
+
+  public attemptedEdit() {
+    const query = "select * from %Atelier_v1_Utils.Extension_GetStatus(?)";
+    this.api.actionQuery(query, [this.name]).then(statusObj => {
+      const docStatus = statusObj.result.content.pop();
+      // if(!docStatus.editable && docStatus.inSourceControl && !docStatus.isCheckedOut) {
+      if(!docStatus.editable) {
+        const attemptedEditAction = {
+          id: "0",
+          label: "Attempted Edit"
+        };
+        vscode.commands.executeCommand('undo');
+        this.userAction(attemptedEditAction, false, "", "", 1);
+      } // else if(!docStatus.editable && docStatus.in)
+    });
+  }
+
+  private async processSaveFlag(userAction) {
+    if(userAction.save) {
+      const bitString = userAction.save.toString().padStart(3, "0");
+      // Save the current document
+      if(bitString.charAt(0) === "1") {
+        await vscode.window.activeTextEditor.document.save();
+      }
+      // Save all documents
+      if(bitString.charAt(2) === "1") {
+        await vscode.workspace.saveAll();
+      }
+    }
+    return userAction;
   }
 }
 
@@ -196,4 +313,21 @@ export async function mainMenu(uri: vscode.Uri) {
   }
   const studioActions = new StudioActions(uri);
   return studioActions && studioActions.getMenu("");
+}
+
+export async function fireAttemptedEdit(uri: vscode.Uri) {
+  if(!uri || uri.scheme !== FILESYSTEM_SCHEMA) {
+    return;
+  }
+  const studioActions = new StudioActions(uri);
+  studioActions.attemptedEdit();
+}
+
+export async function contextMenu(node: PackageNode | ClassNode | RoutineNode): Promise<any> {
+  const nodeOrUri = node || vscode.window.activeTextEditor.document.uri;
+  if(!nodeOrUri || (nodeOrUri instanceof vscode.Uri && nodeOrUri.scheme !== FILESYSTEM_SCHEMA)) {
+    return;
+  }
+  const studioActions = new StudioActions(nodeOrUri);
+  return studioActions && studioActions.getMenu("", true);
 }

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -45,7 +45,9 @@ class StudioActions {
       outputChannel.appendLine(errorText);
       outputChannel.show();
     }
-    // outputChannel.appendLine(JSON.stringify(userAction));
+    if(config().studioActionDebugOutput) {
+      outputChannel.appendLine(JSON.stringify(userAction));
+    }
     switch (serverAction) {
       case 0:
         /// do nothing

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
-import { FILESYSTEM_SCHEMA } from "../extension";
+import { config, FILESYSTEM_SCHEMA } from "../extension";
 import { outputChannel } from "../utils";
 
 interface StudioAction extends vscode.QuickPickItem {
@@ -36,7 +36,10 @@ class StudioActions {
           .showWarningMessage(target, { modal: true }, "Yes", "No")
           .then(answer => (answer === "Yes" ? "1" : answer === "No" ? "0" : "2"));
       case 2: // Run a CSP page/Template. The Target is the full url to the CSP page/Template
-        throw new Error("Not suppoorted");
+        const conn = config().conn;
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(`http://${conn.host}:${conn.port}${target}`));
+        break;
+        // throw new Error("Not suppoorted");
       case 3: // Run an EXE on the client.
         throw new Error("Not suppoorted");
       case 4: // Insert the text in Target in the current document at the current selection point

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
 import { viewOthers } from "./commands/viewOthers";
 import { xml2doc } from "./commands/xml2doc";
-import { mainMenu, fireAttemptedEdit, contextMenu } from "./commands/studio";
+import { mainMenu, fireAttemptedEdit, contextMenu, fireChangedNamespace, documentBeingProcessed } from "./commands/studio";
 
 import { getLanguageConfiguration } from "./languageConfiguration";
 
@@ -163,6 +163,7 @@ export const checkConnection = (clearCookies = false): void => {
       /// Use xdebug's websocket, to catch when server disconnected
       connectionSocket = new WebSocket(api.xdebugUrl());
       connectionSocket.onopen = () => {
+        fireChangedNamespace();
         panel.text = `${connInfo} - Connected`;
       };
       connectionSocket.onclose = event => {
@@ -246,7 +247,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   workspace.onDidSaveTextDocument(file => {
     if (schemas.includes(file.uri.scheme) || languages.includes(file.languageId)) {
-      return vscode.commands.executeCommand("vscode-objectscript.compile");
+      if(documentBeingProcessed !== file) {
+        // return vscode.commands.executeCommand("vscode-objectscript.compile");
+        return importAndCompile(false, file);
+      }
     }
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
 import { viewOthers } from "./commands/viewOthers";
 import { xml2doc } from "./commands/xml2doc";
-import { mainMenu, fireAttemptedEdit, contextMenu, fireChangedNamespace, documentBeingProcessed } from "./commands/studio";
+import { mainMenu, contextMenu, documentBeingProcessed, fireOtherStudioAction, OtherStudioAction } from "./commands/studio";
 
 import { getLanguageConfiguration } from "./languageConfiguration";
 
@@ -163,7 +163,7 @@ export const checkConnection = (clearCookies = false): void => {
       /// Use xdebug's websocket, to catch when server disconnected
       connectionSocket = new WebSocket(api.xdebugUrl());
       connectionSocket.onopen = () => {
-        fireChangedNamespace();
+        fireOtherStudioAction(OtherStudioAction.ConnectedToNewNamespace);
         panel.text = `${connInfo} - Connected`;
       };
       connectionSocket.onclose = event => {
@@ -307,7 +307,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if(event.contentChanges.length !== 0
         && event.document.uri.scheme === FILESYSTEM_SCHEMA
         && !event.document.isDirty) {
-          fireAttemptedEdit(event.document.uri);
+          fireOtherStudioAction(OtherStudioAction.AttemptedEdit, event.document.uri);
       }
     }),
     window.onDidChangeActiveTextEditor(editor => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
 import { viewOthers } from "./commands/viewOthers";
 import { xml2doc } from "./commands/xml2doc";
-import { mainMenu } from "./commands/studio";
+import { mainMenu, fireAttemptedEdit, contextMenu } from "./commands/studio";
 
 import { getLanguageConfiguration } from "./languageConfiguration";
 
@@ -298,6 +298,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     reporter,
     workspace.onDidChangeTextDocument(event => {
       diagnosticProvider.updateDiagnostics(event.document);
+      if(event.contentChanges.length !== 0
+        && event.document.uri.scheme === FILESYSTEM_SCHEMA
+        && !event.document.isDirty) {
+          fireAttemptedEdit(event.document.uri);
+      }
     }),
     window.onDidChangeActiveTextEditor(editor => {
       if (editor) {
@@ -371,6 +376,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.commands.registerCommand("vscode-objectscript.viewOthers", viewOthers),
     vscode.commands.registerCommand("vscode-objectscript.studio.actions", mainMenu),
+    vscode.commands.registerCommand("vscode-objectscript.studio.contextActions", contextMenu),
     vscode.commands.registerCommand("vscode-objectscript.subclass", subclass),
     vscode.commands.registerCommand("vscode-objectscript.superclass", superclass),
     vscode.commands.registerCommand("vscode-objectscript.serverActions", serverActions),


### PR DESCRIPTION
Addresses the following studio extension VSCode gaps:
- MenuItem save flags are not supported
- No differentiation between different menus - Added the menu name to the right of the menu item
- Studio actions produce JSON output - Added an option to enable the output, but it is disabled by default
- For prompts, AfterUserAction supplies the user's text in Answer instead of Msg (with Answer indicating yes/no/cancel); also, there's no yes/no/cancel, it's just text or cancel
- Actions can't open CSP pages (which should include authentication, similar to Atelier)
- Actions can't open documents
- Actions can't modify document text
- ObjectScript explorer needs to support context menus - A context menu was added to the explorer that displays the available context actions
- No support for disabling menu items - Disabled items no longer appear in the list of actions
- Items marked read-only appear to be editable and even saved, but are not actually.
- Items that are not read-only, but are editable, should fire an "other" action with Type 1, Name 0 when edit is attempted (and support UserAction/AfterUserAction).
- Should fire Type 1, Name 5 ("changed namespace") when connection is established.