### PR TITLE
Hide 'vscode-objectscript-output' language from selector (fixes #805)

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,6 +440,7 @@
       },
       {
         "id": "vscode-objectscript-output",
+        "aliases": [],
         "mimetypes": [
           "text/x-code-output"
         ]

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -29,7 +29,7 @@ async function main() {
     installExtension("intersystems-community.servermanager");
     installExtension("intersystems.language-server");
 
-    const launchArgs = ["-n", workspace];
+    const launchArgs = ["-n", workspace, "--enable-proposed-api", "intersystems-community.vscode-objectscript"];
 
     // Download VS Code, unzip it and run the integration test
     await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs });


### PR DESCRIPTION
This PR fixes #805