### PR TITLE
fix #581 constrain QuickOpen results to isfs path if set

### DIFF
--- a/src/providers/FileSystemPovider/FileSearchProvider.ts
+++ b/src/providers/FileSystemPovider/FileSearchProvider.ts
@@ -17,13 +17,20 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     const category = `&${options.folder.query}&`.includes("&csp&") ? "CSP" : "*";
     const generated = `&${options.folder.query}&`.includes("&generated=1&");
     const api = new AtelierAPI(options.folder);
+    let filter = query.pattern;
+    if (category !== "CSP") {
+      if (options.folder.path !== "/") {
+        filter = options.folder.path.slice(1) + "/%" + filter;
+      }
+      filter = filter.replace("/", ".");
+    }
     let counter = 0;
     if (!api.enabled) {
       return null;
     }
     return api
       .getDocNames({
-        filter: query.pattern,
+        filter,
         category,
         generated,
       })

--- a/src/providers/FileSystemPovider/FileSearchProvider.ts
+++ b/src/providers/FileSystemPovider/FileSearchProvider.ts
@@ -22,7 +22,7 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
       if (options.folder.path !== "/") {
         filter = options.folder.path.slice(1) + "/%" + filter;
       }
-      filter = filter.replace("/", ".");
+      filter = filter.replace(/\//g, ".");
     }
     let counter = 0;
     if (!api.enabled) {


### PR DESCRIPTION
This PR fixes #581

Prior to this change, if a workspace's isfs folder specified a path then the QuickOpen (Ctrl+p) results were not limited to that path.

For example, QuickOpen on a workspace referencing `isfs://local:samples/Cinema` would incorrectly include matches outside the Cinema package.

We now also respect `?type=cls` or `?type=rtn` parameters, and avoid collapsing foo.bar.1.int completely (foo/bar/1.int) but instead behave as Explorer does (foo/bar.1.int)

We do not apply any `filter=XYZ` parameter because the docnames endpoint of the Atelier API doesn't support doing this server-side.