### PR TITLE
Fix proposed API registration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -634,24 +634,20 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   const diagnosticProvider = new ObjectScriptDiagnosticProvider();
 
-  // Gather the proposed APIs we will register to use when building with enableProposedApi = true
+  // Gather the proposed APIs we will register to use when building with enabledApiProposals != []
   const proposed = [
-    packageJson.enableProposedApi &&
     packageJson.enabledApiProposals.includes("fileSearchProvider") &&
     typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi &&
     packageJson.enabledApiProposals.includes("fileSearchProvider") &&
     typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_READONLY_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi &&
     packageJson.enabledApiProposals.includes("textSearchProvider") &&
     typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_SCHEMA, new TextSearchProvider())
       : null,
-    packageJson.enableProposedApi &&
     packageJson.enabledApiProposals.includes("textSearchProvider") &&
     typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_READONLY_SCHEMA, new TextSearchProvider())

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -636,16 +636,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   // Gather the proposed APIs we will register to use when building with enableProposedApi = true
   const proposed = [
-    packageJson.enableProposedApi && typeof vscode.workspace.registerFileSearchProvider === "function"
+    packageJson.enableProposedApi &&
+    packageJson.enabledApiProposals.includes("fileSearchProvider") &&
+    typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerFileSearchProvider === "function"
+    packageJson.enableProposedApi &&
+    packageJson.enabledApiProposals.includes("fileSearchProvider") &&
+    typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_READONLY_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerTextSearchProvider === "function"
+    packageJson.enableProposedApi &&
+    packageJson.enabledApiProposals.includes("textSearchProvider") &&
+    typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_SCHEMA, new TextSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerTextSearchProvider === "function"
+    packageJson.enableProposedApi &&
+    packageJson.enabledApiProposals.includes("textSearchProvider") &&
+    typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_READONLY_SCHEMA, new TextSearchProvider())
       : null,
   ].filter(notNull);


### PR DESCRIPTION
This PR fixes an issue where beta and dev vsix's cannot be activated with proposed APIs disabled.

See #781, starting from https://github.com/intersystems-community/vscode-objectscript/issues/781#issuecomment-997830201 for how this issue manifests.