### PR TITLE
fix #691 Add `objectscript.serverSourceControl.disableOtherActionTriggers` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -785,6 +785,11 @@
             }
           }
         },
+        "objectscript.serverSourceControl.disableActionTriggers": {
+          "description": "Prevent server-side source control action triggers from firing.",
+          "type": "boolean",
+          "scope": "resource"
+        },
         "objectscript.export": {
           "type": "object",
           "description": "Control what to export from the server into the local folder.",

--- a/package.json
+++ b/package.json
@@ -785,8 +785,8 @@
             }
           }
         },
-        "objectscript.serverSourceControl.disableActionTriggers": {
-          "description": "Prevent server-side source control action triggers from firing.",
+        "objectscript.serverSourceControl.disableOtherActionTriggers": {
+          "description": "Prevent server-side source control 'other action' triggers from firing.",
           "type": "boolean",
           "scope": "resource"
         },

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -459,6 +459,9 @@ export async function _contextMenu(sourceControl: boolean, node: PackageNode | C
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function fireOtherStudioAction(action: OtherStudioAction, uri?: vscode.Uri, userAction?): Promise<void> {
+  if (vscode.workspace.getConfiguration("objectscript.serverSourceControl", uri)?.get("disableActionTriggers")) {
+    return;
+  }
   const studioActions = new StudioActions(uri);
   return studioActions && studioActions.fireOtherStudioAction(action, userAction);
 }

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -459,7 +459,7 @@ export async function _contextMenu(sourceControl: boolean, node: PackageNode | C
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export async function fireOtherStudioAction(action: OtherStudioAction, uri?: vscode.Uri, userAction?): Promise<void> {
-  if (vscode.workspace.getConfiguration("objectscript.serverSourceControl", uri)?.get("disableActionTriggers")) {
+  if (vscode.workspace.getConfiguration("objectscript.serverSourceControl", uri)?.get("disableOtherActionTriggers")) {
     return;
   }
   const studioActions = new StudioActions(uri);


### PR DESCRIPTION
This PR fixes #691

With `"objectscript.serverSourceControl.disableOtherActionTriggers": true` the 'Other Studio action' server-side source control calls are suppressed.

The calls currently made (and thus suppressed by this setting) are:

- AttemptedEdit = 0
- CreatedNewDocument = 1
- DeletedDocument = 2
- FirstTimeDocumentSave = 7
