### PR TITLE
Improve client-side DFI workflow

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -30,6 +30,7 @@ export const getCategory = (fileName: string, addCategory: any | boolean): strin
     case "int":
     case "inc":
     case "mac":
+    case "dfi":
       return fileExt;
     default:
       return "oth";
@@ -51,17 +52,26 @@ export const getFileName = (
     const cat = addCategory ? getCategory(name, addCategory) : null;
     return [folder, cat, ...nameArr].filter(notNull).join(path.sep);
   } else {
-    // This is a class, routine or include file
-    if (map) {
-      for (const pattern of Object.keys(map)) {
-        if (new RegExp(`^${pattern}$`).test(name)) {
-          name = name.replace(new RegExp(`^${pattern}$`), map[pattern]);
-          break;
+    let fileNameArray: string[];
+    let fileExt: string;
+    if (/\.dfi$/i.test(name)) {
+      // This is a DFI file
+      fileNameArray = name.split("-");
+      fileNameArray.push(fileNameArray.pop().slice(0, -4));
+      fileExt = "dfi";
+    } else {
+      // This is a class, routine or include file
+      if (map) {
+        for (const pattern of Object.keys(map)) {
+          if (new RegExp(`^${pattern}$`).test(name)) {
+            name = name.replace(new RegExp(`^${pattern}$`), map[pattern]);
+            break;
+          }
         }
       }
+      fileNameArray = name.split(".");
+      fileExt = fileNameArray.pop().toLowerCase();
     }
-    const fileNameArray: string[] = name.split(".");
-    const fileExt = fileNameArray.pop().toLowerCase();
     const cat = addCategory ? getCategory(name, addCategory) : null;
     if (split) {
       const fileName = [folder, cat, ...fileNameArray].filter(notNull).join(path.sep);


### PR DESCRIPTION
This PR fixes #35 and fixes #313

Previously, DFI files could only be edited and synced to the server using server-side editing by adding `?filter=*.dfi` to an `isfs` folder URI. This PR adds support for client-side editing of DFI files.

Changes made:
- Export DFI files to folder `dfi` instead of `oth` when `objectscript.export.addCategory`  is `true`.
- Export DFI files to subfolders when `objectscript.export.atelier` is `true`.
- Sync DFI files to the server on save if the file's path matches the export settings (i.e. if `objectscript.export.addCategory` is `true`, the files must be in the `dfi` folder).