### PR TITLE
fix #237 Don't open wrong local document from ObjectScript Explorer

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -17,7 +17,7 @@ import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { currentFile, CurrentFile, outputChannel } from "../utils";
 import { RootNode } from "../explorer/models/rootNode";
 import { PackageNode } from "../explorer/models/packageNode";
-import { ClassNode } from "../explorer/models/classesNode";
+import { ClassNode } from "../explorer/models/classNode";
 import { RoutineNode } from "../explorer/models/routineNode";
 
 async function compileFlags(): Promise<string> {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 
 import { AtelierAPI } from "../api";
-import { ClassNode } from "../explorer/models/classesNode";
+import { ClassNode } from "../explorer/models/classNode";
 import { PackageNode } from "../explorer/models/packageNode";
 import { RootNode } from "../explorer/models/rootNode";
 import { RoutineNode } from "../explorer/models/routineNode";

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -47,6 +47,14 @@ export const getFileName = (folder: string, name: string, split: boolean, addCat
   return [folder, cat, name].filter(notNull).join(path.sep);
 };
 
+export const getFolderName = (folder: string, name: string, split: boolean, cat: string = null): string => {
+  const folderNameArray: string[] = name.split(".");
+  if (split) {
+    return [folder, cat, ...folderNameArray].filter(notNull).join(path.sep);
+  }
+  return [folder, cat, name].filter(notNull).join(path.sep);
+};
+
 export async function exportFile(
   workspaceFolder: string,
   namespace: string,
@@ -186,13 +194,15 @@ export async function exportAll(workspaceFolder?: string): Promise<any> {
 }
 
 export async function exportExplorerItem(nodes: NodeBase[]): Promise<any> {
-  const origNamespace = config("conn").ns;
   const node = nodes[0];
+  const origNamespace = config("conn", node.workspaceFolder).ns;
   if (origNamespace !== node.namespace) {
     const answer = await vscode.window.showWarningMessage(
       `
-You are about to export items from another namespace.
-Edits to these files in your local workspace will be compiled in the primary namespace of your workspace root, not the namespace from which you originally exported them.
+You are about to export from namespace ${node.namespace}.
+
+Future edits to the file(s) in your local workspace will be saved and compiled in the primary namespace of your workspace root, ${origNamespace}, not the namespace from which you originally exported.
+
 Would you like to continue?`,
       {
         modal: true,

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -3,7 +3,7 @@ import { AtelierAPI } from "../api";
 import { config, FILESYSTEM_SCHEMA } from "../extension";
 import { outputChannel, outputConsole, currentFile } from "../utils";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
-import { ClassNode } from "../explorer/models/classesNode";
+import { ClassNode } from "../explorer/models/classNode";
 import { PackageNode } from "../explorer/models/packageNode";
 import { RoutineNode } from "../explorer/models/routineNode";
 import { NodeBase } from "../explorer/models/nodeBase";
@@ -431,6 +431,7 @@ export async function _contextMenu(sourceControl: boolean, node: PackageNode | C
   return studioActions && studioActions.getMenu(StudioMenuType.Context, sourceControl);
 }
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function fireOtherStudioAction(action: OtherStudioAction, uri?: vscode.Uri, userAction?): Promise<void> {
   const studioActions = new StudioActions(uri);
   return studioActions && studioActions.fireOtherStudioAction(action, userAction);

--- a/src/explorer/models/classNode.ts
+++ b/src/explorer/models/classNode.ts
@@ -10,20 +10,20 @@ export class ClassNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
+    const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
+    const isLocalFile = itemUri.scheme === "file";
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace)],
+        arguments: [itemUri],
         command: "vscode-objectscript.explorer.openClass",
         title: "Open class",
       },
+      resourceUri: isLocalFile ? itemUri : undefined,
       contextValue: "dataNode:classNode",
       label: `${displayName}`,
-      // iconPath: {
-      //     light: path.join(__filename, '..', '..', '..', '..', 'images', 'light', 'class.svg'),
-      //     dark: path.join(__filename, '..', '..', '..', '..', 'images', 'dark', 'class.svg')
-      // }
+      tooltip: isLocalFile ? undefined : this.fullName,
     };
   }
 }

--- a/src/explorer/models/cspFileNode.ts
+++ b/src/explorer/models/cspFileNode.ts
@@ -20,6 +20,7 @@ export class CSPFileNode extends NodeBase {
         command: "vscode-objectscript.explorer.openCSPFile",
         title: "Open File",
       },
+      resourceUri: isLocalFile ? itemUri : undefined,
       contextValue: CSPFileNode.contextValue,
       label: `${displayName}`,
       tooltip: isLocalFile ? undefined : this.fullName,

--- a/src/explorer/models/cspFileNode.ts
+++ b/src/explorer/models/cspFileNode.ts
@@ -10,16 +10,19 @@ export class CSPFileNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
+    const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
+    const isLocalFile = itemUri.scheme === "file";
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace)],
+        arguments: [itemUri],
         command: "vscode-objectscript.explorer.openCSPFile",
         title: "Open File",
       },
       contextValue: CSPFileNode.contextValue,
       label: `${displayName}`,
+      tooltip: isLocalFile ? undefined : this.fullName,
     };
   }
 }

--- a/src/explorer/models/packageNode.ts
+++ b/src/explorer/models/packageNode.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { RootNode } from "./rootNode";
 import { NodeOptions } from "./nodeBase";
