### PR TITLE
fix #495 display TextSearchProvider results from non-primary root

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -208,7 +208,9 @@ export class AtelierAPI {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
     params?: any,
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    headers?: any
+    headers?: any,
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    options?: any
   ): Promise<any> {
     const { active, apiVersion, host, port, username, password, https } = this.config;
     if (!active || !port || !host) {
@@ -326,7 +328,7 @@ export class AtelierAPI {
           data.result.content.length !== 0 &&
           data.result.content[0] != undefined &&
           data.result.content[0].action != undefined;
-        if (!isStudioAction) {
+        if (!isStudioAction && !options?.noOutput) {
           outputConsole(data.console);
         }
       }
@@ -451,7 +453,7 @@ export class AtelierAPI {
       word: false,
       ...params,
     };
-    return this.request(2, "GET", `${this.ns}/action/search`, null, params);
+    return this.request(2, "GET", `${this.ns}/action/search`, null, params, null, { noOutput: true });
   }
 
   // v1+

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -33,14 +33,24 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     }
   }
 
-  public static getUri(name: string, workspaceFolder?: string, namespace?: string, vfs?: boolean): vscode.Uri {
+  public static getUri(
+    name: string,
+    workspaceFolder?: string,
+    namespace?: string,
+    vfs?: boolean,
+    wFolderUri?: vscode.Uri
+  ): vscode.Uri {
     if (vfs === undefined) {
       vfs = config("serverSideEditing");
     }
     let scheme = vfs ? FILESYSTEM_SCHEMA : OBJECTSCRIPT_FILE_SCHEMA;
-    workspaceFolder = workspaceFolder && workspaceFolder !== "" ? workspaceFolder : currentWorkspaceFolder();
     const isCsp = name.includes("/");
-    const wFolderUri = workspaceFolderUri(workspaceFolder);
+
+    // if wFolderUri was passed it takes precedence
+    if (!wFolderUri) {
+      workspaceFolder = workspaceFolder && workspaceFolder !== "" ? workspaceFolder : currentWorkspaceFolder();
+      wFolderUri = workspaceFolderUri(workspaceFolder);
+    }
     let uri: vscode.Uri;
     if (wFolderUri.scheme === FILESYSTEM_SCHEMA || wFolderUri.scheme === FILESYSTEM_READONLY_SCHEMA) {
       const fileExt = name.split(".").pop();

--- a/src/providers/FileSystemPovider/TextSearchProvider.ts
+++ b/src/providers/FileSystemPovider/TextSearchProvider.ts
@@ -33,7 +33,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
       .then((files: SearchResult[]) =>
         files.map(async (file) => {
           const fileName = file.doc;
-          const uri = DocumentContentProvider.getUri(fileName);
+          const uri = DocumentContentProvider.getUri(fileName, "", "", true, options.folder);
           const document = await vscode.workspace.openTextDocument(uri);
           return {
             ...file,


### PR DESCRIPTION
This PR fixes #495, including suppressing display of search results in output channel.