### PR TITLE
Fix debugging breakpoint command message when class has multiple packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 *.vsix
 vscode*.d.ts
 test-fixtures
+.DS_Store

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -46,7 +46,7 @@ async function convertClientPathToDebugger(uri: vscode.Uri, namespace: string): 
     if (query.ns && query.ns !== "") {
       namespace = query.ns.toString();
     }
-    fileName = path.slice(1).replace(/\//, ".");
+    fileName = path.slice(1).replace(/\//g, ".");
   } else {
     fileName = await vscode.workspace
       .openTextDocument(uri)


### PR DESCRIPTION
Currently, when the debugger sends a breakpoint command to the server for a class file that has multiple packages, the file URI gets generated incorrectly. The `convertClientPathToDebugger()` method doesn't convert all "/" in the isfs URI to ".", which causes the URI to be formatted in a way that the server doesn't understand. For example, here's the log of a `breakpoint_set` command that fails:

```
^IRIS.Temp.Atelier("debug",89842,1,23)="Received:breakpoint_set -i 7 -t line -s enabled -f dbgp://|USER|User.test%2Ftest.cls -m tst -n 2"
^IRIS.Temp.Atelier("debug",89842,1,24)="Calling state breakpoint_set"
^IRIS.Temp.Atelier("debug",89842,1,25)="mapping: USER:User.test/test.cls:tst:2 -> :-1"
^IRIS.Temp.Atelier("debug",89842,1,26)="Event:error|<response command='breakpoint_set' transaction_id='7'><error code='201'><message>Breakpoint Cannot Be Mapped</message></error></response>"
```
After adding the global flag to the regular expression in `convertClientPathToDebugger()`, the class name is formatted correctly and the breakpoint can be set:
```
^IRIS.Temp.Atelier("debug",91831,1,23)="Received:breakpoint_set -i 7 -t line -s enabled -f dbgp://|USER|User.test.test.cls -m tst -n 2"
^IRIS.Temp.Atelier("debug",91831,1,24)="Calling state breakpoint_set"
^IRIS.Temp.Atelier("debug",91831,1,25)="mapping: USER:User.test.test.cls:tst:2 -> User.test.test.1:7"
^IRIS.Temp.Atelier("debug",91831,1,26)="Setting BP"
^IRIS.Temp.Atelier("debug",91831,1,27)="IsStopped"
^IRIS.Temp.Atelier("debug",91831,1,28)="Location zDebugStub+37:%Debugger.System.1:255:1:255:0:0:255:1:255:0:0:USER"
^IRIS.Temp.Atelier("debug",91831,1,29)="Stack 3^zDebugStub+37^%Debugger.System.1"
^IRIS.Temp.Atelier("debug",91831,1,30)="BP enabled:User.test.test.1(7)::0"
^IRIS.Temp.Atelier("debug",91831,1,31)="Event:breakpoint_set|<response command='breakpoint_set' transaction_id='7' state='enabled' id='1'/>"
```