### PR TITLE
fix #332 Announce when proposed APIs are being used

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -536,6 +536,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       : null,
   ].filter(notNull);
 
+  if (proposed.length > 0) {
+    outputChannel.appendLine(`${extensionId} version ${extensionVersion} activating with proposed APIs available.\n`);
+    outputChannel.show(true);
+  }
+
   context.subscriptions.push(
     reporter,
     workspace.onDidChangeTextDocument((event) => {


### PR DESCRIPTION
This PR fixes #332 by writing a message to the ObjectScript output channel when the extension hooks up to proposed APIs during activate.