### PR TITLE
Add new file prompt to explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,10 @@
           "when": "false"
         },
         {
+          "command": "vscode-objectscript.explorer.new",
+          "when": "false"
+        },
+        {
           "command": "vscode-objectscript.explorer.refresh",
           "when": "vscode-objectscript.connectActive"
         },
@@ -167,6 +171,10 @@
         {
           "command": "vscode-objectscript.explorer.compile",
           "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:/"
+        },
+        {
+          "command": "vscode-objectscript.explorer.new",
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^data/"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextSourceControl",
@@ -418,6 +426,11 @@
         "title": "Refresh Explorer",
         "category": "ObjectScript",
         "icon": "$(refresh)"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.explorer.new",
+        "title": "New..."
       },
       {
         "category": "ObjectScript",

--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -1,0 +1,132 @@
+import * as vscode from "vscode";
+import { AtelierAPI } from "../api/index";
+import { DocumentContentProvider } from "../providers/DocumentContentProvider";
+import { NodeBase } from "./../explorer/models/nodeBase";
+import { RootNode } from "./../explorer/models/rootNode";
+import { PackageNode } from "../explorer/models/packageNode";
+import { ClassNode } from "../explorer/models/classesNode";
+import { RoutineNode } from "../explorer/models/routineNode";
+import { fireOtherStudioAction, OtherStudioAction } from "./studio";
+
+export async function createNewFile(node: NodeBase) {
+  try {
+    const name = await vscode.window.showInputBox(getInputBoxOptions(node));
+    // Check if user cancelled
+    if (!name) {
+      return;
+    }
+
+    const api = new AtelierAPI();
+    const response = await api.putDoc(name, { enc: false, content: getContent(name) }, true);
+
+    vscode.commands.executeCommand("vscode-objectscript.explorer.refresh");
+    const uri = DocumentContentProvider.getUri(response.result.name, node.workspaceFolder, node.namespace);
+    if (response.result.ext && response.result.ext[0] && response.result.ext[1]) {
+      // ext is an array containing the responses for actions 1 and 7
+      fireOtherStudioAction(OtherStudioAction.CreatedNewDocument, uri, response.result.ext[0]);
+      fireOtherStudioAction(OtherStudioAction.FirstTimeDocumentSave, uri, response.result.ext[1]);
+    }
+    vscode.window.showTextDocument(uri, { preview: false });
+  } catch (error) {
+    vscode.window.showErrorMessage(error.message);
+  }
+}
+
+function getInputBoxOptions(node: NodeBase): vscode.InputBoxOptions {
+  let fileExtension: string;
+  let filePath: string;
+
+  if (node instanceof PackageNode || node instanceof RootNode) {
+    if (node.category === "CSP") {
+      filePath = node.fullName ? node.fullName + "/" : "";
+    } else {
+      switch (node.category) {
+        case "RTN":
+          fileExtension = "mac";
+          break;
+        case "OTH":
+          fileExtension = "";
+          break;
+        default:
+          fileExtension = node.category.toLowerCase();
+      }
+      filePath = node instanceof PackageNode ? node.fullName + "." : "";
+    }
+  } else if (node instanceof ClassNode || node instanceof RoutineNode) {
+    const clickedFileExtension = node.fullName.match(/.*\.(.*)/)[1];
+    // CSP files
+    if (node.fullName.includes("/")) {
+      filePath = node.fullName.match(/(.*\/)/)[1];
+    }
+    // Classes and Routines
+    else if (clickedFileExtension.match(/(mac|inc|cls)/i)) {
+      const match = node.fullName.match(/(.*\.).*\./);
+      filePath = match ? match[1] : "";
+      fileExtension = clickedFileExtension;
+    }
+    // Other
+    else {
+      filePath = "";
+    }
+  }
+
+  let prompt: string;
+  let sampleName: string;
+  switch (fileExtension) {
+    case "cls":
+      prompt = "Create a class:";
+      sampleName = "ClassName";
+      break;
+    case "mac":
+    case "inc":
+      prompt = "Create a routine:";
+      sampleName = "RoutineName";
+      break;
+    default:
+      prompt = "Create a file:";
+      sampleName = "FileName";
+  }
+
+  return {
+    prompt: prompt,
+    value: filePath + sampleName + (fileExtension ? "." + fileExtension : ""),
+    valueSelection: [filePath.length, filePath.length + sampleName.length],
+  };
+}
+
+function getContent(fileName: string): string[] {
+  const [name, fileExtension] = fileName.match(/(.*)\.(.*)/).slice(1);
+  let contentArray: string[];
+  switch (fileExtension.toUpperCase()) {
+    case "CLS":
+      contentArray = ["Class " + name, "{", "", "}"];
+      break;
+    case "MAC":
+      contentArray = ["ROUTINE " + name, ""];
+      break;
+    case "INC":
+      contentArray = ["ROUTINE " + name + " [Type=INC]", ""];
+      break;
+    case "CSP":
+      contentArray = [
+        "<html>",
+        "<head>",
+        "",
+        "<!-- Put your page Title here -->",
+        "<title>	Cache Server Page </title>",
+        "",
+        "</head>",
+        "",
+        "<body>",
+        "",
+        "\t<!-- Put your page code here -->",
+        "\tMy page body",
+        "</body>",
+        "</html>",
+      ];
+      break;
+    default:
+      contentArray = [""];
+  }
+  return contentArray;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
 import { viewOthers } from "./commands/viewOthers";
 import { xml2doc } from "./commands/xml2doc";
+import { createNewFile } from "./commands/newFile";
 import {
   mainCommandMenu,
   contextCommandMenu,
@@ -411,6 +412,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("vscode-objectscript.explorer.refresh", () => explorerProvider.refresh()),
     vscode.commands.registerCommand("vscode-objectscript.explorer.openClass", vscode.window.showTextDocument),
     vscode.commands.registerCommand("vscode-objectscript.explorer.openRoutine", vscode.window.showTextDocument),
+    vscode.commands.registerCommand("vscode-objectscript.explorer.new", createNewFile),
     vscode.commands.registerCommand("vscode-objectscript.explorer.export", (item, items) =>
       exportExplorerItem(items && items.length ? items : [item])
     ),


### PR DESCRIPTION
Adds a "New..." option in the explorer that opens a prompt where the user can fill in the name of a new file. The file is then saved to the server and opened in an editor.