### PR TITLE
implement isfs://server:namespace/ alternative syntax (#450)

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -100,10 +100,16 @@ export class AtelierAPI {
       if (wsOrFile instanceof vscode.Uri) {
         if (schemas.includes(wsOrFile.scheme)) {
           workspaceFolderName = wsOrFile.authority;
-          const { query } = url.parse(decodeURIComponent(wsOrFile.toString()), true);
-          if (query) {
-            if (query.ns && query.ns !== "") {
-              namespace = query.ns.toString();
+          const parts = workspaceFolderName.split(":");
+          if (parts.length === 2 && config("intersystems.servers").has(parts[0].toLowerCase())) {
+            workspaceFolderName = parts[0];
+            namespace = parts[1];
+          } else {
+            const { query } = url.parse(wsOrFile.toString(true), true);
+            if (query) {
+              if (query.ns && query.ns !== "") {
+                namespace = query.ns.toString();
+              }
             }
           }
         }

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -108,7 +108,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
 
   public provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): vscode.ProviderResult<string> {
     const api = new AtelierAPI(uri);
-    const query = url.parse(decodeURIComponent(uri.toString()), true).query;
+    const query = url.parse(uri.toString(true), true).query;
     const fileName = query && query.csp ? uri.path.substring(1) : uri.path.split("/").slice(1).join(".");
     if (query) {
       if (query.ns && query.ns !== "") {

--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -47,7 +47,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       return;
     }
     const sql = `CALL %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?)`;
-    const { query } = url.parse(decodeURIComponent(uri.toString()), true);
+    const { query } = url.parse(uri.toString(true), true);
     const type = query.type && query.type != "" ? query.type.toString() : "all";
     const csp = query.csp === "" || query.csp === "1";
     let filter = "";
@@ -181,7 +181,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     if (uri.path.startsWith("/.")) {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
     }
-    const { query } = url.parse(decodeURIComponent(uri.toString()), true);
+    const { query } = url.parse(uri.toString(true), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
     if (fileName.startsWith(".")) {
@@ -244,7 +244,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public delete(uri: vscode.Uri, options: { recursive: boolean }): void | Thenable<void> {
-    const { query } = url.parse(decodeURIComponent(uri.toString()), true);
+    const { query } = url.parse(uri.toString(true), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
     if (fileName.startsWith(".")) {
@@ -330,7 +330,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
     }
 
-    const { query } = url.parse(decodeURIComponent(uri.toString()), true);
+    const { query } = url.parse(uri.toString(true), true);
     const csp = query.csp === "" || query.csp === "1";
     const fileName = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
     const name = path.basename(uri.path);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -81,7 +81,7 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
   const content = document.getText();
   let name = "";
   let ext = "";
-  const { query } = url.parse(decodeURIComponent(uri.toString()), true);
+  const { query } = url.parse(uri.toString(true), true);
   const csp = query.csp === "" || query.csp === "1";
   if (csp) {
     name = uri.path;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -167,7 +167,8 @@ export function connectionTarget(uri?: vscode.Uri): ConnectionTarget {
       }
     } else if (schemas.includes(uri.scheme)) {
       result.apiTarget = uri;
-      result.configName = uri.authority;
+      const parts = uri.authority.split(":");
+      result.configName = parts.length === 2 ? parts[0] : uri.authority;
     }
   }
 
@@ -178,7 +179,8 @@ export function connectionTarget(uri?: vscode.Uri): ConnectionTarget {
         ? vscode.workspace.workspaceFolders[0]
         : undefined;
     if (firstFolder && schemas.includes(firstFolder.uri.scheme)) {
-      result.configName = firstFolder.uri.authority;
+      const parts = firstFolder.uri.authority.split(":");
+      result.configName = parts.length === 2 ? parts[0] : firstFolder.uri.authority;
       result.apiTarget = firstFolder.uri;
     } else {
       result.configName = workspaceState.get<string>("workspaceFolder") || firstFolder ? firstFolder.name : "";


### PR DESCRIPTION
This PR implements #450 

isfs workspace root uris can now specify the namespace as a colon-separated suffix on the server name instead of adding the ?ns=XYZ queryparam.

Example of a .code-workspace file that demonstrates the new syntax alongside the old:
```
{
	"folders": [
		{
			"name": "iris201:USER",
			"uri": "isfs://iris201/?ns=USER"
		},
		{
			"name": "iris201:USER new style",
			"uri": "isfs://iris201:USER/"
		},
		{
			"name": "iris201:USER new style - webfiles",
			"uri": "isfs://iris201:USER/?csp"
		},
		{
			"name": "iris201:%SYS",
			"uri": "isfs://iris201/?ns=%SYS"
		},
		{
			"name": "iris201:%SYS new style",
			"uri": "isfs://iris201:%SYS/"
		}
	]
}
```