### PR TITLE
Fix multi-select compile and delete in ObjectScript Explorer

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -239,7 +239,7 @@ export async function exportAll(workspaceFolder?: string): Promise<any> {
   });
 }
 
-export async function exportExplorerItem(nodes: NodeBase[]): Promise<any> {
+export async function exportExplorerItems(nodes: NodeBase[]): Promise<any> {
   const node = nodes[0];
   const origNamespace = config("conn", node.workspaceFolder).ns;
   if (origNamespace !== node.namespace) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,12 +22,12 @@ import {
   importAndCompile,
   importFolder as importFileOrFolder,
   namespaceCompile,
-  compileExplorerItem,
+  compileExplorerItems,
   checkChangedOnServer,
   compileOnly,
 } from "./commands/compile";
-import { deleteItem } from "./commands/delete";
-import { exportAll, exportExplorerItem } from "./commands/export";
+import { deleteExplorerItems } from "./commands/delete";
+import { exportAll, exportExplorerItems } from "./commands/export";
 import { serverActions } from "./commands/serverActions";
 import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
@@ -841,10 +841,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     // Register the vscode-objectscript.explorer.open command elsewhere
     registerExplorerOpen(explorerProvider),
     vscode.commands.registerCommand("vscode-objectscript.explorer.export", (item, items) =>
-      exportExplorerItem(items && items.length ? items : [item])
+      exportExplorerItems(items && items.length ? items : [item])
     ),
-    vscode.commands.registerCommand("vscode-objectscript.explorer.delete", deleteItem),
-    vscode.commands.registerCommand("vscode-objectscript.explorer.compile", compileExplorerItem),
+    vscode.commands.registerCommand("vscode-objectscript.explorer.delete", (item, items) =>
+      deleteExplorerItems(items && items.length ? items : [item])
+    ),
+    vscode.commands.registerCommand("vscode-objectscript.explorer.compile", (item, items) =>
+      compileExplorerItems(items && items.length ? items : [item])
+    ),
     vscode.commands.registerCommand("vscode-objectscript.explorer.showGenerated", (workspaceNode: WorkspaceNode) => {
       workspaceState.update(`ExplorerGenerated:${workspaceNode.uniqueId}`, true);
       return explorerProvider.refresh();


### PR DESCRIPTION
This PR fixes #746 

I modified the handler functions for `vscode-objectscript.explorer.compile` and `vscode-objectscript.explorer.delete` to accept an array of `NodeBase` instead of a single instance. For delete, I added a confirmation prompt that is only shown when the user is attempting to delete multiple Explorer nodes.