### PR TITLE
Fix `DocumentContentProvider.getUri()` for ISFS routines with dots

### DIFF
--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -57,7 +57,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
       const fileName = name
         .split(".")
         .slice(0, -1)
-        .join(fileExt.match(/cls/i) ? "/" : ".");
+        .join(/cls|mac|int|inc/i.test(fileExt) ? "/" : ".");
       name = fileName + "." + fileExt;
       uri = wFolderUri.with({
         path: `/${name}`,


### PR DESCRIPTION
This PR fixes #748

Fixed `DocumentContentProvider.getUri()` so URIs created for mac, inc or int routines in ISFS folders correctly split dots in the routine name into folders. For example, `%SYS.cspServer.mac` is currently given the URI `iris5:%SYS:/%SYS.cspServer.mac`, but after this PR it will correctly be given the URI `iris5:%SYS:/%SYS/cspServer.mac`.