### PR TITLE
Fix two unrelated server-side source control issues

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { config, FILESYSTEM_SCHEMA } from "../extension";
-import { outputChannel, outputConsole, currentFile, getServerName } from "../utils";
+import { outputChannel, outputConsole, getServerName } from "../utils";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { ClassNode } from "../explorer/models/classNode";
 import { PackageNode } from "../explorer/models/packageNode";
 import { RoutineNode } from "../explorer/models/routineNode";
 import { NodeBase } from "../explorer/models/nodeBase";
-import { importAndCompile, loadChanges } from "./compile";
+import { importAndCompile } from "./compile";
 
 export let documentBeingProcessed: vscode.TextDocument = null;
 
@@ -272,34 +272,38 @@ class StudioActions {
               const actionToProcess = data.result.content.pop();
 
               if (actionToProcess.reload) {
-                const document = vscode.window.activeTextEditor.document;
-                const file = currentFile(document);
                 // Avoid the reload triggering the edit listener here
-                suppressEditListenerMap.set(file.uri.toString(), true);
-                await loadChanges([file]);
+                suppressEditListenerMap.set(this.uri.toString(), true);
+                await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
               }
 
               // CSP pages should not have a progress bar
               if (actionToProcess.action === 2) {
                 resolve();
               }
-              return actionToProcess;
-            })
-            .then((actionToProcess) => {
+
+              const attemptedEditLabel = getOtherStudioActionLabel(OtherStudioAction.AttemptedEdit);
               if (afterUserAction && actionToProcess.errorText !== "") {
+                if (action.label === attemptedEditLabel) {
+                  suppressEditListenerMap.set(this.uri.toString(), true);
+                  await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
+                }
                 outputChannel.appendLine(actionToProcess.errorText);
                 outputChannel.show();
               }
-              actionToProcess &&
-                !afterUserAction &&
-                this.processUserAction(actionToProcess).then((answer) => {
-                  // call AfterUserAction only if there is a valid answer
-                  if (answer) {
-                    answer.msg || answer.msg === ""
-                      ? this.userAction(action, true, answer.answer, answer.msg, type)
-                      : this.userAction(action, true, answer, "", type);
-                  }
-                });
+              if (actionToProcess && !afterUserAction) {
+                const answer = await this.processUserAction(actionToProcess);
+                // call AfterUserAction only if there is a valid answer
+                if ((action.label = attemptedEditLabel) && answer !== "1") {
+                  suppressEditListenerMap.set(this.uri.toString(), true);
+                  await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
+                }
+                if (answer) {
+                  answer.msg || answer.msg === ""
+                    ? this.userAction(action, true, answer.answer, answer.msg, type)
+                    : this.userAction(action, true, answer, "", type);
+                }
+              }
             })
             .then(() => resolve())
             .catch((err) => {


### PR DESCRIPTION
This PR fixes a few issues I found while working on https://github.com/intersystems/git-source-control.

Specifically:
We issue "undo" commands based on attempted edits. The way this works makes some invalid assumptions about the source control extension's behavior, and causes very confusing behavior in reasonable cases where (for example) edits are seamless rather than prompting the user. I think there may be room for improvement in how we handle files that server-side source control says are read-only, but the way we're doing this now with "undo" is not the solution. (Even for an extension that works nicely with this - %Studio.SourceControl.ISC - I find the current behavior jarring.)

Also, I'd see weird behavior where I could launch a CSP page, but after the session expired it'd start giving me a login page where I couldn't actually log in. This was inconsistent and finicky, and I think may be related to things going on under the hood with GetCSPToken and some of the platform-level security constraints around CSRF tokens and/or cookie scope. Regardless of the root cause, the fix is to just add CSPSHARE=1. Studio does this too under the hood. Steps to reproduce were (with git-source-control):
* Launch one of the CSP pages (in /isc/studio/usertemplates) from the menu
* kill ^%cspSession
* Launch it again
Previously, subsequent launches would show a page where login doesn't work. Now they just show the requested page.