### PR TITLE
fix #503 ask for password when needed

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -357,7 +357,8 @@ export class AtelierAPI {
         return data;
       }
     } catch (error) {
-      if (error.error && error.error.code === "ECONNREFUSED") {
+      if (error.code === "ECONNREFUSED") {
+        authRequestMap.delete(target);
         panel.text = `${this.connInfo} $(debug-disconnect)`;
         panel.tooltip = "Disconnected";
         workspaceState.update(this.configName + ":host", undefined);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -279,7 +279,7 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
     .catch((error) => {
       let message = error.message;
       let errorMessage;
-      if (error.status === 401) {
+      if (error.statusCode === 401) {
         setTimeout(() => {
           const username = api.config.username;
           if (username === "") {


### PR DESCRIPTION
This PR fixes #503

Previous work to standardize contents of thrown errors broke interactive password prompting in 1.0.5