### PR TITLE
Add AfterUserAction support when deleting files

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -340,7 +340,7 @@ class StudioActions {
       .then((action) => this.userAction(action));
   }
 
-  public fireOtherStudioAction(action: OtherStudioAction) {
+  public fireOtherStudioAction(action: OtherStudioAction, userAction?) {
     const actionObject = {
       id: action.toString(),
       label: getOtherStudioActionLabel(action),
@@ -352,6 +352,14 @@ class StudioActions {
         if (!docStatus.editable) {
           vscode.commands.executeCommand("undo");
           this.userAction(actionObject, false, "", "", 1);
+        }
+      });
+    } else if (userAction) {
+      this.processUserAction(userAction).then((answer) => {
+        if (answer) {
+          answer.msg || answer.msg === ""
+            ? this.userAction(actionObject, true, answer.answer, answer.msg, 1)
+            : this.userAction(actionObject, true, answer, "", 1);
         }
       });
     } else {
@@ -420,7 +428,7 @@ export async function _contextMenu(sourceControl: boolean, node: PackageNode | C
   return studioActions && studioActions.getMenu(StudioMenuType.Context, sourceControl);
 }
 
-export async function fireOtherStudioAction(action: OtherStudioAction, uri?: vscode.Uri): Promise<void> {
+export async function fireOtherStudioAction(action: OtherStudioAction, uri?: vscode.Uri, userAction?): Promise<void> {
   const studioActions = new StudioActions(uri);
-  return studioActions && studioActions.fireOtherStudioAction(action);
+  return studioActions && studioActions.fireOtherStudioAction(action, userAction);
 }

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -28,6 +28,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
       vfs = config("serverSideEditing");
     }
     workspaceFolder = workspaceFolder && workspaceFolder !== "" ? workspaceFolder : currentWorkspaceFolder();
+    const isCsp = name.includes("/");
     const wFolderUri = workspaceFolderUri(workspaceFolder);
     let uri: vscode.Uri;
     if (wFolderUri.scheme === FILESYSTEM_SCHEMA) {
@@ -61,7 +62,6 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
         });
       }
     }
-    const isCsp = name.includes("/");
     if (namespace && namespace !== "") {
       if (isCsp) {
         uri = uri.with({


### PR DESCRIPTION
When files are deleted, the Studio Extension's AfterUserAction method is called. 

Also, a bug was fixed where some classes were being flagged as CSP files and could not be opened.