### PR TITLE
Improve wording of confirmation message for namespace compile command

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -338,7 +338,7 @@ export async function namespaceCompile(askFlags = false): Promise<any> {
     throw new Error(`No Active Connection`);
   }
   const confirm = await vscode.window.showWarningMessage(
-    `Compiling all files in namespace '${api.ns}' is expensive! Are you sure you want to proceed?`,
+    `Compiling all files in namespace '${api.ns}' might be expensive. Are you sure you want to proceed?`,
     "Cancel",
     "Confirm"
   );


### PR DESCRIPTION
This PR improves the wording from #716, which addressed #677 