### PR TITLE
Reinstate password prompting, and leverage servermanager for password storage in keychain

### DIFF
--- a/package.json
+++ b/package.json
@@ -246,7 +246,6 @@
           "group": "navigation@2",
           "when": "vscode-objectscript.connectActive && resourceScheme =~ /^isfs(-readonly)?$/"
         }
-
       ],
       "touchBar": [
         {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@ import * as url from "url";
 import * as vscode from "vscode";
 import * as Cache from "vscode-cache";
 import {
+  getResolvedConnectionSpec,
   config,
   extensionContext,
   FILESYSTEM_SCHEMA,
@@ -169,7 +170,7 @@ export class AtelierAPI {
         webServer: { scheme, host, port, pathPrefix = "" },
         username,
         password,
-      } = config("intersystems.servers", workspaceFolderName).get(serverName);
+      } = getResolvedConnectionSpec(serverName, config("intersystems.servers", workspaceFolderName).get(serverName));
       this._config = {
         active: this.externalServer || conn.active,
         apiVersion: 1,

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 import { config, workspaceState, checkConnection, FILESYSTEM_SCHEMA, FILESYSTEM_READONLY_SCHEMA } from "../extension";
-import { currentWorkspaceFolder, terminalWithDocker, currentFile } from "../utils";
+import { connectionTarget, terminalWithDocker, currentFile } from "../utils";
 import { mainCommandMenu, mainSourceControlMenu } from "./studio";
 import { AtelierAPI } from "../api";
 
 export async function serverActions(): Promise<void> {
-  const workspaceFolder = currentWorkspaceFolder();
-  const api = new AtelierAPI(workspaceFolder);
+  const { apiTarget, configName: workspaceFolder } = connectionTarget();
+  const api = new AtelierAPI(apiTarget);
   const { active, host = "", ns = "", https, port = 0, username, password } = api.config;
   const { links } = config("conn");
   const nsEncoded = encodeURIComponent(ns);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,14 @@ import { ObjectScriptExplorerProvider } from "./explorer/explorer";
 import { WorkspaceNode } from "./explorer/models/workspaceNode";
 import { FileSystemProvider } from "./providers/FileSystemPovider/FileSystemProvider";
 import { WorkspaceSymbolProvider } from "./providers/WorkspaceSymbolProvider";
-import { currentWorkspaceFolder, outputChannel, portFromDockerCompose, terminalWithDocker, notNull } from "./utils";
+import {
+  connectionTarget,
+  currentWorkspaceFolder,
+  outputChannel,
+  portFromDockerCompose,
+  terminalWithDocker,
+  notNull,
+} from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentRangeFormattingEditProvider } from "./providers/DocumentRangeFormattingEditProvider";
 
@@ -96,7 +103,7 @@ export const config = (setting?: string, workspaceFolderName?: string): vscode.W
   ) {
     workspaceFolderName = vscode.workspace.workspaceFolders[0].name;
   }
-  let prefix;
+  let prefix: string;
   const workspaceFolder = vscode.workspace.workspaceFolders.find(
     (el) => el.name.toLowerCase() === workspaceFolderName.toLowerCase()
   );
@@ -145,17 +152,19 @@ let reporter: TelemetryReporter = null;
 
 let connectionSocket: WebSocket;
 
-export const checkConnection = (clearCookies = false): void => {
-  const workspaceFolder = currentWorkspaceFolder();
+let serverManagerApi: any;
+
+export function checkConnection(clearCookies = false, uri?: vscode.Uri): void {
+  const { apiTarget, configName } = connectionTarget(uri);
   if (clearCookies) {
     /// clean-up cached values
-    workspaceState.update(workspaceFolder + ":host", undefined);
-    workspaceState.update(workspaceFolder + ":port", undefined);
-    workspaceState.update(workspaceFolder + ":password", undefined);
-    workspaceState.update(workspaceFolder + ":apiVersion", undefined);
-    workspaceState.update(workspaceFolder + ":docker", undefined);
+    workspaceState.update(configName + ":host", undefined);
+    workspaceState.update(configName + ":port", undefined);
+    workspaceState.update(configName + ":password", undefined);
+    workspaceState.update(configName + ":apiVersion", undefined);
+    workspaceState.update(configName + ":docker", undefined);
   }
-  let api = new AtelierAPI(workspaceFolder);
+  let api = new AtelierAPI(apiTarget, false);
   const { active, host = "", port = 0, ns = "" } = api.config;
   let connInfo = `${host}:${port}[${ns}]`;
   if (!host.length || !port || !ns.length) {
@@ -168,9 +177,9 @@ export const checkConnection = (clearCookies = false): void => {
     panel.text = `${packageJson.displayName} - Disabled`;
     return;
   }
-  if (!workspaceState.get(workspaceFolder + ":port") && !api.externalServer) {
+  if (!workspaceState.get(configName + ":port") && !api.externalServer) {
     const { port: dockerPort, docker: withDocker } = portFromDockerCompose();
-    workspaceState.update(workspaceFolder + ":docker", withDocker);
+    workspaceState.update(configName + ":docker", withDocker);
     if (withDocker) {
       if (!dockerPort) {
         outputChannel.appendLine(
@@ -181,8 +190,8 @@ export const checkConnection = (clearCookies = false): void => {
       }
       terminalWithDocker();
       if (dockerPort !== port) {
-        workspaceState.update(workspaceFolder + ":host", "localhost");
-        workspaceState.update(workspaceFolder + ":port", dockerPort);
+        workspaceState.update(configName + ":host", "localhost");
+        workspaceState.update(configName + ":port", dockerPort);
       }
       connInfo = `localhost:${dockerPort}[${ns}]`;
     }
@@ -194,10 +203,15 @@ export const checkConnection = (clearCookies = false): void => {
     panel.text = `${connInfo} - Connected`;
     return;
   }
-  api = new AtelierAPI(workspaceFolder);
+
+  // Why must this be recreated here?
+  api = new AtelierAPI(apiTarget, false);
+
   if (!api.config.host || !api.config.port || !api.config.ns) {
-    outputChannel.appendLine("host, port and ns must be specified.");
+    const message = "host, port and ns must be specified.";
+    outputChannel.appendLine(message);
     panel.text = `${packageJson.displayName} - ERROR`;
+    panel.tooltip = message;
     return;
   }
   api
@@ -222,32 +236,39 @@ export const checkConnection = (clearCookies = false): void => {
     .catch((error) => {
       let message = error.message;
       if (error instanceof StatusCodeError && error.statusCode === 401) {
-        setTimeout(
-          () =>
+        setTimeout(() => {
+          const username = api.config.username;
+          if (username === "") {
+            vscode.window.showErrorMessage(`Anonymous access rejected by ${connInfo}.`);
+            if (!api.externalServer) {
+              vscode.window.showErrorMessage("Connection has been disabled.");
+              disableConnection(configName);
+            }
+          } else {
             vscode.window
               .showInputBox({
                 password: true,
-                placeHolder: "Not Authorized, please enter password to connect to: " + connInfo,
+                placeHolder: `Not Authorized. Enter password to connect as user '${username}' to ${connInfo}`,
+                prompt: !api.externalServer ? "If no password is entered the connection will be disabled." : "",
                 ignoreFocusOut: true,
               })
               .then((password) => {
                 if (password) {
-                  workspaceState.update(currentWorkspaceFolder() + ":password", password);
-                  checkConnection();
-                } else {
-                  vscode.workspace.getConfiguration().update("objectscript.conn.active", false);
+                  workspaceState.update(configName + ":password", password);
+                  checkConnection(false, uri);
+                } else if (!api.externalServer) {
+                  disableConnection(configName);
                 }
-              }),
-          1000
-        );
+              });
+          }
+        }, 1000);
         message = "Not Authorized";
         outputChannel.appendLine(
-          `Authorization error: please check your username/password in the settings,
-          and if you have sufficient privileges on the server.`
+          `Authorization error: Check your credentials in Settings, and that you have sufficient privileges on the /api/atelier web application on ${connInfo}`
         );
       } else {
-        outputChannel.appendLine("Error: " + message);
-        outputChannel.appendLine("Please check your network settings in the settings.");
+        outputChannel.appendLine(`Error: ${message}`);
+        outputChannel.appendLine(`Check your server details in Settings (${connInfo}).`);
       }
       console.error(error);
       panel.text = `${connInfo} - ERROR`;
@@ -257,43 +278,69 @@ export const checkConnection = (clearCookies = false): void => {
     .finally(() => {
       explorerProvider.refresh();
     });
-};
+}
 
-async function serverManager(): Promise<void> {
+// Set objectscript.conn.active = false at WorkspaceFolder level if objectscript.conn is defined there,
+//  else set it false at Workspace level
+function disableConnection(configName: string) {
+  const connConfig: vscode.WorkspaceConfiguration = config("", configName);
+  const target: vscode.ConfigurationTarget = connConfig.inspect("conn").workspaceFolderValue
+    ? vscode.ConfigurationTarget.WorkspaceFolder
+    : vscode.ConfigurationTarget.Workspace;
+  const targetConfig: any =
+    connConfig.inspect("conn").workspaceFolderValue || connConfig.inspect("conn").workspaceValue;
+  return connConfig.update("conn", { ...targetConfig, active: false }, target);
+}
+
+// Promise to return the API of the servermanager
+async function serverManager(): Promise<any> {
   const extId = "intersystems-community.servermanager";
+  let extension = vscode.extensions.getExtension(extId);
   const ignore =
     config("ignoreInstallServerManager") ||
     vscode.workspace.getConfiguration("intersystems.servers").get("/ignore", false);
-  if (ignore || vscode.extensions.getExtension(extId)) {
-    return;
+  if (!extension) {
+    if (ignore) {
+      return;
+    }
+    await vscode.window
+      .showInformationMessage(
+        "The InterSystems® Server Manager extension is recommended to help you define connections and store passwords securely in your keychain.",
+        "Install",
+        "Skip",
+        "Ignore"
+      )
+      .then(async (action) => {
+        switch (action) {
+          case "Install":
+            await vscode.commands.executeCommand("workbench.extensions.search", `@tag:"intersystems"`);
+            await vscode.commands.executeCommand("extension.open", extId);
+            await vscode.commands.executeCommand("workbench.extensions.installExtension", extId);
+            extension = vscode.extensions.getExtension(extId);
+            break;
+          case "Ignore":
+            config().update("ignoreInstallServerManager", true, vscode.ConfigurationTarget.Global);
+            break;
+          case "Skip":
+          default:
+        }
+      });
   }
-  return vscode.window
-    .showInformationMessage(
-      "The InterSystems® Server Manager extension is recommended to help you define connections.",
-      "Install",
-      "Skip",
-      "Ignore"
-    )
-    .then(async (action) => {
-      switch (action) {
-        case "Install":
-          await vscode.commands.executeCommand("workbench.extensions.search", `@tag:"intersystems"`);
-          await vscode.commands.executeCommand("extension.open", extId);
-          await vscode.commands.executeCommand("workbench.extensions.installExtension", extId);
-          break;
-        case "Ignore":
-          config().update("ignoreInstallServerManager", true, vscode.ConfigurationTarget.Global);
-          break;
-        case "Skip":
-        default:
-      }
-    });
+  if (extension) {
+    if (!extension.isActive) {
+      await extension.activate();
+    }
+    return extension.exports;
+  }
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   if (!packageJson.version.includes("SNAPSHOT")) {
     reporter = new TelemetryReporter(extensionId, extensionVersion, aiKey);
   }
+
+  // Get api for servermanager extension, perhaps offering to install it
+  serverManagerApi = await serverManager();
 
   const languages = packageJson.contributes.languages.map((lang) => lang.id);
   workspaceState = context.workspaceState;
@@ -305,7 +352,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   fileSystemProvider = new FileSystemProvider();
 
   explorerProvider = new ObjectScriptExplorerProvider();
-  // vscode.window.registerTreeDataProvider("ObjectScriptExplorer", explorerProvider);
   vscode.window.createTreeView("ObjectScriptExplorer", {
     treeDataProvider: explorerProvider,
     showCollapseAll: true,
@@ -322,7 +368,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   panel.command = "vscode-objectscript.serverActions";
   panel.show();
 
-  checkConnection(true);
+  // Check once (flushing cookies) each connection used by the workspace(s)
+  const toCheck = new Map<string, vscode.Uri>();
+  vscode.workspace.workspaceFolders.map((workspaceFolder) => {
+    const uri = workspaceFolder.uri;
+    const { configName } = connectionTarget(uri);
+    toCheck.set(configName, uri);
+  });
+  toCheck.forEach(function (uri) {
+    checkConnection(true, uri);
+  });
+
   vscode.workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
     if (affectsConfiguration("objectscript.conn")) {
       checkConnection(true);
@@ -597,9 +653,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     ...proposed
   );
   reporter && reporter.sendTelemetryEvent("extensionActivated");
-
-  // offer to install servermanager extension
-  await serverManager();
 }
 
 export function deactivate(): void {

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -27,8 +27,8 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
-    const api = new AtelierAPI(uri);
     const parent = await this._lookupAsDirectory(uri);
+    const api = new AtelierAPI(uri);
     const sql = `CALL %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?)`;
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const type = query.type && query.type != "" ? query.type.toString() : "all";
@@ -100,6 +100,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       overwrite: boolean;
     }
   ): void | Thenable<void> {
+    if (uri.path.match(/\/\.[^/]*\//)) {
+      throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
+    }
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
@@ -224,6 +227,10 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   private async _lookupAsDirectory(uri: vscode.Uri): Promise<Directory> {
+    // Reject attempt to access /node_modules
+    if (uri.path.startsWith("/node_modules")) {
+      throw vscode.FileSystemError.FileNotADirectory(uri);
+    }
     const entry = await this._lookup(uri);
     if (entry instanceof Directory) {
       return entry;
@@ -232,6 +239,10 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   private async _lookupAsFile(uri: vscode.Uri): Promise<File> {
+    // Reject attempts to access files in .-folders such as .vscode and .git
+    if (uri.path.match(/\/\.[^/]*\//)) {
+      throw vscode.FileSystemError.FileNotFound("dot-folders not supported by server");
+    }
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");


### PR DESCRIPTION
This PR fixes #192 and also takes advantage of intersystems.servermanager's ability (0.0.4+) to store connection passwords in the local keychain.

It has required a lot of refactoring, partly because keychain access has to be async.

Additional work was done in the FileSystemProvider to suppress unnecessary server access attempts, e.g. to /node_modules, /.vscode and /.git