### PR TITLE
fix #334 connect FileSearchProvider call to server

### DIFF
--- a/src/api/atelier.d.ts
+++ b/src/api/atelier.d.ts
@@ -56,6 +56,14 @@ export interface SearchResult {
   matches: SearchMatch[];
 }
 
+export interface DocSearchResult {
+  name: string;
+  cat: "RTN" | "CLS" | "CSP" | "OTH";
+  ts: string;
+  db: string;
+  gen: boolean;
+}
+
 export interface AtelierJob {
   pid: number;
   namespace: string;

--- a/src/providers/FileSystemPovider/FileSearchProvider.ts
+++ b/src/providers/FileSystemPovider/FileSearchProvider.ts
@@ -25,20 +25,21 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
       .getDocNames({
         filter: query.pattern,
         category,
-        generated
+        generated,
       })
       .then((data) => data.result.content)
       .then((files: DocSearchResult[]) =>
-        files.map((file) => {
-          if (category === "*" && file.cat === "CSP") {
-            return null;
-          }
-          if (!options.maxResults || ++counter <= options.maxResults) {
-            return options.folder.with({ path: `/${file.name}` });
-          } else {
-            return null;
-          }
-        })
+        files
+          .map((file) => {
+            if (category === "*" && file.cat === "CSP") {
+              return null;
+            }
+            if (!options.maxResults || ++counter <= options.maxResults) {
+              return options.folder.with({ path: `/${file.name}` });
+            } else {
+              return null;
+            }
+          })
           .filter((el) => el !== null)
       );
   }

--- a/src/providers/FileSystemPovider/FileSearchProvider.ts
+++ b/src/providers/FileSystemPovider/FileSearchProvider.ts
@@ -1,4 +1,6 @@
 import * as vscode from "vscode";
+import { DocSearchResult } from "../../api/atelier";
+import { AtelierAPI } from "../../api";
 
 export class FileSearchProvider implements vscode.FileSearchProvider {
   /**
@@ -12,6 +14,32 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     options: vscode.FileSearchOptions,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.Uri[]> {
-    return [];
+    const category = `&${options.folder.query}&`.includes("&csp&") ? "CSP" : "*";
+    const generated = `&${options.folder.query}&`.includes("&generated=1&");
+    const api = new AtelierAPI(options.folder);
+    let counter = 0;
+    if (!api.enabled) {
+      return null;
+    }
+    return api
+      .getDocNames({
+        filter: query.pattern,
+        category,
+        generated
+      })
+      .then((data) => data.result.content)
+      .then((files: DocSearchResult[]) =>
+        files.map((file) => {
+          if (category === "*" && file.cat === "CSP") {
+            return null;
+          }
+          if (!options.maxResults || ++counter <= options.maxResults) {
+            return options.folder.with({ path: `/${file.name}` });
+          } else {
+            return null;
+          }
+        })
+          .filter((el) => el !== null)
+      );
   }
 }


### PR DESCRIPTION
This PR fixes #334 

When running with proposed API enabled and isfs or isfs-readonly folders the QuickOpen field (Ctrl/Cmd+P without Shift) will now search server-side document names.