### PR TITLE
Enable "View other" for custom Studio documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
         },
         {
           "command": "vscode-objectscript.viewOthers",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "vscode-objectscript.connectActive"
         },
         {
           "command": "vscode-objectscript.subclass",
@@ -274,7 +274,7 @@
       "editor/context": [
         {
           "command": "vscode-objectscript.viewOthers",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "vscode-objectscript.connectActive",
           "group": "objectscript@1"
         },
         {
@@ -319,7 +319,7 @@
         {
           "command": "vscode-objectscript.touchBar.viewOthers",
           "group": "objectscript.viewOthers",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "vscode-objectscript.connectActive"
         }
       ],
       "explorer/context": [

--- a/snippets/objectscript-class.json
+++ b/snippets/objectscript-class.json
@@ -78,6 +78,7 @@
     "body": [
       "XData $1",
       "{",
+      "$0",
       "}"
     ],
     "description": "XData"

--- a/snippets/objectscript-class.json
+++ b/snippets/objectscript-class.json
@@ -19,6 +19,10 @@
     "prefix": "Property",
     "body": "Property $1 As ${2:%String};"
   },
+  "Projection": {
+    "prefix": "Projection",
+    "body": "Projection $1 As $2;"
+  },
   "Unique Property": {
 	"prefix": ["Unique", "Property"],
 	"body": ["Property $1 As ${2:%String};", "", "Index $1Index On $1 [Unique];"]
@@ -26,7 +30,7 @@
   "Always-Computed Property": {
 	"prefix": ["Computed", "Property"],
 	"body" : ["Property $1 As ${2:%String} [Calculated, SqlComputed, SqlComputeCode =", "{set {$1} = {$3}}];"]
-  },	
+  },
   "Date/Time Property": {
 	"prefix": ["Date", "Time", "Property"],
 	"body" : ["Property $1 as ${2|%Date,%Time|}(MINVAL = $3, MAXVAL = $4);"]
@@ -68,6 +72,15 @@
     "prefix": ["Relationship"],
     "body": "Relationship $1 As ${2:classname} [ Cardinality = ${3|one,many,parent,children|}, Inverse = ${4:correspondingProperty} ];",
     "description": "Relationship"
+  },
+  "XData": {
+    "prefix": "XData",
+    "body": [
+      "XData $1",
+      "{",
+      "}"
+    ],
+    "description": "XData"
   },
   "BusinessService": {
 		"prefix": ["BusinessService","Interoperability","ClassService"],


### PR DESCRIPTION
"View other" should work not just for COS classes/routines. Custom Studio documents could be XML or in some other format and have output from "View other". Hence, when in a folder in a workspace that has the ObjectScript extension enabled, whatever document is in context should allow you to use "View other" because it is not possible to predict all possible formats of custom Studio documents.