### PR TITLE
fix #510 respect pathPrefix on server action URLs

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -137,9 +137,9 @@ export class AtelierAPI {
   }
 
   public xdebugUrl(): string {
-    const { host, https, port, apiVersion } = this.config;
+    const { host, https, port, apiVersion, pathPrefix } = this.config;
     const proto = https ? "wss" : "ws";
-    return `${proto}://${host}:${port}/api/atelier/v${apiVersion}/%25SYS/debug`;
+    return `${proto}://${host}:${port}${pathPrefix}/api/atelier/v${apiVersion}/%25SYS/debug`;
   }
 
   public updateCookies(newCookies: string[]): Promise<any> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -315,7 +315,7 @@ export class AtelierAPI {
       }
       await this.updateCookies(response.headers.raw()["set-cookie"] || []);
       panel.text = `${this.connInfo}`;
-      panel.tooltip = `Connected as ${username}`;
+      panel.tooltip = `Connected${pathPrefix ? " to " + pathPrefix : ""} as ${username}`;
       if (method === "HEAD") {
         authRequestMap.delete(target);
         return this.cookies;

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -15,7 +15,7 @@ type ServerAction = { detail: string; id: string; label: string };
 export async function serverActions(): Promise<void> {
   const { apiTarget, configName: workspaceFolder } = connectionTarget();
   const api = new AtelierAPI(apiTarget);
-  const { active, host = "", ns = "", https, port = 0, username, password, docker } = api.config;
+  const { active, host = "", ns = "", https, port = 0, pathPrefix, username, password, docker } = api.config;
   const explorerCount = (await explorerProvider.getChildren()).length;
   if (!explorerCount && (!docker || host === "")) {
     await vscode.commands.executeCommand("ObjectScriptExplorer.focus");
@@ -71,7 +71,7 @@ export async function serverActions(): Promise<void> {
   const classname = file && file.name.toLowerCase().endsWith(".cls") ? file.name.slice(0, -4) : "";
   const classnameEncoded = encodeURIComponent(classname);
   const connInfo = `${host}:${port}[${nsEncoded}]`;
-  const serverUrl = `${https ? "https" : "http"}://${host}:${port}`;
+  const serverUrl = `${https ? "https" : "http"}://${host}:${port}${pathPrefix}`;
   const portalUrl = `${serverUrl}/csp/sys/UtilHome.csp?$NAMESPACE=${nsEncoded}`;
   const classRef = `${serverUrl}/csp/documatic/%25CSP.Documatic.cls?LIBRARY=${nsEncoded}${
     classname ? "&CLASSNAME=" + classnameEncoded : ""

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -199,7 +199,7 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
     _onDidChangeConnection.fire();
   }
   let api = new AtelierAPI(apiTarget, false);
-  const { active, host = "", port = 0, username, ns = "" } = api.config;
+  const { active, host = "", port = 0, pathPrefix, username, ns = "" } = api.config;
   vscode.commands.executeCommand("setContext", "vscode-objectscript.connectActive", active);
   if (!panel.text) {
     panel.text = `${PANEL_LABEL}`;
@@ -268,7 +268,7 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
     .serverInfo()
     .then((info) => {
       panel.text = api.connInfo;
-      panel.tooltip = `Connected as ${username}`;
+      panel.tooltip = `Connected${pathPrefix ? " to " + pathPrefix : ""} as ${username}`;
       const hasHS = info.result.content.features.find((el) => el.name === "HEALTHSHARE" && el.enabled) !== undefined;
       reporter &&
         reporter.sendTelemetryEvent("connected", {


### PR DESCRIPTION
This PR fixes #510

It also adds pathPrefix info to the "Connected as" tooltip of the status bar panel when pathPrefix is set.