### PR TITLE
Improve client-side CSP workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,7 @@
       "view/item/context": [
         {
           "command": "vscode-objectscript.explorer.export",
-          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:(?!(cspApplication|cspFileNode))/"
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^dataNode:/"
         },
         {
           "command": "vscode-objectscript.explorer.export",
@@ -385,7 +385,8 @@
           "ObjectScript CSP"
         ],
         "extensions": [
-          "csp"
+          ".csp",
+          ".csr"
         ]
       },
       {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -318,11 +318,11 @@ export async function importFolder(uri: vscode.Uri, noCompile = false): Promise<
   if (fs.lstatSync(uripath).isFile()) {
     return importFiles([uripath], noCompile);
   }
-  var globpattern = "*.{cls,inc,int,mac}";
+  let globpattern = "*.{cls,inc,int,mac}";
   const workspace = currentWorkspaceFolder();
   const workspacePath = workspaceFolderUri(workspace).fsPath;
   const { folder } = config("export", workspace);
-  const folderPathNoWorkspaceArr = uripath.replace(workspacePath+path.sep,'').split(path.sep);
+  const folderPathNoWorkspaceArr = uripath.replace(workspacePath + path.sep, "").split(path.sep);
   if (folderPathNoWorkspaceArr[0] === folder) {
     // This folder is in the export tree, so import all files
     // We need to include eveything becuase CSP applications can

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -321,10 +321,9 @@ export async function importFolder(uri: vscode.Uri, noCompile = false): Promise<
   let globpattern = "*.{cls,inc,int,mac}";
   const workspace = currentWorkspaceFolder();
   const workspacePath = workspaceFolderUri(workspace).fsPath;
-  const { folder } = config("export", workspace);
   const folderPathNoWorkspaceArr = uripath.replace(workspacePath + path.sep, "").split(path.sep);
-  if (folderPathNoWorkspaceArr[0] === folder) {
-    // This folder is in the export tree, so import all files
+  if (folderPathNoWorkspaceArr.includes("csp")) {
+    // This folder is a CSP application, so import all files
     // We need to include eveything becuase CSP applications can
     // include non-InterSystems files
     globpattern = "*";

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -50,8 +50,7 @@ export const getFileName = (
     const nameArr: string[] = name.split("/");
     const cat = addCategory ? getCategory(name, addCategory) : null;
     return [folder, cat, ...nameArr].filter(notNull).join(path.sep);
-  }
-  else {
+  } else {
     // This is a class, routine or include file
     if (map) {
       for (const pattern of Object.keys(map)) {
@@ -134,23 +133,18 @@ export async function exportFile(
             if (Buffer.isBuffer(content)) {
               // This is a binary file
               let isSkipped = "";
-              
               if (dontExportIfNoChanges && fs.existsSync(fileName)) {
                 const existingContent = fs.readFileSync(fileName);
                 if (content.equals(existingContent)) {
                   fs.writeFileSync(fileName, content);
-                }
-                else {
+                } else {
                   isSkipped = " => skipped - no changes.";
                 }
-              }
-              else {
+              } else {
                 fs.writeFileSync(fileName, content);
               }
-
               log(`Success ${isSkipped}`);
-            }
-            else {
+            } else {
               // This is a text file
               let joinedContent = content.join("\n");
               let isSkipped = "";

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -13,7 +13,7 @@ const filesFilter = (file: any) => {
   return true;
 };
 
-const getCategory = (fileName: string, addCategory: any | boolean): string => {
+export const getCategory = (fileName: string, addCategory: any | boolean): string => {
   const fileExt = fileName.split(".").pop().toLowerCase();
   if (typeof addCategory === "object") {
     for (const pattern of Object.keys(addCategory)) {
@@ -45,22 +45,31 @@ export const getFileName = (
     [key: string]: string;
   }
 ): string => {
-  if (map) {
-    for (const pattern of Object.keys(map)) {
-      if (new RegExp(`^${pattern}$`).test(name)) {
-        name = name.replace(new RegExp(`^${pattern}$`), map[pattern]);
-        break;
+  if (name.includes("/")) {
+    // This is a file from a web application
+    const nameArr: string[] = name.split("/");
+    const cat = addCategory ? getCategory(name, addCategory) : null;
+    return [folder, cat, ...nameArr].filter(notNull).join(path.sep);
+  }
+  else {
+    // This is a class, routine or include file
+    if (map) {
+      for (const pattern of Object.keys(map)) {
+        if (new RegExp(`^${pattern}$`).test(name)) {
+          name = name.replace(new RegExp(`^${pattern}$`), map[pattern]);
+          break;
+        }
       }
     }
+    const fileNameArray: string[] = name.split(".");
+    const fileExt = fileNameArray.pop().toLowerCase();
+    const cat = addCategory ? getCategory(name, addCategory) : null;
+    if (split) {
+      const fileName = [folder, cat, ...fileNameArray].filter(notNull).join(path.sep);
+      return [fileName, fileExt].join(".");
+    }
+    return [folder, cat, name].filter(notNull).join(path.sep);
   }
-  const fileNameArray: string[] = name.split(".");
-  const fileExt = fileNameArray.pop().toLowerCase();
-  const cat = addCategory ? getCategory(name, addCategory) : null;
-  if (split) {
-    const fileName = [folder, cat, ...fileNameArray].filter(notNull).join(path.sep);
-    return [fileName, fileExt].join(".");
-  }
-  return [folder, cat, name].filter(notNull).join(path.sep);
 };
 
 export const getFolderName = (folder: string, name: string, split: boolean, cat: string = null): string => {
@@ -122,26 +131,48 @@ export async function exportFile(
 
         return promise
           .then((res: any) => {
-            let joinedContent = content instanceof Buffer ? content.toString("utf-8") : (content || []).join("\n");
-            let isSkipped = "";
-
-            if (res.found) {
-              joinedContent = res.content.toString("utf8");
-            }
-
-            if (dontExportIfNoChanges && fs.existsSync(fileName)) {
-              const existingContent = fs.readFileSync(fileName, "utf8");
-              // stringify to harmonise the text encoding.
-              if (JSON.stringify(joinedContent) !== JSON.stringify(existingContent)) {
-                fs.writeFileSync(fileName, joinedContent);
-              } else {
-                isSkipped = " => skipped - no changes.";
+            if (Buffer.isBuffer(content)) {
+              // This is a binary file
+              let isSkipped = "";
+              
+              if (dontExportIfNoChanges && fs.existsSync(fileName)) {
+                const existingContent = fs.readFileSync(fileName);
+                if (content.equals(existingContent)) {
+                  fs.writeFileSync(fileName, content);
+                }
+                else {
+                  isSkipped = " => skipped - no changes.";
+                }
               }
-            } else {
-              fs.writeFileSync(fileName, joinedContent);
-            }
+              else {
+                fs.writeFileSync(fileName, content);
+              }
 
-            log(`Success ${isSkipped}`);
+              log(`Success ${isSkipped}`);
+            }
+            else {
+              // This is a text file
+              let joinedContent = content.join("\n");
+              let isSkipped = "";
+
+              if (res.found) {
+                joinedContent = res.content.toString("utf8");
+              }
+
+              if (dontExportIfNoChanges && fs.existsSync(fileName)) {
+                const existingContent = fs.readFileSync(fileName, "utf8");
+                // stringify to harmonise the text encoding.
+                if (JSON.stringify(joinedContent) !== JSON.stringify(existingContent)) {
+                  fs.writeFileSync(fileName, joinedContent);
+                } else {
+                  isSkipped = " => skipped - no changes.";
+                }
+              } else {
+                fs.writeFileSync(fileName, joinedContent);
+              }
+
+              log(`Success ${isSkipped}`);
+            }
           })
           .catch((error) => {
             throw error;

--- a/src/explorer/models/rootNode.ts
+++ b/src/explorer/models/rootNode.ts
@@ -155,7 +155,8 @@ export class RootNode extends NodeBase {
   }
 
   public getItems4Export(): Promise<string[]> {
-    const path = this instanceof PackageNode ? this.fullName + "/" : "";
-    return this.getList(path, "ALL", true).then((data) => data.map((el) => el.Name));
+    const path = this instanceof PackageNode || this.isCsp ? this.fullName + "/" : "";
+    const cat = this.isCsp ? "CSP" : "ALL";
+    return this.getList(path, cat, true).then((data) => data.map((el) => el.Name));
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,7 @@ import {
   notNull,
   currentFile,
   InputBoxManager,
+  isImportableLocalFile
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentRangeFormattingEditProvider } from "./providers/DocumentRangeFormattingEditProvider";
@@ -520,6 +521,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     if (schemas.includes(file.uri.scheme) || languages.includes(file.languageId)) {
       if (documentBeingProcessed !== file) {
         return importAndCompile(false, file);
+      }
+    }
+    else if (file.uri.scheme === "file") {
+      if (isImportableLocalFile(file)) {
+        // This local file is in the exported file tree, so it's a non-InterSystems file that's 
+        // part of a CSP application, so import it on save
+        return importFileOrFolder(file.uri, true);
       }
     }
   });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,7 +75,7 @@ import {
   notNull,
   currentFile,
   InputBoxManager,
-  isImportableLocalFile
+  isImportableLocalFile,
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentRangeFormattingEditProvider } from "./providers/DocumentRangeFormattingEditProvider";
@@ -522,10 +522,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       if (documentBeingProcessed !== file) {
         return importAndCompile(false, file);
       }
-    }
-    else if (file.uri.scheme === "file") {
+    } else if (file.uri.scheme === "file") {
       if (isImportableLocalFile(file)) {
-        // This local file is in the exported file tree, so it's a non-InterSystems file that's 
+        // This local file is in the exported file tree, so it's a non-InterSystems file that's
         // part of a CSP application, so import it on save
         return importFileOrFolder(file.uri, true);
       }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -62,16 +62,16 @@ export interface ConnectionTarget {
  * @param workspace The workspace the file is in.
  */
 function getServerDocName(localPath: string, workspace: string): string {
-  var result = localPath;
+  let result = localPath;
   const workspacePath = workspaceFolderUri(workspace).fsPath;
-  result = result.replace(workspacePath+path.sep,'');
+  result = result.replace(workspacePath + path.sep, "");
   const { folder, addCategory } = config("export", workspace);
-  result = result.replace(folder+path.sep,'');
+  result = result.replace(folder + path.sep, "");
   const cat = addCategory ? getCategory(localPath, addCategory) : null;
   if (cat !== null) {
-    result = result.replace(cat+path.sep,'');
+    result = result.replace(cat + path.sep, "");
   }
-  return result.replace(path.sep,"/");
+  return result.replace(path.sep, "/");
 }
 
 /**
@@ -80,11 +80,11 @@ function getServerDocName(localPath: string, workspace: string): string {
  * @param file The file to check.
  */
 export function isImportableLocalFile(file: vscode.TextDocument): boolean {
-  var result = false;
+  let result = false;
   const workspace = currentWorkspaceFolder(file);
   const workspacePath = workspaceFolderUri(workspace).fsPath;
   const { folder, addCategory } = config("export", workspace);
-  const filePathNoWorkspaceArr = file.fileName.replace(workspacePath+path.sep,'').split(path.sep);
+  const filePathNoWorkspaceArr = file.fileName.replace(workspacePath + path.sep, "").split(path.sep);
   const cat = addCategory ? getCategory(file.fileName, addCategory) : null;
   if (filePathNoWorkspaceArr[0] === folder) {
     if (cat === null || (cat !== null && filePathNoWorkspaceArr[1] === cat)) {
@@ -142,9 +142,8 @@ export function currentFile(document?: vscode.TextDocument): CurrentFile {
     }
   } else {
     if (document.uri.scheme === "file") {
-      name = getServerDocName(fileName,currentWorkspaceFolder(document));
-    }
-    else {
+      name = getServerDocName(fileName, currentWorkspaceFolder(document));
+    } else {
       name = fileName;
     }
     // Need to strip leading / for custom Studio documents which should not be treated as files.


### PR DESCRIPTION
This PR fixes #147 and fixes #449 

@daimor @gjsjohnmurray I will send the dev vsix for this PR to the InterSystems devs that requested it and will promote this from draft when I get their feedback.

Changes made:
- Enable exporting of CSP application files from ObjectScript Explorer
- Import non-InterSystems CSP application files upon save.
- Import individual web application text files from the file explorer using "Import ..." commands.
- Import all text files in exported web application folder using "Import ..." commands.
- Color .csr files

How to use:
- Open a workspace that contains web app files in a csp directory that matches the path on the server.
- Open a text file in your local copy of the web app files, edit it, and then save it. The file will be automatically synced to the server.
- Right-click on the web app directory, select "Import Without Compilation". All text files in the directory will be synced with the server.

**NOTE:** This only works with web apps that are of the format csp/*