### PR TITLE
Capture children of eval command property response if they exist

### DIFF
--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -548,8 +548,8 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       let variablesReference: number;
       // if the property has children, generate a variable ID and save the property (including children) so VS Code can request them
       if (result.hasChildren || result.type === "array" || result.type === "object") {
-        // variablesReference = this._variableIdCounter++;
-        // this._evalResultProperties.set(variablesReference, result);
+        variablesReference = this._variableIdCounter++;
+        this._evalResultProperties.set(variablesReference, result);
       } else {
         variablesReference = 0;
       }


### PR DESCRIPTION
We're considering adding support for drilling down into OREF's during debugging in the Atelier debugger so we'll need this code back into effect to get the most of the server enhancements.