### PR TITLE
fix #464 add objectscript.overwriteServerChanges setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -833,6 +833,11 @@
           "default": "cuk",
           "description": "Compilation flags."
         },
+        "objectscript.overwriteServerChanges": {
+          "type": "boolean",
+          "default": false,
+          "description": "Overwrite a changed server version without confirmation when importing the local file."
+        },
         "objectscript.autoPreviewXML": {
           "type": "boolean",
           "default": false,

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -69,7 +69,7 @@ async function importFile(file: CurrentFile, ignoreConflict?: boolean): Promise<
   const api = new AtelierAPI(file.uri);
   const content = file.content.split(/\r?\n/);
   const mtime = await checkChangedOnServer(file);
-  ignoreConflict = ignoreConflict || mtime < 0;
+  ignoreConflict = ignoreConflict || mtime < 0 || (file.uri.scheme === "file" && config("overwriteServerChanges"));
   return api
     .putDoc(
       file.name,


### PR DESCRIPTION
This PR fixes #464 

It adds the `objectscript.overwriteServerChanges` setting (default = `false`). This setting intentionally only affects import from file-type uris. When server-side editing (isfs) is being used, conflicts are always notified.