### PR TITLE
fix docker port lookup command for Windows

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -289,7 +289,7 @@ export async function portFromDockerCompose(): Promise<{ port: number; docker: b
   const cmd = `docker-compose -f ${file} ${envFileParam} `;
 
   return new Promise((resolve, reject) => {
-    exec(`${cmd} ps --services --filter 'status=running'`, { cwd }, (error, stdout) => {
+    exec(`${cmd} ps --services --filter status=running`, { cwd }, (error, stdout) => {
       if (error) {
         reject(error.message);
       }


### PR DESCRIPTION
This PR fixes #516 

Windows shell (cmd.exe) does not handle single quotes so the call to `exec` to lookup docker port fails. Works as expected after removing the quotes.
