### PR TITLE
Fix #348 : correct context for AtelierAPI; fix CSP slashes

### DIFF
--- a/src/commands/viewOthers.ts
+++ b/src/commands/viewOthers.ts
@@ -21,7 +21,7 @@ export async function viewOthers(): Promise<void> {
   const getOthers = (info) => {
     return info.result.content[0].others;
   };
-  const api = new AtelierAPI();
+  const api = new AtelierAPI(file.uri);
   return api
     .actionIndex([file.name])
     .then((info) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -84,7 +84,7 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
   const { query } = url.parse(decodeURIComponent(uri.toString()), true);
   const csp = query.csp === "" || query.csp === "1";
   if (csp) {
-    name = fileName;
+    name = fileName.replace("\\", "/");
   } else if (fileExt === "cls") {
     const match = content.match(/^Class (%?\w+(?:\.\w+)+)/im);
     if (match) {


### PR DESCRIPTION
This PR fixes #348 

viewOthers was always using AtelierAPI based on workspace settings; now goes based on current file (e.g., fixes View Other with multiple isfs folders pointing to different servers, or without a workspace default server properly configured)
In currentFile, for CSP files, should use forward slashes (were backslashes on Windows, which prevented "view other" for working on CSP files in isfs).