### PR TITLE
CHANGELOG update for 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [1.0.0] 19-Oct-2020
+## [1.0.1] 20-Oct-2020
 - First production release.
 
 ## [0.9.5]


### PR DESCRIPTION
A CI problem with the release procedure (v1.0.0 being initially saved as a draft) prevented 1.0.0 from getting published. Releasing 1.0.1 to resolve this.