### PR TITLE
Add "Edit Other" command and menu option

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,6 +214,10 @@
         {
           "command": "vscode-objectscript.compileOnlyWithFlags",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.editOthers",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
         }
       ],
       "view/title": [
@@ -286,29 +290,34 @@
           "group": "objectscript@1"
         },
         {
+          "command": "vscode-objectscript.editOthers",
+          "when": "resourceScheme == file && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "group": "objectscript@2"
+        },
+        {
           "command": "vscode-objectscript.compile",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
-          "group": "objectscript@2"
+          "group": "objectscript@3"
         },
         {
           "command": "vscode-objectscript.previewXml",
           "when": "editorLangId =~ /^xml/",
-          "group": "objectscript@3"
+          "group": "objectscript@4"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextSourceControl",
           "when": "resourceScheme == isfs && vscode-objectscript.connectActive",
-          "group": "objectscript@4"
+          "group": "objectscript@5"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextOther",
           "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive",
-          "group": "objectscript@5"
+          "group": "objectscript@6"
         },
         {
           "command": "vscode-objectscript.compileOnly",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
-          "group": "objectscript@6"
+          "group": "objectscript@7"
         }
       ],
       "editor/title": [
@@ -637,6 +646,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.compileOnlyWithFlags",
         "title": "Compile Current File with Specified Flags..."
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.editOthers",
+        "title": "Edit Other"
       }
     ],
     "keybindings": [

--- a/src/commands/viewOthers.ts
+++ b/src/commands/viewOthers.ts
@@ -4,7 +4,7 @@ import { config } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { currentFile } from "../utils";
 
-export async function viewOthers(): Promise<void> {
+export async function viewOthers(forceEditable = false): Promise<void> {
   const file = currentFile();
   if (!file) {
     return;
@@ -13,7 +13,7 @@ export async function viewOthers(): Promise<void> {
     return;
   }
 
-  const open = async (item: string) => {
+  const open = async (item: string, forceEditable: boolean) => {
     const colonidx: number = item.indexOf(":");
     if (colonidx !== -1) {
       // A location is appened to the name of the other document
@@ -22,7 +22,12 @@ export async function viewOthers(): Promise<void> {
       // Split the document name form the location
       let loc = item.slice(colonidx + 1);
       item = item.slice(0, colonidx);
-      const uri = DocumentContentProvider.getUri(item);
+      let uri: vscode.Uri;
+      if (forceEditable) {
+        uri = DocumentContentProvider.getUri(item, undefined, undefined, forceEditable);
+      } else {
+        uri = DocumentContentProvider.getUri(item);
+      }
 
       if (item.endsWith(".cls")) {
         // Locations in classes are of the format method+offset+namespace
@@ -74,7 +79,12 @@ export async function viewOthers(): Promise<void> {
       }
       vscode.window.showTextDocument(uri, options);
     } else {
-      const uri = DocumentContentProvider.getUri(item);
+      let uri: vscode.Uri;
+      if (forceEditable) {
+        uri = DocumentContentProvider.getUri(item, undefined, undefined, forceEditable);
+      } else {
+        uri = DocumentContentProvider.getUri(item);
+      }
       vscode.window.showTextDocument(uri);
     }
   };
@@ -148,10 +158,10 @@ export async function viewOthers(): Promise<void> {
         return;
       }
       if (listOthers.length === 1) {
-        open(listOthers[0]);
+        open(listOthers[0], forceEditable);
       } else {
         vscode.window.showQuickPick(listOthers).then((item) => {
-          open(item);
+          open(item, forceEditable);
         });
       }
     })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -775,7 +775,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         });
     }),
     vscode.commands.registerCommand("vscode-objectscript.jumpToTagAndOffset", jumpToTagAndOffset),
-    vscode.commands.registerCommand("vscode-objectscript.viewOthers", viewOthers),
+    vscode.commands.registerCommand("vscode-objectscript.viewOthers", () => viewOthers(false)),
     vscode.commands.registerCommand("vscode-objectscript.serverCommands.sourceControl", mainSourceControlMenu),
     vscode.commands.registerCommand(
       "vscode-objectscript.serverCommands.contextSourceControl",
@@ -786,7 +786,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.subclass", subclass),
     vscode.commands.registerCommand("vscode-objectscript.superclass", superclass),
     vscode.commands.registerCommand("vscode-objectscript.serverActions", serverActions),
-    vscode.commands.registerCommand("vscode-objectscript.touchBar.viewOthers", viewOthers),
+    vscode.commands.registerCommand("vscode-objectscript.touchBar.viewOthers", () => viewOthers(false)),
     vscode.commands.registerCommand("vscode-objectscript.explorer.refresh", () => explorerProvider.refresh()),
     // Register the vscode-objectscript.explorer.open command elsewhere
     registerExplorerOpen(explorerProvider),
@@ -870,6 +870,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       { language: "vscode-objectscript-output" },
       new DocumentLinkProvider()
     ),
+    vscode.commands.registerCommand("vscode-objectscript.editOthers", () => viewOthers(true)),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed


### PR DESCRIPTION
This PR fixes #309 

Modifies `viewOthers()` to take boolean argument `forceEditable`. When `forceEditable` is `true`, the other document will open using the writeable `isfs` schema regardless of the user's `objectscript.serverSideEditing` setting. If `forceEditable` is `false` (the case for the `vscode-objectscript.viewOthers` command), we will defer to the user's `objectscript.serverSideEditing` setting like before. New menu option `Edit Other` will appear below `View Other` if an InterSystems file with schema `file` is open.
