### PR TITLE
Allow Server Command menu to open a URL in an external browser

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -162,8 +162,17 @@ class StudioActions {
               `;
           });
         });
-      case 3: // Run an EXE on the client.
-        throw new Error("processUserAction: Run EXE (Action=5) not supported");
+      case 3: {
+        // Run an EXE on the client.
+        const urlRegex = /^(ht|f)tp(s?):\/\//gim;
+        if (target.search(urlRegex) === 0) {
+          // Allow target that is a URL to be opened in an external browser
+          vscode.env.openExternal(vscode.Uri.parse(target));
+          break;
+        } else {
+          throw new Error("processUserAction: Run EXE (Action=3) not supported");
+        }
+      }
       case 4: {
         // Insert the text in Target in the current document at the current selection point
         const editor = vscode.window.activeTextEditor;


### PR DESCRIPTION
This PR allows a server command menu to open a URL in the user's default browser (externally to VSCode, rather than a VSCode web view).
Previously, a server command menu with an Action==3 was not supported at all.
With this change, a server command menu with an Action==3 and a Target that is a URL will open in the user's default browser - which is the same functionality that was previously supported in IRIS Studio.