### PR TITLE
fix #233 and make other improvements/fixes to ObjectScript Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "onCommand:vscode-objectscript.explorer.refresh",
     "onCommand:vscode-objectscript.explorer.openClass",
     "onCommand:vscode-objectscript.explorer.openRoutine",
+    "onCommand:vscode-objectscript.explorer.openCSPFile",
     "onCommand:vscode-objectscript.compileFolder",
     "onCommand:vscode-objectscript.importFolder",
     "onLanguage:objectscript",
@@ -160,11 +161,11 @@
       "view/item/context": [
         {
           "command": "vscode-objectscript.explorer.export",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:(?!(cspApplication|cspFileNode))/"
         },
         {
           "command": "vscode-objectscript.explorer.export",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataRootNode:/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataRootNode:(?!cspRootNode)/"
         },
         {
           "command": "vscode-objectscript.explorer.delete",
@@ -185,28 +186,32 @@
         {
           "command": "vscode-objectscript.explorer.otherNamespace",
           "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:extra:).)*$/",
-          "group": "inline"
+          "group": "inline@30"
         },
         {
           "command": "vscode-objectscript.explorer.otherNamespaceClose",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode:extra:/",
-          "group": "inline"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:extra:/",
+          "group": "inline@30"
         },
         {
           "command": "vscode-objectscript.explorer.showGenerated",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:generated:).)*$/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:generated:).)*$/",
+          "group": "inline@20"
         },
         {
           "command": "vscode-objectscript.explorer.hideGenerated",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:generated:/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:generated:/",
+          "group": "inline@20"
         },
         {
           "command": "vscode-objectscript.explorer.showSystem",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:(%SYS|system):).)*$/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode((?!:(%SYS|system):).)*$/",
+          "group": "inline@10"
         },
         {
           "command": "vscode-objectscript.explorer.hideSystem",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:system:/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:system:/",
+          "group": "inline@10"
         }
       ],
       "editor/context": [
@@ -408,31 +413,37 @@
       {
         "command": "vscode-objectscript.explorer.otherNamespace",
         "title": "View Another Namespace...",
+        "icon": "$(add)",
         "category": "ObjectScript"
       },
       {
         "command": "vscode-objectscript.explorer.showGenerated",
-        "title": "Show Generated",
+        "title": "Show Generated Items",
+        "icon": "$(server-process)",
         "category": "ObjectScript"
       },
       {
         "command": "vscode-objectscript.explorer.hideGenerated",
-        "title": "Hide Generated",
+        "title": "Hide Generated Items",
+        "icon": "$(server-process)",
         "category": "ObjectScript"
       },
       {
         "command": "vscode-objectscript.explorer.showSystem",
-        "title": "Show System",
+        "title": "Show System Items",
+        "icon": "$(library)",
         "category": "ObjectScript"
       },
       {
         "command": "vscode-objectscript.explorer.hideSystem",
-        "title": "Hide System",
+        "title": "Hide System Items",
+        "icon": "$(library)",
         "category": "ObjectScript"
       },
       {
         "command": "vscode-objectscript.explorer.otherNamespaceClose",
         "title": "Close Namespace",
+        "icon": "$(remove)",
         "category": "ObjectScript"
       },
       {

--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -24,7 +24,11 @@ export class ObjectScriptExplorerProvider implements vscode.TreeDataProvider<Nod
       .then((data) => data.result.content.namespaces)
       .then((data) => data.filter((ns) => ns !== api.ns && !extra4Workspace.includes(ns)))
       .then((data) => data.map((ns) => ({ label: ns })))
-      .then(vscode.window.showQuickPick)
+      .then((data) =>
+        vscode.window.showQuickPick(data, {
+          placeHolder: `Choose a namespace on ${api.config.host}:${api.config.port} to add to ObjectScript Explorer`,
+        })
+      )
       .then((ns) => this.showExtra4Workspace(workspaceFolder, ns.label));
   }
 

--- a/src/explorer/models/cspFileNode.ts
+++ b/src/explorer/models/cspFileNode.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode";
+import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
+import { NodeBase, NodeOptions } from "./nodeBase";
+
+export class CSPFileNode extends NodeBase {
+  public static readonly contextValue: string = "dataNode:cspFileNode";
+  public constructor(label: string, fullName: string, options: NodeOptions) {
+    super(label, fullName, options);
+  }
+
+  public getTreeItem(): vscode.TreeItem {
+    const displayName: string = this.label;
+
+    return {
+      collapsibleState: vscode.TreeItemCollapsibleState.None,
+      command: {
+        arguments: [DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace)],
+        command: "vscode-objectscript.explorer.openCSPFile",
+        title: "Open File",
+      },
+      contextValue: CSPFileNode.contextValue,
+      label: `${displayName}`,
+    };
+  }
+}

