### PR TITLE
fix #293 Fix broken image and inter-document links

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -12,15 +12,15 @@ The settings that define an InterSystems IRIS server and the connection to the s
 
 First, configure one or more servers. Open the settings editor by selecting **File > Preferences > Settings** (**Code > Preferences > Settings** on Mac) from the menu. Select the **User** or **Workspace** settings level by selecting it at the top of the settings window. For example, the following screen shot shows Workspace selected:
 
-![Workspace selected.](../assets/images/ClickWorkspace.png "workspace selected")
+![Workspace selected.](./assets/images/ClickWorkspace.png "workspace selected")
 
 Find Extensions in the list in the left pane of the editor window, click to open, then select InterSystems Server Manager from the list to find the correct place in the settings UI. The following screen shot shows InterSystems Server Manager selected:
 
-![Select server manager.](../assets/images/ServerManagerSelect.png "select server manager")
+![Select server manager.](./assets/images/ServerManagerSelect.png "select server manager")
 
 And this screen shot shows Server Manager area of the edit pane:
 
-![Server manager settings.](../assets/images/ServerManagerSettings.png "server manager settings")
+![Server manager settings.](./assets/images/ServerManagerSettings.png "server manager settings")
 
 You need to edit the server configuration in the settings.json file, so your only option is to click *Edit in settings.json*. 
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -23,12 +23,12 @@ Next, you need to install the following extensions:
 
 Run VS Code. From within the application, click the extensions button in the Activity Bar on the left edge of the VS Code window:
 
-![Extensions button.](../assets/images/extensions.png "extensions button")
+![Extensions button.](./assets/images/extensions.png "extensions button")
 
 Type `intersystems` in the search field to find these extensions in the Marketplace, as illustrated in the following screen shot:
 
-![Search in Marketplace.](../assets/images/marketplace.png "search in marketplace")
+![Search in Marketplace.](./assets/images/marketplace.png "search in marketplace")
 
 For each of the listed extensions, click the extension, then click **install**. Note that the InterSystems ObjectScript extension adds an ObjectScript button to the Activity Bar:
 
-![ObjectScript button.](../assets/images/objectscript.png "objectscript button")
+![ObjectScript button.](./assets/images/objectscript.png "objectscript button")

--- a/docs/RunDebug.md
+++ b/docs/RunDebug.md
@@ -10,7 +10,7 @@ In order to run or debug an ObjectScript class or routine, you must create a lau
 
 If no launch configurations are available, you are prompted to create one:
 
-![Create launch configuration.](../assets/images/CreateLaunchConfig.png "create launch configuration")
+![Create launch configuration.](./assets/images/CreateLaunchConfig.png "create launch configuration")
 
 Clicking the link creates and opens a `launch.json` file containing the following default information:
 

--- a/docs/ServerSide.md
+++ b/docs/ServerSide.md
@@ -8,7 +8,7 @@ nav_order: 7
 
 You can configure the InterSystems ObjectScript extension to edit code directly on the server, using the [multi-root workspaces](https://code.visualstudio.com/docs/editor/multi-root-workspaces) VS Code feature. This type of configuration is useful in cases where source code is stored in a Version Control System (VCS) as XML, and you are using source control in Studio using Studio extensions, as provided by `%Studio.Extension.Base`. 
 
-First configure the connection to InterSystems as described in [Configuration](../Configuration).
+First configure the connection to InterSystems as described in [Configuration](./Configuration).
 
 Use **File > New File** to create a new file. Add content similar to the following example. Note that `my-project` in the `isfs://` uri, should be the same as the name of any folder where there are settings for the connection.
 

--- a/docs/Settings.md
+++ b/docs/Settings.md
@@ -6,7 +6,7 @@ nav_order: 4
 ---
 # Settings
 
-VS Code provides a number of settings that enable you to customize various aspects of its function. Many settings are general to VS Code, and you can learn about them in the [Visual Studio Code Documentation](https://code.visualstudio.com/docs). The InterSystems ObjectScript and InterSystems Server Manager extensions supply specific settings used to configure VS Code for ObjectScript development. You can learn more in the section [Configuration](../configuration).
+VS Code provides a number of settings that enable you to customize various aspects of its function. Many settings are general to VS Code, and you can learn about them in the [Visual Studio Code Documentation](https://code.visualstudio.com/docs). The InterSystems ObjectScript and InterSystems Server Manager extensions supply specific settings used to configure VS Code for ObjectScript development. You can learn more in the section [Configuration](./Configuration).
 
 There are several levels on which settings are stored and used:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,10 @@ nav_exclude: true
 
 # Welcome to the VS Code InterSystems ObjectScript documentation
 
-* [Introduction](introduction)
-* [Installation](installation)
-* [Workspace](workspace)
-* [Settings](settings)
-* [Configuration](configuration)
-* [Running and Debugging](rundebug)
-* [Server-side Editing](serverside)
+* [Introduction](./introduction)
+* [Installation](./Installation)
+* [Workspace](./workspace)
+* [Settings](./Settings)
+* [Configuration](./Configuration)
+* [Running and Debugging](./RunDebug)
+* [Server-side Editing](./ServerSide)

--- a/docs/workspace.md
+++ b/docs/workspace.md
@@ -14,4 +14,4 @@ A multi root workspace has a \*.code-workspace file in the root folder. The file
 
 To edit a *.code-workspace* file in VS Code using the InterSystems ObjectScript extension, select **File > Preferences > Settings** (**Code > Preferences > Settings** on Mac) and select the Workspace option. When you click **Edit in settings.json**, VS Code opens the *.code-workspace* file for that workspace.
 
-The InterSystems ObjectScript extension uses the Multi-root workspaces feature to support ObjectScript development on the InterSystems server. See [Server-side Editing](../ServerSide).
+The InterSystems ObjectScript extension uses the Multi-root workspaces feature to support ObjectScript development on the InterSystems server. See [Server-side Editing](./ServerSide).


### PR DESCRIPTION
This PR fixes #293 

Inter-document links have been standardized to use `./XXX` format and to match exactly the case of the target document names. Inconsistent capitalization of document names has not been addressed, i.e. a few remain all lowercase.