### PR TITLE
fix #337 handle Unicode chars in identifiers

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,7 +86,8 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
   if (csp) {
     name = uri.path;
   } else if (fileExt === "cls") {
-    const match = content.match(/^Class (%?\w+(?:\.\w+)+)/im);
+    // Allow Unicode letters
+    const match = content.match(/^Class (%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
     if (match) {
       [, name, ext = "cls"] = match;
     }

--- a/syntaxes/objectscript-class.tmLanguage.json
+++ b/syntaxes/objectscript-class.tmLanguage.json
@@ -17,7 +17,7 @@
           "include": "#comments"
         },
         {
-          "match": "(?i)^(\\Include\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+          "match": "(?i)^(\\Include\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -31,7 +31,7 @@
           }
         },
         {
-          "match": "(?i)^(\\bClass\\b)(\\s)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+          "match": "(?i)^(\\bClass\\b)(\\s)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -45,7 +45,7 @@
           }
         },
         {
-          "match": "(?i)(\\bExtends\\b)(\\s)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+          "match": "(?i)(\\bExtends\\b)(\\s)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -73,7 +73,7 @@
           },
           "patterns": [
             {
-              "match": "(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+              "match": "(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
               "captures": {
                 "1": {
                   "name": "entity.name.class.objectscript_class"
@@ -112,7 +112,7 @@
     "as": {
       "patterns": [
         {
-          "match": "(?i)(\\bAs\\b(?:\\slist of)?)(\\s+)(%?[a-z][0-9a-z]*(?:_[0-9a-z]+)*(?:\\.[a-z][0-9a-z]*(?:_[0-9a-z]+)*)*)",
+          "match": "(?i)(\\bAs\\b(?:\\slist of)?)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -155,7 +155,7 @@
           "include": "#comments"
         },
         {
-          "begin": "(?i)(^\\bIndex\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)(^\\bIndex\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -180,7 +180,7 @@
           }
         },
         {
-          "match": "(?i)^(\\bForeignKey\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "match": "(?i)^(\\bForeignKey\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -194,7 +194,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\bParameter\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)^(\\bParameter\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -219,7 +219,7 @@
           }
         },
         {
-          "match": "(?i)^(\\Projection\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "match": "(?i)^(\\Projection\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -233,7 +233,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\bProperty\\b)(\\s+)((?:%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)|(?:\"[^\".]+\"))",
+          "begin": "(?i)^(\\bProperty\\b)(\\s+)((?:%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)|(?:\"[^\".]+\"))",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -258,7 +258,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\bRelationship\\b)(\\s+)((?:%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)|(?:\"[^\".]+\"))",
+          "begin": "(?i)^(\\bRelationship\\b)(\\s+)((?:%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)|(?:\"[^\".]+\"))",
             "beginCaptures": {
               "1": {
                 "name": "keyword.objectscript_class"
@@ -283,7 +283,7 @@
             }
         },
         {
-          "begin": "(?i)^(\\bClient(?:Class)?Method\\b)(\\s+)((?:%|%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)|(?:\"[^\".]+\"))",
+          "begin": "(?i)^(\\bClient(?:Class)?Method\\b)(\\s+)((?:%|%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)|(?:\"[^\".]+\"))",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -308,7 +308,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\b(?:Class)?Method\\b)(\\s+)((?:%|%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)|(?:\"[^\".]+\"))",
+          "begin": "(?i)^(\\b(?:Class)?Method\\b)(\\s+)((?:%|%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)|(?:\"[^\".]+\"))",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -333,7 +333,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\Query\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)^(\\Query\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -358,7 +358,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\bTrigger\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)^(\\bTrigger\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -411,7 +411,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\XData\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)^(\\XData\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -439,7 +439,7 @@
           }
         },
         {
-          "begin": "(?i)^(\\Storage\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)",
+          "begin": "(?i)^(\\Storage\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)",
           "beginCaptures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -572,7 +572,7 @@
               "include": "#as"
             },
             {
-              "match": "[a-zA-Z][a-zA-Z0-9]*",
+              "match": "[\\p{Alpha}][\\p{Alnum}]*",
               "name": "variable.name.objectscript"
             },
             {
@@ -585,7 +585,7 @@
     "index": {
       "patterns": [
         {
-          "match": "(\\bOn\\b)(\\s+)(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+          "match": "(\\bOn\\b)(\\s+)(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
           "captures": {
             "1": {
               "name": "keyword.objectscript_class"
@@ -613,7 +613,7 @@
           },
           "patterns": [
             {
-              "match": "(%?[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*(?:\\.[a-zA-Z][0-9a-zA-Z]*(?:_[0-9a-zA-Z]+)*)*)",
+              "match": "(%?[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*(?:\\.[\\p{Alpha}][\\p{Alnum}]*(?:_[\\p{Alnum}]+)*)*)",
               "captures": {
                 "1": {
                   "name": "entity.other.attribute-name.objectscript_class"

--- a/syntaxes/objectscript-macros.tmLanguage.json
+++ b/syntaxes/objectscript-macros.tmLanguage.json
@@ -4,7 +4,7 @@
   "scopeName": "source.objectscript_macros",
   "patterns": [
     {
-      "match": "^(ROUTINE)\\s(\\b[a-zA-Z0-9.]+\\b)",
+      "match": "^(ROUTINE)\\s(\\b[\\p{Alnum}.]+\\b)",
       "captures": {
         "1": { "name": "keyword.control" },
         "2": { "name": "entity.name.class" }
@@ -23,7 +23,7 @@
     "include": {
       "patterns": [
         {
-          "begin": "^\\s*(\\#\\s*(?:(?i)include))\\s+([a-zA-Z%][a-zA-Z0-9]*)",
+          "begin": "^\\s*(\\#\\s*(?:(?i)include))\\s+([\\p{Alpha}%][\\p{Alnum}]*)",
           "end": "(?=$)",
           "beginCaptures": {
             "1": { "name": "keyword.other.objectscript" },
@@ -36,7 +36,7 @@
       "patterns": [
         {
           "name": "meta.preprocessor.objectscript",
-          "match": "^\\s*(\\#\\s*(?:(?i)dim))\\s+((?<id>[a-zA-Z%][a-zA-Z0-9]*))(?:\\s*(,)\\s*((\\g<id>)*))*(?:\\s+((?i)As)(?:\\s(\\g<id>(?:\\.\\g<id>)*)))?",
+          "match": "^\\s*(\\#\\s*(?:(?i)dim))\\s+((?<id>[\\p{Alpha}%][\\p{Alnum}]*))(?:\\s*(,)\\s*((\\g<id>)*))*(?:\\s+((?i)As)(?:\\s(\\g<id>(?:\\.\\g<id>)*)))?",
           "captures": {
             "1": { "name": "keyword.control.objectscript" },
             "2": { "name": "variable.name" },
@@ -52,7 +52,7 @@
       "patterns": [
         {
           "name": "meta.preprocessor.objectscript",
-          "begin": "^\\s*(\\#\\s*(?:(?i)define))\\s+((?<id>[%a-zA-Z0-9]*))(?:(\\()(\\s*\\g<id>\\s*((,)\\s*\\g<id>\\s*)*)(\\)))?",
+          "begin": "^\\s*(\\#\\s*(?:(?i)define))\\s+((?<id>[%\\p{Alnum}]*))(?:(\\()(\\s*\\g<id>\\s*((,)\\s*\\g<id>\\s*)*)(\\)))?",
           "beginCaptures": {
             "1": { "name": "keyword.control.objectscript" },
             "2": { "name": "entity.name.objectscript" },
@@ -76,7 +76,7 @@
       "patterns": [
         {
           "name": "meta.preprocessor.objectscript",
-          "begin": "^\\s*(\\#\\s*(?:(?i)def1arg))\\s+((?<id>[a-zA-Z%][a-zA-Z0-9]*))(?:(\\()(\\s*\\g<id>\\s*)(\\)))",
+          "begin": "^\\s*(\\#\\s*(?:(?i)def1arg))\\s+((?<id>[\\p{Alpha}%][\\p{Alnum}]*))(?:(\\()(\\s*\\g<id>\\s*)(\\)))",
           "beginCaptures": {
             "1": { "name": "keyword.control.objectscript" },
             "2": { "name": "entity.name.objectscript" },
@@ -114,7 +114,7 @@
     },
 
     "macros": {
-      "patterns": [{ "match": "\\$\\$\\$[a-zA-Z]([a-zA-Z0-9])*", "name": "support.constant" }]
+      "patterns": [{ "match": "\\$\\$\\$[\\p{Alpha}]([\\p{Alnum}])*", "name": "support.constant" }]
     },
 
     "comment-line": {

--- a/syntaxes/objectscript.tmLanguage.json
+++ b/syntaxes/objectscript.tmLanguage.json
@@ -4,7 +4,7 @@
   "scopeName": "source.objectscript",
   "patterns": [
     {
-      "match": "^(ROUTINE)\\s(\\b[a-zA-Z0-9.]+\\b)",
+      "match": "^(ROUTINE)\\s(\\b[\\p{Alnum}.]+\\b)",
       "captures": {
         "1": { "name": "keyword.control" },
         "2": { "name": "entity.name.class" }
@@ -141,7 +141,7 @@
     "macros": {
       "patterns": [
         {
-          "match": "(?i)(#dim)(\\s)(%?[a-zA-Z0-9]+)(\\s)(?:(As)(\\s)(%?[a-zA-Z0-9.]+))?",
+          "match": "(?i)(#dim)(\\s)(%?[\\p{Alnum}]+)(\\s)(?:(As)(\\s)(%?[\\p{Alnum}.]+))?",
           "captures": {
             "1": { "name": "meta.preprocessor.dim.objectscript" },
             "2": { "name": "whitespace.objectscript" },
@@ -160,7 +160,7 @@
     "elements": {
       "patterns": [
         {
-          "match": "^([a-zA-Z0-9]+)(\\([^)]*\\))(?:\\s+(public|private))?",
+          "match": "^([\\p{Alnum}]+)(\\([^)]*\\))(?:\\s+(public|private))?",
           "captures": {
             "1": { "name": "entity.name.function" },
             "2": { "name": "other" },
@@ -177,11 +177,11 @@
           }
         },
         {
-          "match": "%[a-zA-Z0-9]+",
+          "match": "%[\\p{Alnum}]+",
           "name": "entity.other.attribute-name"
         },
         {
-          "match": "[i|r]%[a-zA-Z0-9]+",
+          "match": "[i|r]%[\\p{Alnum}]+",
           "name": "entity.other.attribute-name"
         },
         {
@@ -189,48 +189,48 @@
           "name": "entity.other.attribute-name"
         },
         {
-          "match": "(\\.{1,2})(%?[a-zA-Z0-9]+)(?=\\()",
+          "match": "(\\.{1,2})(%?[\\p{Alnum}]+)(?=\\()",
           "captures": {
             "1": { "name": "punctuation.objectscript" },
             "2": { "name": "entity.other.attribute-name" }
           }
         },
         {
-          "match": "(\\.{1,2})(%?[a-zA-Z0-9]+)(?!\\()",
+          "match": "(\\.{1,2})(%?[\\p{Alnum}]+)(?!\\()",
           "captures": {
             "1": { "name": "punctuation.objectscript" },
             "2": { "name": "entity.other.attribute-name" }
           }
         },
         {
-          "match": "(\\.{1,2}#)([a-zA-Z0-9]+)",
+          "match": "(\\.{1,2}#)([\\p{Alnum}]+)",
           "captures": {
             "1": { "name": "punctuation.objectscript" },
             "2": { "name": "meta.parameter.type.variable" }
           }
         },
         {
-          "match": "%?[a-zA-Z0-9]+",
+          "match": "%?[\\p{Alnum}]+",
           "name": "variable.name.objectscrip"
         },
         {
-          "match": "\\^%?[a-zA-Z0-9]+(\\.[a-zA-Z0-9]+)*",
+          "match": "\\^%?[\\p{Alnum}]+(\\.[\\p{Alnum}]+)*",
           "name": "variable.name.global.objectscrip"
         },
         {
-          "match": "(?i)\\$system(.[a-zA-Z0-9]+)*",
+          "match": "(?i)\\$system(.[\\p{Alnum}]+)*",
           "name": "entity.name.function.system.objectscript"
         },
         {
-          "match": "\\$[a-zA-Z0-9]+",
+          "match": "\\$[\\p{Alnum}]+",
           "name": "entity.name.function.system.objectscript"
         },
         {
-          "match": "\\${2}[a-zA-Z0-9]+",
+          "match": "\\${2}[\\p{Alnum}]+",
           "name": "entity.name.function.local.objectscript"
         },
         {
-          "match": "\\${3}[a-zA-Z0-9]+",
+          "match": "\\${3}[\\p{Alnum}]+",
           "name": "meta.preprocessor.objectscript"
         }
       ]


### PR DESCRIPTION
This PR fixes #337 and also corrects TextMate handling of identifiers that contain Unicode characters.