### PR TITLE
Show menu options from correct namespace for Studio Actions in ObjectScript Explorer

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -75,7 +75,8 @@ class StudioActions {
       this.api = new AtelierAPI(uri);
     } else if (uriOrNode) {
       const node: NodeBase = uriOrNode;
-      this.api = new AtelierAPI();
+      this.api = new AtelierAPI(node.workspaceFolder);
+      this.api.setNamespace(node.namespace);
       this.name = node instanceof PackageNode ? node.fullName + ".PKG" : node.fullName;
     } else {
       this.api = new AtelierAPI();


### PR DESCRIPTION
If a user opens a second namespace using the `+` button in the ObjectScript Explorer and tries to run a Studio Action, the menu options shown will be from the original namespace. This PR makes the menus namespace aware. 