### PR TITLE
fix #586 handle reference to nonexistent server spec

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -168,7 +168,7 @@ export class AtelierAPI {
     let serverName = workspaceFolderName.toLowerCase();
     if (config("intersystems.servers").has(serverName)) {
       this.externalServer = true;
-    } else if (conn.server) {
+    } else if (conn.server && config("intersystems.servers", workspaceFolderName).has(conn.server)) {
       serverName = conn.server;
     } else {
       serverName = "";
@@ -203,7 +203,7 @@ export class AtelierAPI {
     } else {
       this._config = conn;
       this._config.ns = namespace || conn.ns;
-      this._config.serverName = serverName;
+      this._config.serverName = "";
     }
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -262,6 +262,7 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
     outputChannel.appendError(message);
     panel.text = `${PANEL_LABEL} $(error)`;
     panel.tooltip = `ERROR - ${message}`;
+    disableConnection(configName);
     return;
   }
   api


### PR DESCRIPTION
This PR fixes #586

If the `server` property of `objectscript.conn` names a server that doesn't exist in `intersystems.servers` the ObjectScript Explorer was empty and its Refresh button produced an error.