### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ For more about `isfs` and `isfs-readonly` folder specifications see the [Notes](
 
 - The `/api/atelier/` web application used by this extension usually requires the authenticated user to have Use permission on the %Development resource ([read more](https://community.intersystems.com/post/using-atelier-rest-api)). One way is to assign the %Developer role to the user.
 
-- If you are getting `ERROR # 5540: SQLCODE: -99 Message: User xxx is not privileged for the operation` when you try to get or refresh class/routine/include-  lists, grant your username (or a SQL role you hold) execute permission for the following SQL Procedure in the target namespace.
+- If you are getting `ERROR # 5540: SQLCODE: -99 Message: User xxx is not privileged for the operation` when you try to get or refresh lists of classes, routines or includes, then grant user xxx (or a SQL role they hold) Execute permission for the following SQL Procedure in the target namespace.
 
 ```SQL
 GRANT EXECUTE ON %Library.RoutineMgr_StudioOpenDialog TO xxx

--- a/README.md
+++ b/README.md
@@ -110,12 +110,14 @@ For more about `isfs` and `isfs-readonly` folder specifications see the [Notes](
 
 - Connection-related output appears in the "Output" view while switched to the "ObjectScript" channel using the drop-down menu on the view titlebar.
 
-- For Caché/IRIS instance with maximum security level, add `%Development` role for `/api/atelier/` web-application ([read more](https://community.intersystems.com/post/using-atelier-rest-api)).
+- The `/api/atelier/` web application used by this extension usually requires the authenticated user to have Use permission on the %Development resource ([read more](https://community.intersystems.com/post/using-atelier-rest-api)). One way is to assign the %Developer role to the user.
 
 - If you are getting `ERROR # 5540: SQLCODE: -99 Message: User xxx is not privileged for the operation` when you try to get or refresh class/routine/include-  lists, grant your username (or a SQL role you hold) execute permission for the following SQL Procedure in the target namespace.
+
 ```SQL
 GRANT EXECUTE ON %Library.RoutineMgr_StudioOpenDialog TO xxx
 ```
+
 ### More about `intersystems.servers`
 This settings object is useful for both client-side and server-side development.
 - An example server definition named 'local':


### PR DESCRIPTION
- Clarify and correct advice about security requirement of `/api/atelier` web app.
- Improve note about SQL GRANT.
- Fix bad indent of "More about `intersystems.servers`" header when displayed in the Extensions view of VS Code.