### PR TITLE
Fix #361, support opening "other" doc types via isfs

### DIFF
--- a/package.json
+++ b/package.json
@@ -286,12 +286,12 @@
         },
         {
           "command": "vscode-objectscript.serverCommands.contextSourceControl",
-          "when": "resourceScheme == isfs && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "resourceScheme == isfs && vscode-objectscript.connectActive",
           "group": "objectscript@4"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextOther",
-          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive",
           "group": "objectscript@5"
         }
       ],
@@ -337,12 +337,12 @@
         },
         {
           "command": "vscode-objectscript.serverCommands.contextSourceControl",
-          "when": "resourceScheme == isfs && resourceLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "resourceScheme == isfs && vscode-objectscript.connectActive",
           "group": "objectscript@2"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextOther",
-          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && resourceLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive",
           "group": "objectscript@3"
         }
       ]

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -281,9 +281,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
-    if (!csp && !fileName.match(/\.(cls|mac|int|inc|dfi|bpl)$/i)) {
-      throw vscode.FileSystemError.FileNotFound();
-    }
     const name = path.basename(uri.path);
     const api = new AtelierAPI(uri);
     return api


### PR DESCRIPTION
Also enables them for source control actions even if they're XML files (e.g., DFI and some other custom document types used in Interoperability and HS)

This PR fixes #361 