### PR TITLE
fix #683 better isfs handling of server-side changes

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -3,7 +3,7 @@ import path = require("path");
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { config } from "../extension";
-import { mkdirSyncRecursive, notNull, outputChannel, workspaceFolderUri } from "../utils";
+import { mkdirSyncRecursive, notNull, outputChannel, uriOfWorkspaceFolder } from "../utils";
 import { NodeBase } from "../explorer/models/nodeBase";
 
 const filesFilter = (file: any) => {
@@ -185,7 +185,10 @@ export async function exportList(files: string[], workspaceFolder: string, names
   }
   const { atelier, folder, addCategory, map } = config("export", workspaceFolder);
 
-  const root = [workspaceFolderUri(workspaceFolder).fsPath, typeof folder === "string" && folder.length ? folder : null]
+  const root = [
+    uriOfWorkspaceFolder(workspaceFolder).fsPath,
+    typeof folder === "string" && folder.length ? folder : null,
+  ]
     .filter(notNull)
     .join(path.sep);
   const run = async (fileList) => {

--- a/src/commands/viewOthers.ts
+++ b/src/commands/viewOthers.ts
@@ -200,7 +200,17 @@ export async function viewOthers(forceEditable = false): Promise<void> {
     .catch((err) => {
       if (err.errorText && err.errorText !== "") {
         outputChannel.appendLine("\n" + err.errorText);
-        vscode.window.showErrorMessage(`Failed to get other documents. Check output channel for details.`, "Dismiss");
+        vscode.window
+          .showErrorMessage(
+            `Failed to get other documents. Check 'ObjectScript' output channel for details.`,
+            "Show",
+            "Dismiss"
+          )
+          .then((action) => {
+            if (action === "Show") {
+              outputChannel.show(true);
+            }
+          });
       } else {
         vscode.window.showErrorMessage(`Failed to get other documents.`, "Dismiss");
       }

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -6,7 +6,7 @@ import { AtelierAPI } from "../api";
 
 import { getFileName, getFolderName } from "../commands/export";
 import { config, FILESYSTEM_SCHEMA, FILESYSTEM_READONLY_SCHEMA, OBJECTSCRIPT_FILE_SCHEMA } from "../extension";
-import { currentWorkspaceFolder, workspaceFolderUri } from "../utils";
+import { currentWorkspaceFolder, uriOfWorkspaceFolder } from "../utils";
 
 export class DocumentContentProvider implements vscode.TextDocumentContentProvider {
   public get onDidChange(): vscode.Event<vscode.Uri> {
@@ -16,7 +16,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
   public static getAsFile(name: string, workspaceFolder: string): string {
     const { atelier, folder, addCategory, map } = config("export", workspaceFolder);
 
-    const root = [workspaceFolderUri(workspaceFolder).fsPath, folder].join(path.sep);
+    const root = [uriOfWorkspaceFolder(workspaceFolder).fsPath, folder].join(path.sep);
     const fileName = getFileName(root, name, atelier, addCategory, map);
     if (fs.existsSync(fileName)) {
       return fs.realpathSync.native(fileName);
@@ -26,7 +26,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
   public static getAsFolder(name: string, workspaceFolder: string, category?: string): string {
     const { atelier, folder, addCategory } = config("export", workspaceFolder);
 
-    const root = [workspaceFolderUri(workspaceFolder).fsPath, folder].join(path.sep);
+    const root = [uriOfWorkspaceFolder(workspaceFolder).fsPath, folder].join(path.sep);
     const folderName = getFolderName(root, name, atelier, addCategory ? category : null);
     if (fs.existsSync(folderName)) {
       return fs.realpathSync.native(folderName);
@@ -49,7 +49,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     // if wFolderUri was passed it takes precedence
     if (!wFolderUri) {
       workspaceFolder = workspaceFolder && workspaceFolder !== "" ? workspaceFolder : currentWorkspaceFolder();
-      wFolderUri = workspaceFolderUri(workspaceFolder);
+      wFolderUri = uriOfWorkspaceFolder(workspaceFolder);
     }
     let uri: vscode.Uri;
     if (wFolderUri.scheme === FILESYSTEM_SCHEMA || wFolderUri.scheme === FILESYSTEM_READONLY_SCHEMA) {

--- a/src/providers/FileSystemProvider/File.ts
+++ b/src/providers/FileSystemProvider/File.ts
@@ -10,8 +10,8 @@ export class File implements vscode.FileStat {
   public data?: Uint8Array;
   public constructor(name: string, fileName: string, ts: string, size: number, data: string | Buffer) {
     this.type = vscode.FileType.File;
-    this.ctime = new Date(ts).getTime();
-    this.mtime = new Date(ts).getTime();
+    this.ctime = Number(new Date(ts + "Z"));
+    this.mtime = this.ctime;
     this.size = size;
     this.fileName = fileName;
     this.name = name;

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -149,7 +149,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   public async readFile(uri: vscode.Uri): Promise<Uint8Array> {
     return this._lookupAsFile(uri).then((file: File) => {
       // Update cache entry
-      const uniqueId = `${workspaceFolderOfUri(uri)}:${file.name}`;
+      const uniqueId = `${workspaceFolderOfUri(uri)}:${file.fileName}`;
       workspaceState.update(`${uniqueId}:mtime`, file.mtime);
       return file.data;
     });

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -6,7 +6,8 @@ import { Directory } from "./Directory";
 import { File } from "./File";
 import { fireOtherStudioAction, OtherStudioAction } from "../../commands/studio";
 import { StudioOpenDialog } from "../../queries";
-import { redirectDotvscodeRoot } from "../../utils/index";
+import { redirectDotvscodeRoot, workspaceFolderOfUri } from "../../utils/index";
+import { workspaceState } from "../../extension";
 
 declare function setTimeout(callback: (...args: any[]) => void, ms: number, ...args: any[]): NodeJS.Timeout;
 
@@ -146,7 +147,12 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async readFile(uri: vscode.Uri): Promise<Uint8Array> {
-    return this._lookupAsFile(uri).then((file: File) => file.data);
+    return this._lookupAsFile(uri).then((file: File) => {
+      // Update cache entry
+      const uniqueId = `${workspaceFolderOfUri(uri)}:${file.name}`;
+      workspaceState.update(`${uniqueId}:mtime`, file.mtime);
+      return file.data;
+    });
   }
 
   private generateFileContent(fileName: string, content: Buffer): { content: string[]; enc: boolean } {
@@ -307,8 +313,12 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         } else {
           throw vscode.FileSystemError.FileNotFound(uri);
         }
+      } else if (child instanceof File) {
+        // Return cached copy unless changed, in which case return updated one
+        return this._lookupAsFile(uri, child);
+      } else {
+        entry = child;
       }
-      entry = child;
     }
     return entry;
   }
@@ -325,8 +335,8 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     throw vscode.FileSystemError.FileNotADirectory(uri);
   }
 
-  // Fetch from server and cache it
-  private async _lookupAsFile(uri: vscode.Uri): Promise<File> {
+  // Fetch from server and cache it, optionally the passed cached copy if unchanged on server
+  private async _lookupAsFile(uri: vscode.Uri, cachedFile?: File): Promise<File> {
     uri = redirectDotvscodeRoot(uri);
     if (uri.path.startsWith("/.")) {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
@@ -338,7 +348,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     const name = path.basename(uri.path);
     const api = new AtelierAPI(uri);
     return api
-      .getDoc(fileName)
+      .getDoc(fileName, undefined, cachedFile?.mtime)
       .then((data) => data.result)
       .then((result) => {
         const fileSplit = fileName.split(".");
@@ -373,6 +383,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         })
       )
       .catch((error) => {
+        if (error?.statusCode === 304 && cachedFile) {
+          return cachedFile;
+        }
         throw vscode.FileSystemError.FileNotFound(uri);
       });
   }


### PR DESCRIPTION
This PR fixes #683

- Updates workspace-cached mtime when file is opened again
- Revises stat() method handling to detect when server-side etag has changed, triggering refresh of client cache entry.
- Enhances the 'failed compilation' error messages with a button to show the output channel.

@isc-bsaviano this PR should mean the work you proposed doing to detect server-side changes is no longer needed. Please try the VSIX this PR builds, or point relevant internal users at it for verification.