### PR TITLE
Alert on import error

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -200,9 +200,6 @@ export class AtelierAPI {
             if (data.result.status && data.result.status !== "") {
               const status: string = data.result.status;
               outputChannel.appendLine(status);
-              if (status.endsWith("is marked as read only by source control hooks.")) {
-                vscode.window.showWarningMessage(status, { modal: true });
-              }
               throw new Error(data.result.status);
             }
             if (data.status.summary) {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -21,14 +21,16 @@ async function compileFlags(): Promise<string> {
 
 async function importFile(file: CurrentFile): Promise<any> {
   const api = new AtelierAPI(file.uri);
-  return api.putDoc(
-    file.name,
-    {
-      content: file.content.split(/\r?\n/),
-      enc: false,
-    },
-    true
-  );
+  return api
+    .putDoc(
+      file.name,
+      {
+        content: file.content.split(/\r?\n/),
+        enc: false,
+      },
+      true
+    )
+    .catch((error) => vscode.window.showErrorMessage(error.message));
 }
 
 function updateOthers(others: string[]) {


### PR DESCRIPTION
Add alerts in the bottom right when importing fails. The read-only error will now appear in the bottom right instead of a modal.