### PR TITLE
fix #443 support more ${...} variables in server menu links

### DIFF
--- a/package.json
+++ b/package.json
@@ -694,12 +694,20 @@
               "default": false
             },
             "links": {
-              "description": "Extra links for the server.",
+              "description": "Extra links for the server command menu.",
               "type": "object",
               "patternProperties": {
                 ".*": {
                   "type": "string",
-                  "format": "uri"
+                  "description": "Key is displayed on menu. Value is the uri to open. Several ${...} substitution symbols are supported in the value.",
+                  "anyOf": [
+                    {
+                      "format": "uri"
+                    },
+                    {
+                      "pattern": "^\\${serverUrl}\/.*"
+                    }
+                  ]
                 }
               }
             },

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -80,6 +80,9 @@ export async function serverActions(): Promise<void> {
     link = link
       .replace("${host}", host)
       .replace("${port}", port.toString())
+      .replace("${serverUrl}", serverUrl)
+      .replace("${serverAuth}", auth)
+      .replace("${ns}", nsEncoded)
       .replace("${namespace}", ns == "%SYS" ? "sys" : nsEncoded.toLowerCase())
       .replace("${classname}", classname);
     actions.push({


### PR DESCRIPTION
This PR fixes #443 

New variables are:

- `${serverUrl}` - for example `http://localhost:52773`
- `${serverAuth}` - for example `&IRISUsername=_SYSTEM&IRISPassword=SYS`
- `${ns}` - the raw `ns` parameter of the connection. Different from the already-defined `${namespace}` variable.

An example of how the new capabilities can launch [WebTerminal](https://openexchange.intersystems.com/package/WebTerminal):
```json
    "objectscript.conn": {
        "server": "vscodelab",
        "ns": "%SYS",
        "active": true,
        "links": {
            "$(terminal) WebTerminal": "${serverUrl}/terminal/?ns=${ns}${serverAuth}"
        }
    }
```