### PR TITLE
Add commands for compiling current file

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,6 +206,14 @@
         {
           "command": "vscode-objectscript.jumpToTagAndOffset",
           "when": "editorLangId == objectscript"
+        },
+        {
+          "command": "vscode-objectscript.compileOnly",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.compileOnlyWithFlags",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         }
       ],
       "view/title": [
@@ -296,6 +304,11 @@
           "command": "vscode-objectscript.serverCommands.contextOther",
           "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive",
           "group": "objectscript@5"
+        },
+        {
+          "command": "vscode-objectscript.compileOnly",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "group": "objectscript@6"
         }
       ],
       "editor/title": [
@@ -614,6 +627,16 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.showExplorerForWorkspace",
         "title": "Show Explorer for Workspace"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.compileOnly",
+        "title": "Compile Current File"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.compileOnlyWithFlags",
+        "title": "Compile Current File with Specified Flags..."
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import {
   namespaceCompile,
   compileExplorerItem,
   checkChangedOnServer,
+  compileOnly,
 } from "./commands/compile";
 import { deleteItem } from "./commands/delete";
 import { exportAll, exportExplorerItem } from "./commands/export";
@@ -864,6 +865,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       new ObjectScriptClassCodeLensProvider()
     ),
     vscode.languages.registerDocumentLinkProvider({ language: "objectscript-output" }, new DocumentLinkProvider()),
+    vscode.commands.registerCommand("vscode-objectscript.compileOnly", () => compileOnly(false)),
+    vscode.commands.registerCommand("vscode-objectscript.compileOnlyWithFlags", () => compileOnly(true)),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed


### PR DESCRIPTION
This PR fixes #595 

Adds 2 new commands, `vscode-objectscript.compileOnly` and `vscode-objectscript.compileOnlyWithFlags`, which allow the user to compile the currently open InterSystems file without saving its contents. The compilation will be aborted an a warning message will be presented if the user tries to compile a dirty file.