### PR TITLE
Fix extension reload

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -59,6 +59,7 @@ function getOtherStudioActionLabel(action: OtherStudioAction): string {
   return label;
 }
 
+// Used to avoid triggering the edit listener when files are reloaded by an extension
 const suppressEditListenerMap = new Map<string, boolean>();
 
 class StudioActions {
@@ -268,6 +269,7 @@ class StudioActions {
               if (actionToProcess.reload) {
                 const document = vscode.window.activeTextEditor.document;
                 const file = currentFile(document);
+                // Avoid the reload triggering the edit listener here
                 suppressEditListenerMap.set(file.uri.toString(), true);
                 await loadChanges([file]);
               }
@@ -364,6 +366,8 @@ class StudioActions {
       label: getOtherStudioActionLabel(action),
     };
     if (action === OtherStudioAction.AttemptedEdit) {
+      // Check to see if this "attempted edit" was an action by this extension due to a reload.
+      // There's no way to detect at a higher level from the event.
       if (suppressEditListenerMap.has(this.uri.toString())) {
         suppressEditListenerMap.delete(this.uri.toString());
         return;


### PR DESCRIPTION
This PR does not fix #259 but does address https://github.com/intersystems-community/vscode-objectscript/issues/259#issuecomment-682088028 and some related issues my team has observed.

Use case:
We have a Source Control > Undo Check Out menu item for our Perforce-based extension. This will return reload=true. The problem was twofold - we weren't checking/acting on the "reload" flag from AfterUserAction, and when we did, we were detecting the revert as an edit and blocking it unless the user checked the file out again (obviously not correct).

There isn't really a clean way to detect this case, so we now track URIs for which we've requested a reload and ignore the next "attempted edit" on them. While not the neatest, the solution is at least localized to the legacy studio command set of functionality, and I don't see alternatives.