### PR TITLE
Fix build broken by recent vscode.d.ts change

### DIFF
--- a/src/providers/ObjectScriptCompletionItemProvider.ts
+++ b/src/providers/ObjectScriptCompletionItemProvider.ts
@@ -173,7 +173,7 @@ export class ObjectScriptCompletionItemProvider implements vscode.CompletionItem
           items: items.map((el) => {
             return {
               ...el,
-              label: this._formatter.function(el.label),
+              label: this._formatter.function(el.label as string),
               insertText: this._formatter.function(el.insertText),
               range,
             };
@@ -183,7 +183,7 @@ export class ObjectScriptCompletionItemProvider implements vscode.CompletionItem
         return this.listStructuredSystemVariables(search, textAfter.length > 0).map((el) => {
           return {
             ...el,
-            label: this._formatter.function(el.label),
+            label: this._formatter.function(el.label as string),
             range,
           };
         });


### PR DESCRIPTION
https://github.com/microsoft/vscode/commit/24f9000e97e6a798cf565bb7fbde810ae21ae667 added CompletionItemLabel as an alternative type for the label property of CompletionItem. This broke our build, which always pulls vscode.d.ts and vscode.proposed.d.ts from vscode/main

Example of broken build is at https://github.com/intersystems-community/vscode-objectscript/pull/661/checks?check_run_id=2884905256