--- a/src/explorer/models/rootNode.ts
+++ b/src/explorer/models/rootNode.ts
@@ -5,6 +5,7 @@ import { PackageNode } from "./packageNode";
 import { RoutineNode } from "./routineNode";
 import { AtelierAPI } from "../../api";
 import { ClassNode } from "./classesNode";
+import { CSPFileNode } from "./cspFileNode";
 import { StudioOpenDialog } from "../../queries";
 
 export class RootNode extends NodeBase {
@@ -119,9 +120,10 @@ export class RootNode extends NodeBase {
             case "9":
               return new PackageNode(el.Name, el.fullName, category, this.options);
             case "4":
-            case "5":
             case "100":
               return new ClassNode(el.Name, el.fullName, this.options);
+            case "5":
+              return new CSPFileNode(el.Name, el.fullName, this.options);
             case "0":
             case "1":
             case "2":
@@ -129,7 +131,7 @@ export class RootNode extends NodeBase {
             case "11":
               return new RoutineNode(el.Name, el.fullName, this.options);
             case "10":
-              return new RootNode(el.Name, el.fullName, "dataNode:CSPApplication", this._category, this.options, true);
+              return new RootNode(el.Name, el.fullName, "dataNode:cspApplication", this._category, this.options, true);
             default:
               return null;
           }

--- a/src/explorer/models/workspaceNode.ts
+++ b/src/explorer/models/workspaceNode.ts
@@ -22,7 +22,10 @@ export class WorkspaceNode extends NodeBase {
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
       contextValue: `${this.uniqueId}${flags.join("")}`,
-      label: `${this.label}(${this.connInfo})`,
+      label: this.extraNode
+        ? `[${this.namespace}] on ${this.conn.host}:${this.conn.port}`
+        : `${this.label} (${this.connInfo})`,
+      iconPath: new vscode.ThemeIcon(this.extraNode ? "database" : "server-environment"),
     };
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -574,6 +574,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand("vscode-objectscript.explorer.refresh", () => explorerProvider.refresh()),
     vscode.commands.registerCommand("vscode-objectscript.explorer.openClass", vscode.window.showTextDocument),
     vscode.commands.registerCommand("vscode-objectscript.explorer.openRoutine", vscode.window.showTextDocument),
+    vscode.commands.registerCommand("vscode-objectscript.explorer.openCSPFile", vscode.window.showTextDocument),
     vscode.commands.registerCommand("vscode-objectscript.explorer.export", (item, items) =>
       exportExplorerItem(items && items.length ? items : [item])
     ),

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -85,9 +85,9 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
   private onDidChangeEvent: vscode.EventEmitter<vscode.Uri> = new vscode.EventEmitter<vscode.Uri>();
 
   public provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): vscode.ProviderResult<string> {
-    const fileName = uri.path.split("/").slice(1).join(".");
     const api = new AtelierAPI(uri);
     const query = url.parse(decodeURIComponent(uri.toString()), true).query;
+    const fileName = query && query.csp ? uri.path.substring(1) : uri.path.split("/").slice(1).join(".");
     if (query) {
       if (query.ns && query.ns !== "") {
         const namespace = query.ns.toString();


### PR DESCRIPTION
This fixes #233 and some other things in ObjectScript Explorer.

- Use an icon for "View Another Namespace" instead of a text label.
- Add prompt text to quickpick.
- Fix broken "Remove" action on added root folders.
- Add icons to root folders.
- Differentiate between automatically created ones and manually added (and thus removable) ones.
- Suppress Export command on CSP Files folder and its contents because it doesn't currently work. If/when implemented/fixed it will be easy enough to reinstate the Export command.
- Fix broken opening of CSP files.
- Expose "Show/Hide System" and "Show/Hide Generated" as icons for better discoverability.

Example:

![image](https://user-images.githubusercontent.com/6726799/88811090-0cf32f00-d1ae-11ea-852a-688816a725fe.png)


