### PR TITLE
Improve putDoc() and viewOthers() error handling

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -94,11 +94,6 @@ async function importFile(file: CurrentFile, ignoreConflict?: boolean): Promise<
       checkChangedOnServer(file, true);
     })
     .catch((error) => {
-      if (error.statusCode == 400) {
-        outputChannel.appendLine(error.error.result.status);
-        vscode.window.showErrorMessage(error.error.result.status);
-        return Promise.reject();
-      }
       if (error.statusCode == 409) {
         return vscode.window
           .showErrorMessage(
@@ -140,9 +135,18 @@ What do you want to do?`,
             }
             return Promise.reject();
           });
+      } else {
+        if (error.errorText && error.errorText !== "") {
+          outputChannel.appendLine("\n" + error.errorText);
+          vscode.window.showErrorMessage(
+            `Failed to save file '${file.name}' on the server. Check output channel for details.`,
+            "Dismiss"
+          );
+        } else {
+          vscode.window.showErrorMessage(`Failed to save file '${file.name}' on the server.`, "Dismiss");
+        }
+        return Promise.reject();
       }
-      vscode.window.showErrorMessage(error.message);
-      return Promise.reject();
     });
 }
 

--- a/src/commands/viewOthers.ts
+++ b/src/commands/viewOthers.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { config } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
-import { currentFile } from "../utils";
+import { currentFile, outputChannel } from "../utils";
 
 export async function viewOthers(): Promise<void> {
   const file = currentFile();
@@ -145,6 +145,7 @@ export async function viewOthers(): Promise<void> {
     .then((info) => {
       const listOthers = getOthers(info) || [];
       if (!listOthers.length) {
+        vscode.window.showInformationMessage("There are no other documents to open.", "Dismiss");
         return;
       }
       if (listOthers.length === 1) {
@@ -155,5 +156,12 @@ export async function viewOthers(): Promise<void> {
         });
       }
     })
-    .catch((err) => console.error(err));
+    .catch((err) => {
+      if (err.errorText && err.errorText !== "") {
+        outputChannel.appendLine("\n" + err.errorText);
+        vscode.window.showErrorMessage(`Failed to get other documents. Check output channel for details.`, "Dismiss");
+      } else {
+        vscode.window.showErrorMessage(`Failed to get other documents.`, "Dismiss");
+      }
+    });
 }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -225,8 +225,8 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           )
           .catch((error) => {
             // Throw all failures
-            if (error.error?.result?.status) {
-              throw vscode.FileSystemError.Unavailable(error.error.result.status);
+            if (error.errorText && error.errorText !== "") {
+              throw vscode.FileSystemError.Unavailable(error.errorText);
             }
             throw vscode.FileSystemError.Unavailable(error.message);
           })


### PR DESCRIPTION
This PR fixes #391 

- Modifies `AtelierAPI.request()` to return the error message received from the server if one is present.
- Modifies `FileSystemProvider.writeFile()` to use that error message in its error when a save fails.
- Modifies `importFile()` to log that error message to the output channel and then display an error message popup when a save fails.
- Modifies `viewOthers()` to display an info message popup when there are no other documents to show and log an error message to the output channel and then display an error message popup when the index request fails.