### PR TITLE
fix #285 export serverForUri function as API

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -20,6 +20,7 @@ const DEFAULT_API_VERSION = 1;
 import * as Atelier from "./atelier";
 
 export interface ConnectionSettings {
+  serverName: string;
   active: boolean;
   apiVersion: number;
   https: boolean;
@@ -47,7 +48,7 @@ export class AtelierAPI {
   }
 
   public get config(): ConnectionSettings {
-    const { active = false, https = false, pathPrefix = "", username } = this._config;
+    const { serverName, active = false, https = false, pathPrefix = "", username } = this._config;
     const ns = this.namespace || this._config.ns;
     const host = this.externalServer
       ? this._config.host
@@ -58,6 +59,7 @@ export class AtelierAPI {
     const password = workspaceState.get(this.configName + ":password", this._config.password);
     const apiVersion = workspaceState.get(this.configName + ":apiVersion", DEFAULT_API_VERSION);
     return {
+      serverName,
       active,
       apiVersion,
       https,
@@ -164,13 +166,14 @@ export class AtelierAPI {
       serverName = "";
     }
 
-    if (serverName && serverName.length) {
+    if (serverName !== "") {
       const {
         webServer: { scheme, host, port, pathPrefix = "" },
         username,
         password,
       } = getResolvedConnectionSpec(serverName, config("intersystems.servers", workspaceFolderName).get(serverName));
       this._config = {
+        serverName,
         active: this.externalServer || conn.active,
         apiVersion: workspaceState.get(this.configName + ":apiVersion", DEFAULT_API_VERSION),
         https: scheme === "https",
@@ -190,6 +193,7 @@ export class AtelierAPI {
       }
     } else {
       this._config = conn;
+      this._config.serverName = serverName;
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -722,6 +722,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         apiVersion: active ? apiVersion : undefined,
       };
     },
+    serverDocumentUriForUri(uri: vscode.Uri): vscode.Uri {
+      const { apiTarget } = connectionTarget(uri);
+      if (typeof apiTarget === "string") {
+        // It was a file-type uri, so find its document (we hope it is open)
+        const docs = vscode.workspace.textDocuments.filter((doc) => doc.uri === uri);
+        let fileName = "";
+        if (docs.length === 1) {
+          // Found it, so work out the corresponding server-side name
+          const file = currentFile(docs[0]);
+          // For some local documents there is no server-side equivalent
+          if (file) {
+            fileName = file.name;
+          }
+        }
+        // uri.path will be "/" if no mapping exists to a server-side equivalent
+        uri = vscode.Uri.file(fileName).with({ scheme: OBJECTSCRIPT_FILE_SCHEMA, authority: apiTarget });
+      }
+      return uri;
+    },
   };
 
   // 'export' our public API

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -697,8 +697,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     serverForUri(uri: vscode.Uri): any {
       const { apiTarget } = connectionTarget(uri);
       const api = new AtelierAPI(apiTarget);
-      const { host = "", https, port = 0, pathPrefix, username, password, ns = "" } = api.config;
-      return { scheme: https ? "https" : "http", host, port, pathPrefix, username, password, namespace: ns };
+      const {
+        serverName,
+        active,
+        host = "",
+        https,
+        port,
+        pathPrefix,
+        username,
+        password,
+        ns = "",
+        apiVersion,
+      } = api.config;
+      return {
+        serverName,
+        active,
+        scheme: https ? "https" : "http",
+        host,
+        port,
+        pathPrefix,
+        username,
+        password,
+        namespace: ns,
+        apiVersion: active ? apiVersion : undefined,
+      };
     },
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -356,7 +356,7 @@ async function serverManager(): Promise<any> {
   }
 }
 
-export async function activate(context: vscode.ExtensionContext): Promise<void> {
+export async function activate(context: vscode.ExtensionContext): Promise<any> {
   if (!packageJson.version.includes("SNAPSHOT")) {
     reporter = new TelemetryReporter(extensionId, extensionVersion, aiKey);
   }
@@ -687,10 +687,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       new ObjectScriptClassCodeLensProvider()
     ),
 
-    /* from proposed api */
+    /* Anything we use from the VS Code proposed API */
     ...proposed
   );
   reporter && reporter.sendTelemetryEvent("extensionActivated");
+
+  // The API we export
+  const api = {
+    serverForUri(uri: vscode.Uri): any {
+      const { apiTarget } = connectionTarget(uri);
+      const api = new AtelierAPI(apiTarget);
+      const { host = "", https, port = 0, pathPrefix, username, password, ns = "" } = api.config;
+      return { scheme: https ? "https" : "http", host, port, pathPrefix, username, password, namespace: ns };
+    },
+  };
+
+  // 'export' our public API
+  return api;
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
This PR fixes #285 

It makes the extension export a function `serverForUri` that takes a `vscode.Uri` and returns an object containing sufficient information for the caller to connect to the InterSystems server where the document gets imported and compiled.

It also adds a `serverDocumentUriForUri` API function with which the caller can get a uri for the server-side document of the uri passed to it. This is useful when the caller has a file:// uri and needs the corresponding  objectscript:// uri.

The initial use-case for these APIs was a language server.