### PR TITLE
Fix issues with debugger

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -123,7 +123,7 @@ export class AtelierAPI {
     return !!this._config.active && host.length > 0 && port > 0;
   }
 
-  private get cookies(): string[] {
+  public get cookies(): string[] {
     return this.cache.get("cookies", []);
   }
 

--- a/src/debug/xdebugConnection.ts
+++ b/src/debug/xdebugConnection.ts
@@ -719,8 +719,14 @@ export class Connection extends DbgpConnection {
    *  - show_hidden
    *  - notify_ok
    */
-  public async sendFeatureSetCommand(feature: string, value: string | number): Promise<FeatureSetResponse> {
-    return new FeatureSetResponse(await this._enqueueCommand("feature_set", `-n ${feature} -v ${value}`), this);
+  public async sendFeatureSetCommand(
+    feature: string,
+    value: string | number,
+    base64 = false
+  ): Promise<FeatureSetResponse> {
+    const v =
+      typeof value === "string" && base64 ? `-v_base64 ${Buffer.from(value).toString("base64")}` : `-v ${value}`;
+    return new FeatureSetResponse(await this._enqueueCommand("feature_set", `-n ${feature} ${v}`), this);
   }
 
   // ---------------------------- breakpoints ------------------------------------


### PR DESCRIPTION
fix for debugger target with spaces, 
fix when it stops working after a few debugging, now it should reuse cookies and successfully start, or even just warn that it did not start 

This PR fixes #257
This PR fixes #341 
This PR fixes #342
