### PR TITLE
Add configuration setting for multiline method arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -918,6 +918,11 @@
           "description": "Automatically compile an InterSystems file when saved in the editor.",
           "type": "boolean",
           "default": true
+        },
+        "objectscript.multilineMethodArgs": {
+          "markdownDescription": "List method arguments on multiple lines, if the server supports it. **NOTE:** Only supported on IRIS 2019.1.2, 2020.1.1+, 2021.1.0+ and subsequent versions! On all other versions, this setting will have no effect.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -426,13 +426,16 @@ export class AtelierAPI {
   // api v1+
   public getDoc(name: string, format?: string): Promise<Atelier.Response<Atelier.Document>> {
     let params = {};
+    if (!format && config("multilineMethodArgs") && this._config.apiVersion >= 4) {
+      format = "udl-multiline";
+    }
     if (format) {
       params = {
         format,
       };
     }
     name = this.transformNameIfCsp(name);
-    return this.request(1, "GET", `${this.ns}/doc/${name}`, params);
+    return this.request(1, "GET", `${this.ns}/doc/${name}`, null, params);
   }
 
   // api v1+


### PR DESCRIPTION
This PR fixes #457 

Adds the `objectscript.multilineMethodArgs` boolean configuration option with default value `false`. If set to `true` and the server's Atelier API version is 4 or greater, the `format=udl-multiline` query parameter will be passed to all calls to the [Atelier API GetDoc endpoint](https://docs.intersystems.com/irislatest/csp/docbook/Doc.View.cls?KEY=GSCF_ref#GSCF_ref_getdoc).

@daimor I'm marking this as a draft until I make some corresponding changes to the Language Server but I think this is ready to merge otherwise.