### PR TITLE
fix #490 make Documatic launcher class-specific

### DIFF
--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -59,10 +59,15 @@ export async function serverActions(): Promise<void> {
         return;
       });
   }
+  const file = currentFile();
+  const classname = file && file.name.toLowerCase().endsWith(".cls") ? file.name.slice(0, -4) : "";
+  const classnameEncoded = encodeURIComponent(classname);
   const connInfo = `${host}:${port}[${nsEncoded}]`;
   const serverUrl = `${https ? "https" : "http"}://${host}:${port}`;
   const portalUrl = `${serverUrl}/csp/sys/UtilHome.csp?$NAMESPACE=${nsEncoded}`;
-  const classRef = `${serverUrl}/csp/documatic/%25CSP.Documatic.cls?LIBRARY=${nsEncoded}`;
+  const classRef = `${serverUrl}/csp/documatic/%25CSP.Documatic.cls?LIBRARY=${nsEncoded}${
+    classname ? "&CLASSNAME=" + classnameEncoded : ""
+  }`;
   const iris = workspaceState.get(workspaceFolder + ":iris", false);
   const usernameEncoded = encodeURIComponent(username);
   const passwordEncoded = encodeURIComponent(password);
@@ -70,11 +75,9 @@ export async function serverActions(): Promise<void> {
     ? `&IRISUsername=${usernameEncoded}&IRISPassword=${passwordEncoded}`
     : `&CacheUserName=${usernameEncoded}&CachePassword=${passwordEncoded}`;
   let extraLinks = 0;
-  const file = currentFile();
-  const classname = file && file.name.match(/cls$/i) ? file.name : "";
   for (const title in links) {
     let link = String(links[title]);
-    if (classname == "" && link.includes("${classname}")) {
+    if (classname == "" && (link.includes("${classname}") || link.includes("${classnameEncoded}"))) {
       continue;
     }
     link = link
@@ -84,7 +87,8 @@ export async function serverActions(): Promise<void> {
       .replace("${serverAuth}", auth)
       .replace("${ns}", nsEncoded)
       .replace("${namespace}", ns == "%SYS" ? "sys" : nsEncoded.toLowerCase())
-      .replace("${classname}", classname);
+      .replace("${classname}", classname)
+      .replace("${classnameEncoded}", classnameEncoded);
     actions.push({
       id: "extraLink" + extraLinks++,
       label: title,
@@ -99,14 +103,14 @@ export async function serverActions(): Promise<void> {
     });
   }
   actions.push({
-    detail: portalUrl,
     id: "openPortal",
     label: "Open Management Portal",
+    detail: portalUrl,
   });
   actions.push({
-    detail: classRef,
     id: "openClassReference",
-    label: "Open Class Reference",
+    label: "Open Class Reference" + (classname ? ` for ${classname}` : ""),
+    detail: classRef,
   });
   if (
     !vscode.window.activeTextEditor ||


### PR DESCRIPTION
This PR fixes #490 

The server action menu, accessed by clicking on the connection's panel in the status bar, now targets its Open Class Documentation onto the currently open class if any.

Side-effects of this change:
- the ${classname} substitution no longer includes a redundant ".cls" suffix. This is a breaking change but seems low-risk because this feature doesn't appear to have been documented yet.
- a new ${classnameEncoded} substitution has been added, suitable for use in a URL querystring.