### PR TITLE
Jump to tag and offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "onCommand:vscode-objectscript.export",
     "onCommand:vscode-objectscript.compile",
     "onCommand:vscode-objectscript.viewOthers",
+    "onCommand:vscode-objectscript.jumpToTagAndOffset",
     "onCommand:vscode-objectscript.previewXml",
     "onCommand:vscode-objectscript.explorer.refresh",
     "onCommand:vscode-objectscript.explorer.open",
@@ -519,6 +520,11 @@
         "title": "Refresh Explorer",
         "category": "ObjectScript",
         "icon": "$(refresh)"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.jumpToTagAndOffset",
+        "title": "Jump to Tag + Offset"
       },
       {
         "category": "ObjectScript",

--- a/src/commands/jumpToTagAndOffset.ts
+++ b/src/commands/jumpToTagAndOffset.ts
@@ -1,13 +1,9 @@
 import * as vscode from "vscode";
-import { config } from "../extension";
 import { currentFile } from "../utils";
 
 export async function jumpToTagAndOffset(): Promise<void> {
   const file = currentFile();
   if (!file) {
-    return;
-  }
-  if (!config("conn").active) {
     return;
   }
   const nameMatch = file.name.match(/(.*)\.(int|mac)$/i);

--- a/src/commands/jumpToTagAndOffset.ts
+++ b/src/commands/jumpToTagAndOffset.ts
@@ -1,0 +1,68 @@
+import * as vscode from "vscode";
+import { config } from "../extension";
+import { currentFile } from "../utils";
+
+export async function jumpToTagAndOffset(): Promise<void> {
+  const file = currentFile();
+  if (!file) {
+    return;
+  }
+  if (!config("conn").active) {
+    return;
+  }
+  const nameMatch = file.name.match(/(.*)\.(int|mac)$/i);
+  if (!nameMatch) {
+    return;
+  }
+  const document = vscode.window.activeTextEditor?.document;
+  if (!document) {
+    return;
+  }
+
+  // Build map of labels in routine
+  const map = new Map();
+  const options = [];
+  for (let i = 0; i < document.lineCount; i++) {
+    const labelMatch = document.lineAt(i).text.match(/^(%?\w+).*/);
+    if (labelMatch) {
+      map.set(labelMatch[1], i);
+      options.push(labelMatch[1]);
+    }
+  }
+
+  const items: vscode.QuickPickItem[] = options.map((option) => {
+    return { label: option };
+  });
+  const quickPick = vscode.window.createQuickPick();
+  quickPick.title = "Jump to Tag + Offset";
+  quickPick.items = items;
+  quickPick.canSelectMany = false;
+  quickPick.onDidChangeSelection((_) => {
+    quickPick.value = quickPick.selectedItems[0].label;
+  });
+  quickPick.onDidAccept((_) => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      quickPick.hide();
+      return;
+    }
+    const parts = quickPick.value.split("+");
+    let offset = 0;
+    if (!map.has(parts[0])) {
+      if (parts[0] !== "") {
+        return;
+      }
+    } else {
+      offset += parseInt(map.get(parts[0]), 10);
+    }
+    if (parts.length > 1) {
+      offset += parseInt(parts[1], 10);
+    }
+    const line = editor.document.lineAt(offset);
+    const range = new vscode.Range(line.range.start, line.range.start);
+    editor.selection = new vscode.Selection(range.start, range.start);
+    editor.revealRange(range, vscode.TextEditorRevealType.AtTop);
+    quickPick.hide();
+  });
+  quickPick.show();
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,7 @@ import {
   mainSourceControlMenu,
 } from "./commands/studio";
 import { addServerNamespaceToWorkspace } from "./commands/addServerNamespaceToWorkspace";
+import { jumpToTagAndOffset } from "./commands/jumpToTagAndOffset";
 import { connectFolderToServerNamespace } from "./commands/connectFolderToServerNamespace";
 
 import { getLanguageConfiguration } from "./languageConfiguration";
@@ -398,6 +399,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   });
 
   posPanel = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+  posPanel.command = "vscode-objectscript.jumpToTagAndOffset";
   posPanel.show();
 
   panel = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 1);
@@ -613,6 +615,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           if (value) return value.label;
         });
     }),
+    vscode.commands.registerCommand("vscode-objectscript.jumpToTagAndOffset", jumpToTagAndOffset),
     vscode.commands.registerCommand("vscode-objectscript.viewOthers", viewOthers),
     vscode.commands.registerCommand("vscode-objectscript.serverCommands.sourceControl", mainSourceControlMenu),
     vscode.commands.registerCommand(


### PR DESCRIPTION
This PR fixes #267 

A new command, "Jump to Tag + Offset" (also launched by clicking via the position status bar element, as @gjsjohnmurray suggested) supports jumping to tag[+offset] within .MAC and .INT routines.