### PR TITLE
fix #467 improve Quick Open (ctrl+p) on isfs (uses proposed API)

### DIFF
--- a/src/providers/FileSystemPovider/FileSearchProvider.ts
+++ b/src/providers/FileSystemPovider/FileSearchProvider.ts
@@ -34,6 +34,13 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
             if (category === "*" && file.cat === "CSP") {
               return null;
             }
+            if (file.cat !== "CSP") {
+              if (file.name.startsWith("%") && api.ns !== "%SYS") {
+                return null;
+              }
+              const nameParts = file.name.split(".");
+              file.name = nameParts.slice(0, -2).join("/") + "/" + nameParts.slice(-2).join(".");
+            }
             if (!options.maxResults || ++counter <= options.maxResults) {
               return options.folder.with({ path: `/${file.name}` });
             } else {


### PR DESCRIPTION
This PR fixes #467

The same search as showen on the original issue now returns thus:

![image](https://user-images.githubusercontent.com/6726799/97898575-f0780d00-1d2f-11eb-95c3-457521410f2b.png)
