### PR TITLE
Fix leading / issue that prevents custom Studio documents from being saved on the server

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -100,6 +100,13 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
     }
   } else {
     name = fileName;
+    // Need to strip leading / for custom Studio documents which should not be treated as files.
+    // e.g. For a custom Studio document Test.ZPM, the variable name would be /Test.ZPM which is
+    // not the document name. The document name is Test.ZPM so requests made to the Atelier APIs
+    // using the name with the leading / would fail to find the document.
+    if (name.charAt(0) === "/") {
+      name = name.substr(1);
+    }
   }
   if (!name) {
     return null;


### PR DESCRIPTION
Custom Studio documents will never have / in their name (which is only applicable to CSP files). Hence, if the "name" variable in currentFile() has a leading /, it should be stripped so that the document name is passed correctly to the Atelier API when updating on the document on the server.