### PR TITLE
fix #501 exclude Studio projects from isfs

### DIFF
--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -53,6 +53,10 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     let filter = "";
     if (query.filter && query.filter.length) {
       filter = query.filter.toString();
+      if (!csp) {
+        // always exclude Studio projects, since we can't do anything with them
+        filter += ",'*.prj";
+      }
     } else if (csp) {
       filter = "*";
     } else if (type === "rtn") {


### PR DESCRIPTION
This PR fixes #501 by ensuring .prj items never appear in the tree.