### PR TITLE
fix #284 swap sides in Compare following import conflict

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -94,12 +94,12 @@ What do you want to do?`,
                 return vscode.commands
                   .executeCommand(
                     "vscode.diff",
-                    file.uri,
                     vscode.Uri.file(file.name).with({
                       scheme: OBJECTSCRIPT_FILE_SCHEMA,
                       authority: file.workspaceFolder,
                     }),
-                    `Local • ${file.fileName} ↔ Server • ${file.name}`
+                    file.uri,
+                    `Server • ${file.name} ↔ Local • ${file.fileName}`
                   )
                   .then(() => Promise.reject());
               case "Overwrite on Server":


### PR DESCRIPTION
This PR fixes #284. It aligns our compare with the built-in one that VS Code will present if a similar conflict occurs when saving an isfs:// file.