+import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
 
 export class PackageNode extends RootNode {
   public constructor(label: string, fullName: string, category: string, options: NodeOptions) {
@@ -9,15 +10,16 @@ export class PackageNode extends RootNode {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
+    const localFolderPath = DocumentContentProvider.getAsFolder(this.fullName, this.workspaceFolder, "cls");
+    const localUri = localFolderPath ? vscode.Uri.file(localFolderPath) : undefined;
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+      resourceUri: !this.extraNode ? localUri : undefined,
       contextValue: this.contextValue,
       label: `${displayName}`,
-      // iconPath: {
-      //     light: path.join(__filename, '..', '..', '..', '..', 'images', 'light', 'package.svg'),
-      //     dark: path.join(__filename, '..', '..', '..', '..', 'images', 'dark', 'package.svg')
-      // }
+      tooltip: this.fullName,
+      //iconPath: new vscode.ThemeIcon("package"),
     };
   }
 

--- a/src/explorer/models/rootNode.ts
+++ b/src/explorer/models/rootNode.ts
@@ -4,14 +4,24 @@ import { NodeBase, NodeOptions } from "./nodeBase";
 import { PackageNode } from "./packageNode";
 import { RoutineNode } from "./routineNode";
 import { AtelierAPI } from "../../api";
-import { ClassNode } from "./classesNode";
+import { ClassNode } from "./classNode";
 import { CSPFileNode } from "./cspFileNode";
 import { StudioOpenDialog } from "../../queries";
+
+type IconPath =
+  | string
+  | vscode.Uri
+  | {
+      light: string | vscode.Uri;
+      dark: string | vscode.Uri;
+    }
+  | vscode.ThemeIcon;
 
 export class RootNode extends NodeBase {
   public readonly contextValue: string;
   private readonly _category: string;
   private readonly isCsp: boolean;
+  private readonly iconPath: IconPath;
 
   public constructor(
     label: string,
@@ -19,12 +29,14 @@ export class RootNode extends NodeBase {
     contextValue: string,
     category: string,
     options: NodeOptions,
-    isCsp = false
+    isCsp = false,
+    iconPath?: IconPath
   ) {
     super(label, fullName, options);
     this.contextValue = contextValue;
     this._category = category;
     this.isCsp = isCsp;
+    this.iconPath = iconPath;
   }
 
   public get category(): string {
@@ -36,6 +48,8 @@ export class RootNode extends NodeBase {
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
       contextValue: this.contextValue,
       label: this.label,
+      tooltip: this.isCsp ? this.fullName : undefined,
+      iconPath: this.iconPath,
     };
   }
 

--- a/src/explorer/models/routineNode.ts
+++ b/src/explorer/models/routineNode.ts
@@ -10,20 +10,20 @@ export class RoutineNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
+    const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
+    const isLocalFile = itemUri.scheme === "file";
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace)],
+        arguments: [itemUri],
         command: "vscode-objectscript.explorer.openRoutine",
         title: "Open routine",
       },
+      resourceUri: isLocalFile ? itemUri : undefined,
       contextValue: "dataNode:routineNode",
       label: `${displayName}`,
-      // iconPath: {
-      //     light: path.join(__filename, '..', '..', '..', '..', 'images', 'light', 'routine.svg'),
-      //     dark: path.join(__filename, '..', '..', '..', '..', 'images', 'dark', 'routine.svg')
-      // }
+      tooltip: isLocalFile ? undefined : this.fullName,
     };
   }
 }

--- a/src/explorer/models/workspaceNode.ts
+++ b/src/explorer/models/workspaceNode.ts
@@ -33,19 +33,59 @@ export class WorkspaceNode extends NodeBase {
     const children = [];
     let node: RootNode;
 
-    node = new RootNode("Classes", "", "dataRootNode:classesRootNode", "CLS", this.options);
+    node = new RootNode(
+      "Classes",
+      "",
+      "dataRootNode:classesRootNode",
+      "CLS",
+      this.options,
+      false
+      //new vscode.ThemeIcon("symbol-class")
+    );
     children.push(node);
 
-    node = new RootNode("Routines", "", "dataRootNode:routinesRootNode", "RTN", this.options);
+    node = new RootNode(
+      "Routines",
+      "",
+      "dataRootNode:routinesRootNode",
+      "RTN",
+      this.options,
+      false
+      //new vscode.ThemeIcon("note")
+    );
     children.push(node);
 
-    node = new RootNode("Includes", "", "dataRootNode:routinesRootNode", "INC", this.options);
+    node = new RootNode(
+      "Includes",
+      "",
+      "dataRootNode:routinesRootNode",
+      "INC",
+      this.options,
+      false
+      //new vscode.ThemeIcon("file-symlink-file")
+    );
     children.push(node);
 
-    node = new RootNode("CSP Files", "", "dataRootNode:cspRootNode", "CSP", this.options);
+    node = new RootNode(
+      "CSP Files",
+      "",
+      "dataRootNode:cspRootNode",
+      "CSP",
+      this.options,
+      false
+      //new vscode.ThemeIcon("symbol-file")
+    );
     children.push(node);
 
-    node = new RootNode("Other", "", "dataRootNode:otherRootNode", "OTH", this.options);
+    node = new RootNode(
+      "Other",
+      "",
+      "dataRootNode:otherRootNode",
+      "OTH",
+      this.options,
+      false
+      //new vscode.ThemeIcon("symbol-misc")
+    );
     children.push(node);
 
     return children;


### PR DESCRIPTION
This fixes #237.

It also adds visual differentiation between files in OE that will open from the server and those that will open from the local workspace.

![image](https://user-images.githubusercontent.com/6726799/88948227-8f9cec80-d289-11ea-8777-d044465acc77.png)

Problem indicators will display for the latter.