### PR TITLE
Support server-side (isfs) folder settings, snippets, debug configs etc

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -496,4 +496,12 @@ export class AtelierAPI {
     };
     return this.request(1, "GET", `%SYS/jobs`, null, params);
   }
+
+  // v1+
+  public getCSPApps(detail = false): Promise<Atelier.Response> {
+    const params = {
+      detail: detail ? 1 : 0,
+    };
+    return this.request(1, "GET", `%SYS/cspapps/${this.ns || ""}`, null, params);
+  }
 }

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -251,18 +251,22 @@ export async function importAndCompile(askFlags = false, document?: vscode.TextD
       // console.error(error);
       throw error;
     })
-    .then(() => compile([file], flags));
+    .then(() => {
+      if (!file.fileName.startsWith("\\.vscode\\")) {
+        compile([file], flags);
+      }
+    });
 }
 
 // Compiles all files types in the namespace
-export async function namespaceCompile(askFLags = false): Promise<any> {
+export async function namespaceCompile(askFlags = false): Promise<any> {
   const api = new AtelierAPI();
   const fileTypes = ["*.CLS", "*.MAC", "*.INC", "*.BAS"];
   if (!config("conn").active) {
     throw new Error(`No Active Connection`);
   }
   const defaultFlags = config().compileFlags;
-  const flags = askFLags ? await compileFlags() : defaultFlags;
+  const flags = askFlags ? await compileFlags() : defaultFlags;
   if (flags === undefined) {
     // User cancelled
     return;

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -210,13 +210,13 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     if (uri.path.startsWith("/.")) {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
     }
-    const api = new AtelierAPI(uri);
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
     if (fileName.startsWith(".")) {
       return;
     }
+    const api = new AtelierAPI(uri);
     return this._lookupAsFile(uri).then(
       () => {
         // Weirdly, if the file exists on the server we don't actually write its content here.

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -304,7 +304,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   private async _lookup(uri: vscode.Uri): Promise<Entry> {
     const parts = uri.path.split("/");
     let entry: Entry = this.root;
-    //for (const part of parts) {
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
       if (!part) {
@@ -352,11 +351,11 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
     }
 
-    const api = new AtelierAPI(uri);
     const { query } = url.parse(decodeURIComponent(uri.toString()), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
     const name = path.basename(uri.path);
+    const api = new AtelierAPI(uri);
     return api
       .getDoc(fileName)
       .then((data) => data.result)

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -80,11 +80,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       .actionQuery(sql, [spec, dir, orderBy, system, flat, notStudio, generated])
       .then((data) => data.result.content || [])
       .then((data) => {
-        // If webapp '/' exists it will always list first
-        const rootWebAppExists = csp && data[0]?.Name === "/";
         const results = data
           .filter((item: StudioOpenDialog) =>
-            item.Type === "10" ? csp && item.Name !== "/" : item.Type === "9" ? !csp : !rootWebAppExists
+            item.Type === "10" ? csp && item.Name !== "/" : item.Type === "9" ? !csp : csp ? item.Type === "5" : true
           )
           .map((item: StudioOpenDialog) => {
             // Handle how query returns web apps
@@ -132,20 +130,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
                   return [name, vscode.FileType.Directory];
                 });
               return results.concat(cspSubdirs);
-            });
-        } else if (rootWebAppExists) {
-          // Expanding the root of a CSP-type workspace folder, and earlier we found a '/' root-level webapp
-          // so we now enumerate its files.
-          return api
-            .actionQuery(sql, ["/*", dir, orderBy, "0", "0", notStudio, "0"])
-            .then((data) => data.result.content || [])
-            .then((data) => {
-              const rootAppFiles: [string, vscode.FileType][] = data
-                .filter((item) => item.Type === "5")
-                .map((item) => {
-                  return [item.Name, vscode.FileType.File];
-                });
-              return results.concat(rootAppFiles);
             });
         } else {
           // Nothing else to add.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -84,7 +84,6 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
   const { query } = url.parse(decodeURIComponent(uri.toString()), true);
   const csp = query.csp === "" || query.csp === "1";
   if (csp) {
-    //name = fileName.replace("\\", "/");
     name = uri.path;
   } else if (fileExt === "cls") {
     const match = content.match(/^Class (%?\w+(?:\.\w+)+)/im);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -72,19 +72,20 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
       !document.fileName ||
       !document.languageId ||
       !document.languageId.startsWith("objectscript") ||
-      fileExt.match(/(csp)/i)) // Skip CSP for now, yet
+      fileExt.match(/(csp)/i)) // Skip local CSPs for now
   ) {
     return null;
   }
   const eol = document.eol || vscode.EndOfLine.LF;
-  const uri = document.uri;
+  const uri = redirectDotvscodeRoot(document.uri);
   const content = document.getText();
   let name = "";
   let ext = "";
   const { query } = url.parse(decodeURIComponent(uri.toString()), true);
   const csp = query.csp === "" || query.csp === "1";
   if (csp) {
-    name = fileName.replace("\\", "/");
+    //name = fileName.replace("\\", "/");
+    name = uri.path;
   } else if (fileExt === "cls") {
     const match = content.match(/^Class (%?\w+(?:\.\w+)+)/im);
     if (match) {
@@ -332,4 +333,31 @@ export async function terminalWithDocker(): Promise<vscode.Terminal> {
   }
   terminal.show(true);
   return terminal;
+}
+
+/**
+ * Alter isfs-type uri.path of /.vscode/* files or subdirectories.
+ * Rewrite `/.vscode/path/to/file` as `/_vscode/XYZ/path/to/file`
+ *  where XYZ comes from the `ns` queryparam of uri.
+ * Also alter query to specify `ns=%SYS&csp=1`
+ *
+ * @returns uri, altered if necessary.
+ * @throws if `ns` queryparam is missing but required.
+ */
+export function redirectDotvscodeRoot(uri: vscode.Uri): vscode.Uri {
+  if (!schemas.includes(uri.scheme)) {
+    return uri;
+  }
+  const dotMatch = uri.path.match(/^\/(\.[^/]*)\/(.*)$/);
+  if (dotMatch && dotMatch[1] === ".vscode") {
+    const nsMatch = `&${uri.query}&`.match(/&ns=(.+)&/);
+    if (!nsMatch) {
+      throw new Error("No 'ns' query parameter on uri");
+    }
+    const namespace = nsMatch[1];
+    const newQueryString = (("&" + uri.query).replace(`ns=${namespace}`, "ns=%SYS") + "&csp=1").slice(1);
+    return uri.with({ path: `/_vscode/${namespace}/${dotMatch[2]}`, query: newQueryString });
+  } else {
+    return uri;
+  }
 }


### PR DESCRIPTION
This PR resolves #383

To provide the server-side storage, define a web application named `/_vscode` like this:

![image](https://user-images.githubusercontent.com/6726799/96166839-71ed3400-0f16-11eb-991e-629eb1c2c851.png)

(alter the Physical Path value to suit your platform and install folder)

An isfs-type workspace root folder that connects to a namespace on this server can now write and read folder-specific settings, e.g.

![image](https://user-images.githubusercontent.com/6726799/96167328-225b3800-0f17-11eb-85d4-ed1c3870ad65.png)

Folder-specific snippets file can be created via `Preferences: Configure User Snippets`

![image](https://user-images.githubusercontent.com/6726799/96167570-84b43880-0f17-11eb-91f7-16d1d9a7fb01.png)

To edit the server-side namespace-specific files (all namespaces) directly through VS Code, add an isfs-type root folder with the following uri:

```
isfs://servername/_vscode?ns=%SYS&csp
```

For a single namespace (e.g USER):

```
isfs://servername/_vscode/USER?ns=%SYS&csp
```

