### PR TITLE
Use reveal range instead of moving the cursor

### DIFF
--- a/src/providers/DocumentLinkProvider.ts
+++ b/src/providers/DocumentLinkProvider.ts
@@ -64,10 +64,10 @@ export class DocumentLinkProvider implements vscode.DocumentLinkProvider {
       offset += method.location.range.start.line + 1;
     }
 
-    // move the cursor
-    const cursor = editor.selection.active;
-    const newPosition = cursor.with(offset, 0);
-    editor.selection = new vscode.Selection(newPosition, newPosition);
+    const line = editor.document.lineAt(offset);
+    const range = new vscode.Range(line.range.start, line.range.start);
+    editor.selection = new vscode.Selection(range.start, range.start);
+    editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
 
     return new vscode.DocumentLink(link.range, link.uri);
   }


### PR DESCRIPTION
This PR fixes #657 

Use reveal range when opening links rather than just moving the cursor which does not scroll to the correct position.