### PR TITLE
Allow configuration of server side search max results

### DIFF
--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -29,6 +29,9 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
         regex: query.isRegExp,
         word: query.isWordMatch,
         case: query.isCaseSensitive,
+        // If options.maxResults is null the search is supposed to return an unlimited number of results
+        // Since there's no way for us to pass "unlimited" to the server, I choose a very large number
+        max: options.maxResults !== null ? options.maxResults : 100000,
       })
       .then((data) => data.result)
       .then((files: SearchResult[]) =>

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -31,7 +31,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
         case: query.isCaseSensitive,
         // If options.maxResults is null the search is supposed to return an unlimited number of results
         // Since there's no way for us to pass "unlimited" to the server, I choose a very large number
-        max: options.maxResults !== null ? options.maxResults : 100000,
+        max: options.maxResults ?? 100000,
       })
       .then((data) => data.result)
       .then((files: SearchResult[]) =>


### PR DESCRIPTION
This PR fixes #713 

Edited `provideTextSearchResults()` to send `options.maxResults` to the server if it's non-`null`. If the value is `null` (meaning "send an unlimited number of results"), a value of 100,000 is sent to the server because it's not possible to specify "unlimited".