### PR TITLE
Support AfterUserAction when creating and deleting files on isfs

### DIFF
--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -4,6 +4,7 @@ import * as url from "url";
 import { AtelierAPI } from "../../api";
 import { Directory } from "./Directory";
 import { File } from "./File";
+import { fireOtherStudioAction, OtherStudioAction } from "../../commands/studio";
 
 export type Entry = File | Directory;
 
@@ -151,11 +152,15 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           throw new Error("Not implemented");
         }
       })
-      .then(() =>
+      .then((response) => {
+        if (response && response.result.ext && response.result.ext[0] && response.result.ext[1]) {
+          fireOtherStudioAction(OtherStudioAction.CreatedNewDocument, uri, response.result.ext[0]);
+          fireOtherStudioAction(OtherStudioAction.FirstTimeDocumentSave, uri, response.result.ext[1]);
+        }
         this._lookupAsFile(uri).then((entry) => {
           this._fireSoon({ type: vscode.FileChangeType.Changed, uri });
-        })
-      );
+        });
+      });
   }
 
   public delete(uri: vscode.Uri, options: { recursive: boolean }): void | Thenable<void> {
@@ -166,7 +171,12 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       return;
     }
     const api = new AtelierAPI(uri);
-    return api.deleteDoc(fileName).then(() => this._fireSoon({ type: vscode.FileChangeType.Deleted, uri }));
+    return api.deleteDoc(fileName).then((response) => {
+      if (response.result.ext) {
+        fireOtherStudioAction(OtherStudioAction.DeletedDocument, uri, response.result.ext);
+      }
+      this._fireSoon({ type: vscode.FileChangeType.Deleted, uri });
+    });
   }
 
   public rename(oldUri: vscode.Uri, newUri: vscode.Uri, options: { overwrite: boolean }): void | Thenable<void> {


### PR DESCRIPTION
If necessary, the Studio Extension's AfterUserAction method is called after creating or deleting a file on isfs.