### PR TITLE
Prepare for 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.1.1] 09-Nov-2021
+- Fixes
+    - Debugger: Conditional breakpoint with condition but no hitCondition cannot be set (#766)
+
 ## [1.1.0] 08-Nov-2021
 - Enhancements
     - Add 'Show Class Documentation Preview' button and command.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.1.1] 09-Nov-2021
 - Fixes
-    - Debugger: Conditional breakpoint with condition but no hitCondition cannot be set (#766)
+    - Debugger: Breakpoint with no hitCondition cannot be set (#766)
 
 ## [1.1.0] 08-Nov-2021
 - Enhancements


### PR DESCRIPTION
Debugger: Conditional breakpoint with condition but no hitCondition cannot be set (#766)

This PR updates changelog to create a new release for fix of #766 and #768 