### PR TITLE
Add command to link local folder to server (#330)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
       },
       {
         "view": "ObjectScriptExplorer",
-        "contents": "Connect a workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/) if you want to export or import ObjectScript code.\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)\nOr [hide this ObjectScript view](command:vscode-objectscript.hideExplorerForWorkspace) if it is not needed for the current workspace."
+        "contents": "Connect a workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/) if you want to export or import ObjectScript code.\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)\nOr [hide this ObjectScript view](command:vscode-objectscript.hideExplorerForWorkspace) if it is not needed for the current workspace.",
+        "when": "vscode-objectscript.explorerRoots == 0"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "onCommand:vscode-objectscript.compileFolder",
     "onCommand:vscode-objectscript.importFolder",
     "onCommand:vscode-objectscript.addServerNamespaceToWorkspace",
+    "onCommand:vscode-objectscript.connectFolderToServerNamespace",
+    "onCommand:vscode-objectscript.hideExplorerForWorkspace",
+    "onCommand:vscode-objectscript.showExplorerForWorkspace",
     "onLanguage:objectscript",
     "onLanguage:objectscript-class",
     "onLanguage:objectscript-macros",
@@ -75,6 +78,10 @@
       {
         "view": "explorer",
         "contents": "You can also create a new workspace to edit or view code directly on an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.addServerNamespaceToWorkspace)"
+      },
+      {
+        "view": "ObjectScriptExplorer",
+        "contents": "Connect a workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/) if you want to export or import ObjectScript code.\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)\nOr [hide this ObjectScript view](command:vscode-objectscript.hideExplorerForWorkspace) if it is not needed for the current workspace."
       }
     ],
     "menus": {
@@ -186,6 +193,14 @@
         {
           "command": "vscode-objectscript.serverCommands.contextOther",
           "when": "false"
+        },
+        {
+          "command": "vscode-objectscript.hideExplorerForWorkspace",
+          "when": "config.objectscript.showExplorer"
+        },
+        {
+          "command": "vscode-objectscript.showExplorerForWorkspace",
+          "when": "!config.objectscript.showExplorer"
         }
       ],
       "view/title": [
@@ -568,6 +583,21 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.addServerNamespaceToWorkspace",
         "title": "Add Server Namespace to Workspace..."
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.connectFolderToServerNamespace",
+        "title": "Connect Folder to Server Namespace..."
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.hideExplorerForWorkspace",
+        "title": "Hide Explorer for Workspace"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.showExplorerForWorkspace",
+        "title": "Show Explorer for Workspace"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "viewsWelcome": [
       {
         "view": "explorer",
-        "contents": "You can also create a new workspace to edit or view code directly on an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.addServerNamespaceToWorkspace)"
+        "contents": "Begin local ObjectScript development by opening a folder or cloning a repository. Then switch to the new ObjectScript view in the Activity Bar.\nYou can also create a new workspace to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.addServerNamespaceToWorkspace)"
       },
       {
         "view": "ObjectScriptExplorer",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
       {
         "view": "ObjectScriptExplorer",
         "contents": "Connect a workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/) if you want to export or import ObjectScript code.\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)\nOr [hide this ObjectScript view](command:vscode-objectscript.hideExplorerForWorkspace) if it is not needed for the current workspace.",
-        "when": "vscode-objectscript.explorerRoots == 0"
+        "when": "vscode-objectscript.explorerRootCount == 0"
       }
     ],
     "menus": {

--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -127,7 +127,7 @@ export class ObjectScriptExplorerProvider implements vscode.TreeDataProvider<Nod
           });
         }
       });
-    await vscode.commands.executeCommand("setContext", "vscode-objectscript.explorerRoots", rootNodes.length);
+    await vscode.commands.executeCommand("setContext", "vscode-objectscript.explorerRootCount", rootNodes.length);
     return rootNodes;
   }
 }

--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -127,6 +127,7 @@ export class ObjectScriptExplorerProvider implements vscode.TreeDataProvider<Nod
           });
         }
       });
+    await vscode.commands.executeCommand("setContext", "vscode-objectscript.explorerRoots", rootNodes.length);
     return rootNodes;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ import {
   mainSourceControlMenu,
 } from "./commands/studio";
 import { addServerNamespaceToWorkspace } from "./commands/addServerNamespaceToWorkspace";
+import { connectFolderToServerNamespace } from "./commands/connectFolderToServerNamespace";
 
 import { getLanguageConfiguration } from "./languageConfiguration";
 
@@ -457,6 +458,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   vscode.workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
     if (affectsConfiguration("objectscript.conn")) {
       checkConnection(true);
+      explorerProvider.refresh();
     }
   });
   vscode.window.onDidCloseTerminal((t) => {
@@ -676,6 +678,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     }),
     vscode.commands.registerCommand("vscode-objectscript.addServerNamespaceToWorkspace", () => {
       addServerNamespaceToWorkspace();
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.connectFolderToServerNamespace", () => {
+      connectFolderToServerNamespace();
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.hideExplorerForWorkspace", () => {
+      vscode.workspace
+        .getConfiguration("objectscript")
+        .update("showExplorer", false, vscode.ConfigurationTarget.Workspace);
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.showExplorerForWorkspace", () => {
+      vscode.workspace
+        .getConfiguration("objectscript")
+        .update("showExplorer", true, vscode.ConfigurationTarget.Workspace);
     }),
 
     vscode.workspace.registerTextDocumentContentProvider(OBJECTSCRIPT_FILE_SCHEMA, documentContentProvider),


### PR DESCRIPTION
This PR implements #330 

With one or more local folders open but lacking `objectscript.conn` settings, the ObjectScript view displays a button that runs the new `connectFolderToServerNamespace` command, and a link to `hideExplorerForWorkspace` (also new).

![image](https://user-images.githubusercontent.com/6726799/93327670-94563980-f812-11ea-97db-25c84f968652.png)


 Together with a new `showExplorerForWorkspace` these commands are also available on the palette.