### PR TITLE
Rename the Output Channel Language

### DIFF
--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
         ]
       },
       {
-        "id": "objectscript-output",
+        "id": "vscode-objectscript-output",
         "mimetypes": [
           "text/x-code-output"
         ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -863,7 +863,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       documentSelector("objectscript-class"),
       new ObjectScriptClassCodeLensProvider()
     ),
-    vscode.languages.registerDocumentLinkProvider({ language: "objectscript-output" }, new DocumentLinkProvider()),
+    vscode.languages.registerDocumentLinkProvider(
+      { language: "vscode-objectscript-output" },
+      new DocumentLinkProvider()
+    ),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed


### PR DESCRIPTION
This PR fixes #634

When using the ObjectScript Explorer, REST requests are made to the doc endpoint trying to sync the output channel content with the server.
Renaming the output channel language as suggested in #634 stops the extra requests.