### PR TITLE
fix #599 use `contributes/resourceLabelFormatters` instead of proposed API

### DIFF
--- a/package.json
+++ b/package.json
@@ -994,6 +994,32 @@
           }
         ]
       }
+    ],
+    "resourceLabelFormatters": [
+      {
+        "scheme": "isfs",
+        "authority": "*",
+        "formatting": {
+          "label": "${authority}:${path}",
+          "separator": "/"
+        }
+      },
+      {
+        "scheme": "isfs-readonly",
+        "authority": "*",
+        "formatting": {
+          "label": "${authority}:${path}",
+          "separator": "/"
+        }
+      },
+      {
+        "scheme": "objectscript",
+        "authority": "*",
+        "formatting": {
+          "label": "${path} (read-only)",
+          "separator": "/"
+        }
+      }
     ]
   },
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -580,33 +580,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     packageJson.enableProposedApi && typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_READONLY_SCHEMA, new TextSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerResourceLabelFormatter === "function"
-      ? vscode.workspace.registerResourceLabelFormatter({
-          scheme: FILESYSTEM_SCHEMA,
-          formatting: {
-            label: "${authority}:${path}",
-            separator: "/",
-          },
-        })
-      : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerResourceLabelFormatter === "function"
-      ? vscode.workspace.registerResourceLabelFormatter({
-          scheme: FILESYSTEM_READONLY_SCHEMA,
-          formatting: {
-            label: "${authority}:${path}",
-            separator: "/",
-          },
-        })
-      : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerResourceLabelFormatter === "function"
-      ? vscode.workspace.registerResourceLabelFormatter({
-          scheme: OBJECTSCRIPT_FILE_SCHEMA,
-          formatting: {
-            label: "${path} (read-only)",
-            separator: "/",
-          },
-        })
-      : null,
   ].filter(notNull);
 
   if (proposed.length > 0) {


### PR DESCRIPTION
This PR fixes #599

Previous fix for #455 used a proposed API (`workspace.registerResourceLabelFormatter`) and so was only available to users prepared to run from a beta VSIX with the necessary runtime argument.

This PR reimplements the same feature using the `contributes/resourceLabelFormatters` contribution point.