### PR TITLE
fix #176 Remove obsolete menu reference to renamed command

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,10 +207,6 @@
           "group": "objectscript@2"
         },
         {
-          "command": "vscode-objectscript.studio.actions",
-          "when": "resourceScheme == isfs && vscode-objectscript.connectActive"
-        },
-        {
           "command": "vscode-objectscript.previewXml",
           "when": "editorLangId =~ /^xml/",
           "group": "objectscript@3"


### PR DESCRIPTION
This PR fixes #176. The `vscode-objectscript.studio.actions` command was recently renamed in one PR and amended in another PR. The resulting merge was incorrect.
