### PR TITLE
Add getUriForDocument() to exported API

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -936,6 +936,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     onDidChangeConnection(): vscode.Event<void> {
       return _onDidChangeConnection.event;
     },
+    getUriForDocument(document: string): vscode.Uri {
+      return DocumentContentProvider.getUri(document);
+    },
   };
 
   // 'export' our public API


### PR DESCRIPTION
This PR is required to fix https://github.com/intersystems/language-server/issues/45

By exposing `DocumentContentProvider.getUri()` in the exported API, the Language Server will be able to open the local version of a file for go to definition requests in client-side editing mode.