### PR TITLE
Add configuration option to turn off post-save compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -913,6 +913,11 @@
           "description": "Automatically show terminal when connected to docker-compose.",
           "type": "boolean",
           "default": false
+        },
+        "objectscript.compileOnSave": {
+          "description": "Automatically compile an InterSystems file when saved in the editor.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -534,7 +534,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   workspace.onDidSaveTextDocument((file) => {
     if (schemas.includes(file.uri.scheme) || languages.includes(file.languageId)) {
       if (documentBeingProcessed !== file) {
-        return importAndCompile(false, file);
+        return importAndCompile(false, file, config("compileOnSave"));
       }
     }
   });


### PR DESCRIPTION
This PR fixes #594 

Adds the "objectscript.compileOnSave" boolean configuration option with default value `true`. When `false`, saving an InterSystems file will not automatically compile it.