### PR TITLE
fix #552 load server-side code snippets from isfs workspace roots

### DIFF
--- a/src/providers/FileSystemPovider/FileSystemProvider.ts
+++ b/src/providers/FileSystemPovider/FileSystemProvider.ts
@@ -41,6 +41,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
+    uri = redirectDotvscodeRoot(uri);
     const parent = await this._lookupAsDirectory(uri);
     const api = new AtelierAPI(uri);
     if (!api.active) {
@@ -129,6 +130,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public createDirectory(uri: vscode.Uri): void | Thenable<void> {
+    uri = redirectDotvscodeRoot(uri);
     const basename = path.posix.basename(uri.path);
     const dirname = uri.with({ path: path.posix.dirname(uri.path) });
     return this._lookupAsDirectory(dirname).then((parent) => {
@@ -376,6 +378,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   private async _lookupParentDirectory(uri: vscode.Uri): Promise<Directory> {
+    uri = redirectDotvscodeRoot(uri);
     const dirname = uri.with({ path: path.posix.dirname(uri.path) });
     return await this._lookupAsDirectory(dirname);
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -355,6 +355,7 @@ export async function terminalWithDocker(): Promise<vscode.Terminal> {
  *  Also alter query to specify `ns=%SYS&csp=1`
  * Also handles the alternative syntax isfs://server:namespace/
  *  in which there is no ns queryparam
+ * For both syntaxes the namespace folder name is uppercased
  *
  * @returns uri, altered if necessary.
  * @throws if `ns` queryparam is missing but required.
@@ -368,17 +369,17 @@ export function redirectDotvscodeRoot(uri: vscode.Uri): vscode.Uri {
     let namespace: string;
     const nsMatch = `&${uri.query}&`.match(/&ns=([^&]+)&/);
     if (nsMatch) {
-      namespace = nsMatch[1];
-      const newQueryString = (("&" + uri.query).replace(`ns=${namespace}`, "ns=%SYS") + "&csp=1").slice(1);
+      namespace = nsMatch[1].toUpperCase();
+      const newQueryString = (("&" + uri.query).replace(`ns=${namespace}`, "ns=%SYS") + "&csp").slice(1);
       return uri.with({ path: `/_vscode/${namespace}${dotMatch[2] || ""}`, query: newQueryString });
     } else {
       const parts = uri.authority.split(":");
       if (parts.length === 2) {
-        namespace = parts[1];
+        namespace = parts[1].toUpperCase();
         return uri.with({
           authority: `${parts[0]}:%SYS`,
           path: `/_vscode/${namespace}${dotMatch[2] || ""}`,
-          query: uri.query + "&csp=1",
+          query: uri.query + "&csp",
         });
       }
     }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -363,21 +363,21 @@ export function redirectDotvscodeRoot(uri: vscode.Uri): vscode.Uri {
   if (!schemas.includes(uri.scheme)) {
     return uri;
   }
-  const dotMatch = uri.path.match(/^\/(\.[^/]*)\/(.*)$/);
+  const dotMatch = uri.path.match(/^\/(\.[^/]*)(\/.*)?$/);
   if (dotMatch && dotMatch[1] === ".vscode") {
     let namespace: string;
     const nsMatch = `&${uri.query}&`.match(/&ns=([^&]+)&/);
     if (nsMatch) {
       namespace = nsMatch[1];
       const newQueryString = (("&" + uri.query).replace(`ns=${namespace}`, "ns=%SYS") + "&csp=1").slice(1);
-      return uri.with({ path: `/_vscode/${namespace}/${dotMatch[2]}`, query: newQueryString });
+      return uri.with({ path: `/_vscode/${namespace}${dotMatch[2] || ""}`, query: newQueryString });
     } else {
       const parts = uri.authority.split(":");
       if (parts.length === 2) {
         namespace = parts[1];
         return uri.with({
           authority: `${parts[0]}:%SYS`,
-          path: `/_vscode/${namespace}/${dotMatch[2]}`,
+          path: `/_vscode/${namespace}${dotMatch[2] || ""}`,
           query: uri.query + "&csp=1",
         });
       }


### PR DESCRIPTION
This PR fixes #552

See PR #384 for how to enable server-side storage for settings, snippets etc within isfs workspace roots. All *.code-snippets files in the corresponding server-side directory will now get loaded.

A convenient way to create such a file is to run the `Preferences: Configure User Snippets` command when the workspace is open, then pick `New Snippets file for 'XYZ'` where `XYZ` is the isfs folder name you want to store the file under.

In a multiroot workspace snippets from every isfs-type root are available to the whole workspace. This is standard VS Code behaviour.