### PR TITLE
Add support for conditional breakpoints

### DIFF
--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -323,12 +323,12 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       await Promise.all(
         xdebugBreakpoints.map(async (breakpoint, index) => {
           try {
-            if (breakpoint.hitCount && !/^\d+$/.test(breakpoint.hitCount)) {
+            if (breakpoint.hitCondition && !/^\d+$/.test(breakpoint.hitCondition)) {
               // The user-defined hitCondition wasn't an integer
               vscodeBreakpoints[index] = {
                 verified: false,
                 line: breakpoint.line,
-                message: "Hit count must be an integer",
+                message: "Hit Count must be an integer",
               };
             } else {
               await this._connection.sendBreakpointSetCommand(breakpoint);

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -323,12 +323,12 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       await Promise.all(
         xdebugBreakpoints.map(async (breakpoint, index) => {
           try {
-            if (breakpoint.hitCondition && !/^\d+$/.test(breakpoint.hitCondition)) {
-              // The user-defined hitCondition wasn't an integer
+            if (breakpoint.hitCondition && !/^[1-9]\d*$/.test(breakpoint.hitCondition)) {
+              // The user-defined hitCondition wasn't a positive integer
               vscodeBreakpoints[index] = {
                 verified: false,
                 line: breakpoint.line,
-                message: "Hit Count must be an integer",
+                message: "Hit Count must be a positive integer",
               };
             } else {
               await this._connection.sendBreakpointSetCommand(breakpoint);

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -110,7 +110,8 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       supportsConfigurationDoneRequest: true,
       supportsEvaluateForHovers: true,
       supportsSetVariable: true,
-      supportsConditionalBreakpoints: false, // TODO
+      supportsConditionalBreakpoints: true,
+      supportsHitConditionalBreakpoints: true,
       supportsStepBack: false,
       supportsDataBreakpoints: true,
     };
@@ -266,9 +267,7 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       xdebugBreakpoints = await Promise.all(
         args.breakpoints.map(async (breakpoint) => {
           const line = breakpoint.line;
-          if (breakpoint.condition) {
-            return new xdebug.ConditionalBreakpoint(breakpoint.condition, fileUri, line);
-          } else if (fileName.endsWith("cls")) {
+          if (fileName.endsWith("cls")) {
             return await vscode.workspace.openTextDocument(uri).then((document) => {
               const methodMatchPattern = new RegExp(`^(?:Class)?Method ([^(]+)(?=[( ])`, "i");
               for (let i = line; line > 0; i--) {
@@ -276,14 +275,46 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
                 const methodMatch = lineOfCode.match(methodMatchPattern);
                 if (methodMatch) {
                   const [, methodName] = methodMatch;
-                  return new xdebug.ClassLineBreakpoint(fileUri, line, methodName, line - i - 2);
+                  if (breakpoint.condition) {
+                    return new xdebug.ClassConditionalBreakpoint(
+                      breakpoint.condition,
+                      fileUri,
+                      line,
+                      methodName,
+                      line - i - 2,
+                      breakpoint.hitCondition
+                    );
+                  } else {
+                    return new xdebug.ClassLineBreakpoint(
+                      fileUri,
+                      line,
+                      methodName,
+                      line - i - 2,
+                      breakpoint.hitCondition
+                    );
+                  }
                 }
               }
             });
           } else if (filePath.endsWith("mac") || filePath.endsWith("int")) {
-            return new xdebug.RoutineLineBreakpoint(fileUri, line, "", line - 1);
+            if (breakpoint.condition) {
+              return new xdebug.RoutineConditionalBreakpoint(
+                breakpoint.condition,
+                fileUri,
+                line,
+                "",
+                line - 1,
+                breakpoint.hitCondition
+              );
+            } else {
+              return new xdebug.RoutineLineBreakpoint(fileUri, line, "", line - 1, breakpoint.hitCondition);
+            }
           } else {
-            return new xdebug.LineBreakpoint(fileUri, line);
+            if (breakpoint.condition) {
+              return new xdebug.ConditionalBreakpoint(breakpoint.condition, fileUri, line, breakpoint.hitCondition);
+            } else {
+              return new xdebug.LineBreakpoint(fileUri, line, breakpoint.hitCondition);
+            }
           }
         })
       );
@@ -292,8 +323,17 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       await Promise.all(
         xdebugBreakpoints.map(async (breakpoint, index) => {
           try {
-            await this._connection.sendBreakpointSetCommand(breakpoint);
-            vscodeBreakpoints[index] = { verified: true, line: breakpoint.line };
+            if (breakpoint.hitCount && !/^\d+$/.test(breakpoint.hitCount)) {
+              // The user-defined hitCondition wasn't an integer
+              vscodeBreakpoints[index] = {
+                verified: false,
+                line: breakpoint.line,
+                message: "Hit count must be an integer",
+              };
+            } else {
+              await this._connection.sendBreakpointSetCommand(breakpoint);
+              vscodeBreakpoints[index] = { verified: true, line: breakpoint.line };
+            }
           } catch (error) {
             vscodeBreakpoints[index] = {
               verified: false,

--- a/src/debug/xdebugConnection.ts
+++ b/src/debug/xdebugConnection.ts
@@ -159,7 +159,7 @@ export abstract class Breakpoint {
       this.state = breakpointNode.getAttribute("state") as BreakpointState;
     } else {
       this.type = rest[0];
-      this.hitCondition = rest[1];
+      this.hitCondition = rest[1].trim();
       this.state = "enabled";
     }
   }

--- a/src/debug/xdebugConnection.ts
+++ b/src/debug/xdebugConnection.ts
@@ -143,12 +143,12 @@ export abstract class Breakpoint {
   public state: BreakpointState;
   /** The connection this breakpoint is set on */
   public connection: Connection;
-  /** A numeric value used to determine if the breakpoint should pause execution or be skipped. */
-  public hitCount?: string;
+  /** The value of the `hitCondition` property of the input `DebugProtocol.SourceBreakpoint` */
+  public hitCondition?: string;
   /** Constructs a breakpoint object from an XML node from a XDebug response */
   public constructor(breakpointNode: Element, connection: Connection);
   /** To create a new breakpoint in derived classes */
-  public constructor(type: BreakpointType, hitCount?: string);
+  public constructor(type: BreakpointType, hitCondition?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       // from XML
@@ -159,7 +159,7 @@ export abstract class Breakpoint {
       this.state = breakpointNode.getAttribute("state") as BreakpointState;
     } else {
       this.type = rest[0];
-      this.hitCount = rest[1];
+      this.hitCondition = rest[1];
       this.state = "enabled";
     }
   }
@@ -178,7 +178,7 @@ export class LineBreakpoint extends Breakpoint {
   /** constructs a line breakpoint from an XML node */
   public constructor(breakpointNode: Element, connection: Connection);
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number, hitCount?: string);
+  public constructor(fileUri: string, line: number, hitCondition?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -200,7 +200,7 @@ export class ClassLineBreakpoint extends LineBreakpoint {
   public methodOffset: number;
 
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCount?: string);
+  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCondition?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -221,7 +221,7 @@ export class RoutineLineBreakpoint extends LineBreakpoint {
   public methodOffset: number;
 
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCount?: string);
+  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCondition?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -248,7 +248,7 @@ export class ConditionalBreakpoint extends Breakpoint {
   /** Constructs a breakpoint object from an XML node from a XDebug response */
   public constructor(breakpointNode: Element, connection: Connection);
   /** Contructs a breakpoint object for passing to sendSetBreakpointCommand */
-  public constructor(expression: string, fileUri: string, line?: number, hitCount?: string);
+  public constructor(expression: string, fileUri: string, line?: number, hitCondition?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       // from XML
@@ -277,7 +277,7 @@ export class ClassConditionalBreakpoint extends ConditionalBreakpoint {
     line: number,
     method: string,
     methodOffset: number,
-    hitCount?: string
+    hitCondition?: string
   );
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
@@ -304,7 +304,7 @@ export class RoutineConditionalBreakpoint extends ConditionalBreakpoint {
     line: number,
     method: string,
     methodOffset: number,
-    hitCount?: string
+    hitCondition?: string
   );
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
@@ -854,8 +854,8 @@ export class Connection extends DbgpConnection {
       args += ` -m PLACEHOLDER`;
       args += ` -n PLACEHOLDER`;
     }
-    if (breakpoint.hitCount) {
-      args += ` -h ${breakpoint.hitCount}`;
+    if (breakpoint.hitCondition) {
+      args += ` -h ${breakpoint.hitCondition}`;
     }
     return new BreakpointSetResponse(await this._enqueueCommand("breakpoint_set", args, data), this);
   }

--- a/src/debug/xdebugConnection.ts
+++ b/src/debug/xdebugConnection.ts
@@ -143,10 +143,12 @@ export abstract class Breakpoint {
   public state: BreakpointState;
   /** The connection this breakpoint is set on */
   public connection: Connection;
+  /** A numeric value used to determine if the breakpoint should pause execution or be skipped. */
+  public hitCount?: string;
   /** Constructs a breakpoint object from an XML node from a XDebug response */
   public constructor(breakpointNode: Element, connection: Connection);
   /** To create a new breakpoint in derived classes */
-  public constructor(type: BreakpointType);
+  public constructor(type: BreakpointType, hitCount?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       // from XML
@@ -157,6 +159,7 @@ export abstract class Breakpoint {
       this.state = breakpointNode.getAttribute("state") as BreakpointState;
     } else {
       this.type = rest[0];
+      this.hitCount = rest[1];
       this.state = "enabled";
     }
   }
@@ -175,7 +178,7 @@ export class LineBreakpoint extends Breakpoint {
   /** constructs a line breakpoint from an XML node */
   public constructor(breakpointNode: Element, connection: Connection);
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number);
+  public constructor(fileUri: string, line: number, hitCount?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -185,7 +188,7 @@ export class LineBreakpoint extends Breakpoint {
       this.fileUri = breakpointNode.getAttribute("filename");
     } else {
       // construct from arguments
-      super("line");
+      super("line", rest[2]);
       this.fileUri = rest[0];
       this.line = rest[1];
     }
@@ -197,7 +200,7 @@ export class ClassLineBreakpoint extends LineBreakpoint {
   public methodOffset: number;
 
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number, method: string, methodOffset: number);
+  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCount?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -206,7 +209,7 @@ export class ClassLineBreakpoint extends LineBreakpoint {
       this.line = parseInt(breakpointNode.getAttribute("lineno"), 10);
       this.fileUri = breakpointNode.getAttribute("filename");
     } else {
-      super(rest[0], rest[1]);
+      super(rest[0], rest[1], rest[4]);
       this.method = rest[2];
       this.methodOffset = rest[3];
     }
@@ -218,7 +221,7 @@ export class RoutineLineBreakpoint extends LineBreakpoint {
   public methodOffset: number;
 
   /** contructs a line breakpoint for passing to sendSetBreakpointCommand */
-  public constructor(fileUri: string, line: number, method: string, methodOffset: number);
+  public constructor(fileUri: string, line: number, method: string, methodOffset: number, hitCount?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       const breakpointNode: Element = rest[0];
@@ -227,7 +230,7 @@ export class RoutineLineBreakpoint extends LineBreakpoint {
       this.line = parseInt(breakpointNode.getAttribute("lineno"), 10);
       this.fileUri = breakpointNode.getAttribute("filename");
     } else {
-      super(rest[0], rest[1]);
+      super(rest[0], rest[1], rest[4]);
       this.method = rest[2];
       this.methodOffset = rest[3];
     }
@@ -245,7 +248,7 @@ export class ConditionalBreakpoint extends Breakpoint {
   /** Constructs a breakpoint object from an XML node from a XDebug response */
   public constructor(breakpointNode: Element, connection: Connection);
   /** Contructs a breakpoint object for passing to sendSetBreakpointCommand */
-  public constructor(expression: string, fileUri: string, line?: number);
+  public constructor(expression: string, fileUri: string, line?: number, hitCount?: string);
   public constructor(...rest: any[]) {
     if (typeof rest[0] === "object") {
       // from XML
@@ -255,10 +258,64 @@ export class ConditionalBreakpoint extends Breakpoint {
       this.expression = breakpointNode.getAttribute("expression"); // Base64 encoded?
     } else {
       // from arguments
-      super("conditional");
+      super("conditional", rest[3]);
       this.expression = rest[0];
       this.fileUri = rest[1];
       this.line = rest[2];
+    }
+  }
+}
+
+export class ClassConditionalBreakpoint extends ConditionalBreakpoint {
+  public method: string;
+  public methodOffset: number;
+
+  /** contructs a conditional breakpoint for passing to sendSetBreakpointCommand */
+  public constructor(
+    expression: string,
+    fileUri: string,
+    line: number,
+    method: string,
+    methodOffset: number,
+    hitCount?: string
+  );
+  public constructor(...rest: any[]) {
+    if (typeof rest[0] === "object") {
+      const breakpointNode: Element = rest[0];
+      const connection: Connection = rest[1];
+      super(breakpointNode, connection);
+      this.expression = breakpointNode.getAttribute("expression"); // Base64 encoded?
+    } else {
+      super(rest[0], rest[1], rest[2], rest[5]);
+      this.method = rest[3];
+      this.methodOffset = rest[4];
+    }
+  }
+}
+
+export class RoutineConditionalBreakpoint extends ConditionalBreakpoint {
+  public method: string;
+  public methodOffset: number;
+
+  /** contructs a conditional breakpoint for passing to sendSetBreakpointCommand */
+  public constructor(
+    expression: string,
+    fileUri: string,
+    line: number,
+    method: string,
+    methodOffset: number,
+    hitCount?: string
+  );
+  public constructor(...rest: any[]) {
+    if (typeof rest[0] === "object") {
+      const breakpointNode: Element = rest[0];
+      const connection: Connection = rest[1];
+      super(breakpointNode, connection);
+      this.expression = breakpointNode.getAttribute("expression"); // Base64 encoded?
+    } else {
+      super(rest[0], rest[1], rest[2], rest[5]);
+      this.method = rest[3];
+      this.methodOffset = rest[4];
     }
   }
 }
@@ -782,8 +839,10 @@ export class Connection extends DbgpConnection {
       }
     } else if (breakpoint instanceof ConditionalBreakpoint) {
       args += ` -f ${breakpoint.fileUri}`;
-      if (typeof breakpoint.line === "number") {
-        args += ` -n ${breakpoint.line}`;
+      if (breakpoint instanceof ClassConditionalBreakpoint) {
+        args += ` -m ${breakpoint.method} -n ${breakpoint.methodOffset}`;
+      } else if (breakpoint instanceof RoutineConditionalBreakpoint) {
+        args += ` -n ${breakpoint.methodOffset}`;
       }
       data = breakpoint.expression;
     } else if (breakpoint instanceof Watchpoint) {
@@ -794,6 +853,9 @@ export class Connection extends DbgpConnection {
       args += ` -f PLACEHOLDER`;
       args += ` -m PLACEHOLDER`;
       args += ` -n PLACEHOLDER`;
+    }
+    if (breakpoint.hitCount) {
+      args += ` -h ${breakpoint.hitCount}`;
     }
     return new BreakpointSetResponse(await this._enqueueCommand("breakpoint_set", args, data), this);
   }


### PR DESCRIPTION
This PR adds support for [conditional breakpoints.](https://code.visualstudio.com/docs/editor/debugging#_conditional-breakpoints) Note that due to a limitation in the Atelier debugger implementation, we can only support hit conditions that are integers instead of more complex expressions.