### PR TITLE
Add option to open shell in docker

### DIFF
--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -7,7 +7,7 @@ import {
   FILESYSTEM_READONLY_SCHEMA,
   explorerProvider,
 } from "../extension";
-import { connectionTarget, terminalWithDocker, currentFile } from "../utils";
+import { connectionTarget, terminalWithDocker, shellWithDocker, currentFile } from "../utils";
 import { mainCommandMenu, mainSourceControlMenu } from "./studio";
 import { AtelierAPI } from "../api";
 import { getCSPToken } from "../utils/getCSPToken";
@@ -107,6 +107,13 @@ export async function serverActions(): Promise<void> {
       detail: "Use docker-compose to start session inside configured service",
     });
   }
+  if (workspaceState.get(workspaceFolder + ":docker", false)) {
+    actions.push({
+      id: "openDockerShell",
+      label: "Open Shell in Docker",
+      detail: "Use docker-compose to start shell inside configured service",
+    });
+  }
   actions.push({
     id: "openPortal",
     label: "Open Management Portal",
@@ -157,6 +164,10 @@ export async function serverActions(): Promise<void> {
         }
         case "openDockerTerminal": {
           terminalWithDocker();
+          break;
+        }
+        case "openDockerShell": {
+          shellWithDocker();
           break;
         }
         case "serverSourceControlMenu": {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -396,6 +396,27 @@ export async function terminalWithDocker(): Promise<vscode.Terminal> {
   return terminal;
 }
 
+export async function shellWithDocker(): Promise<vscode.Terminal> {
+  const { "docker-compose": dockerCompose } = config("conn");
+  const { service, file = "docker-compose.yml" } = dockerCompose;
+  const workspace = currentWorkspaceFolder();
+
+  const terminalName = `Shell:${workspace}`;
+  let terminal = terminals.find((t) => t.name == terminalName && t.exitStatus == undefined);
+  if (!terminal) {
+    terminal = vscode.window.createTerminal(terminalName, "docker-compose", [
+      "-f",
+      file,
+      "exec",
+      service,
+      "/bin/bash"
+    ]);
+    terminals.push(terminal);
+  }
+  terminal.show(true);
+  return terminal;
+}
+
 /**
  * Alter isfs-type uri.path of /.vscode/* files or subdirectories.
  * Rewrite `/.vscode/path/to/file` as `/_vscode/XYZ/path/to/file`

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -404,13 +404,7 @@ export async function shellWithDocker(): Promise<vscode.Terminal> {
   const terminalName = `Shell:${workspace}`;
   let terminal = terminals.find((t) => t.name == terminalName && t.exitStatus == undefined);
   if (!terminal) {
-    terminal = vscode.window.createTerminal(terminalName, "docker-compose", [
-      "-f",
-      file,
-      "exec",
-      service,
-      "/bin/bash"
-    ]);
+    terminal = vscode.window.createTerminal(terminalName, "docker-compose", ["-f", file, "exec", service, "/bin/bash"]);
     terminals.push(terminal);
   }
   terminal.show(true);


### PR DESCRIPTION
With the up coming version of IRIS with embedded python, it can be useful to have an easy option to gain shell access in the container