### PR TITLE
Fix `Attempted Edit` Studio Action condition

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -303,7 +303,7 @@ class StudioActions {
               if (actionToProcess && !afterUserAction) {
                 const answer = await this.processUserAction(actionToProcess);
                 // call AfterUserAction only if there is a valid answer
-                if ((action.label === attemptedEditLabel) && answer !== "1") {
+                if (action.label === attemptedEditLabel && answer !== "1") {
                   suppressEditListenerMap.set(this.uri.toString(), true);
                   await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
                 }

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -303,7 +303,7 @@ class StudioActions {
               if (actionToProcess && !afterUserAction) {
                 const answer = await this.processUserAction(actionToProcess);
                 // call AfterUserAction only if there is a valid answer
-                if ((action.label = attemptedEditLabel) && answer !== "1") {
+                if ((action.label === attemptedEditLabel) && answer !== "1") {
                   suppressEditListenerMap.set(this.uri.toString(), true);
                   await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
                 }


### PR DESCRIPTION
This PR fixes #781 

Fixes a typo that caused Studio Actions that required no user input to be treated as `Attempted Edit` Studio Actions.