### PR TITLE
Add default file icons

### DIFF
--- a/images/fileIcon.svg
+++ b/images/fileIcon.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="32px" height="32px" viewBox="0 0 24 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 61.2 (89653) - https://sketch.com -->
+    <title>Product icon</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <polygon id="path-1" points="0 0.90625 7.25 0.90625 7.25 27.1875 0 27.1875"></polygon>
+    </defs>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="components/header-no-burger" transform="translate(-7.000000, -10.000000)">
+            <g id="left" transform="translate(-1.000000, 4.000000)">
+                <g id="logos/icon-HS" transform="translate(8.000000, 6.000000)">
+                    <g id="Icon" stroke-width="1">
+                        <polygon id="Fill-1" points="0 32 32 32 32 0 0 0"></polygon>
+                    </g>
+                    <g id="Group-26" stroke-width="1" transform="translate(8.156250, 1.812500)">
+                        <mask id="mask-2" fill="white">
+                            <use xlink:href="#path-1"></use>
+                        </mask>
+                        <g id="Clip-25"></g>
+                        <polygon id="Fill-24" fill="#323694" mask="url(#mask-2)" points="3.625 2.6957654 0 0.90625 0 23.6084692 7.25 27.1875 7.25 23.1881793 3.625 21.3994848"></polygon>
+                    </g>
+                    <polygon id="Fill-27" fill="#00B4AE" points="15.40625 25.335428 19.03125 27.1875 19.03125 3.70074728 11.78125 0 11.78125 4.13637908 15.40625 5.98675272"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -417,7 +417,11 @@
         "extensions": [
           ".mac",
           ".int"
-        ]
+        ],
+        "icon": {
+          "dark": "./images/fileIcon.svg",
+          "light": "./images/fileIcon.svg"
+        }
       },
       {
         "id": "objectscript-class",
@@ -426,7 +430,11 @@
         ],
         "extensions": [
           ".cls"
-        ]
+        ],
+        "icon": {
+          "dark": "./images/fileIcon.svg",
+          "light": "./images/fileIcon.svg"
+        }
       },
       {
         "id": "objectscript-macros",
@@ -435,7 +443,11 @@
         ],
         "extensions": [
           ".inc"
-        ]
+        ],
+        "icon": {
+          "dark": "./images/fileIcon.svg",
+          "light": "./images/fileIcon.svg"
+        }
       },
       {
         "id": "objectscript-csp",
@@ -445,7 +457,11 @@
         "extensions": [
           ".csp",
           ".csr"
-        ]
+        ],
+        "icon": {
+          "dark": "./images/fileIcon.svg",
+          "light": "./images/fileIcon.svg"
+        }
       },
       {
         "id": "vscode-objectscript-output",

--- a/package.json
+++ b/package.json
@@ -418,7 +418,11 @@
         ],
         "extensions": [
           ".mac"
-        ]
+        ],
+        "icon": {
+          "dark": "./images/fileIcon.svg",
+          "light": "./images/fileIcon.svg"
+        }
       },
       {
         "id": "objectscript-int",


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/140047 adds the ability to provide default file icons for contributed languages. This PR adds the InterSystems logo as the default file icon for all of our contributed languages (classes, routines, includes and CSP/CSR). Unfortunately, the Salesforce cloud will still be the file icon for `.cls` files because it comes from the default [Seti file icon theme](https://github.com/jesseweed/seti-ui). Once this PR gets approved we should consider opening a PR in that repo that uses this icon for `.mac`, `.int`,  `.inc`, `.csp` and `.csr` files so nobody else beats us to them.

EDIT: I've included some screenshots below.

This is the current behavior:
<img width="266" alt="Screen Shot 2022-01-13 at 10 07 59 AM" src="https://user-images.githubusercontent.com/44776135/149396805-2ee3e804-fce4-4422-854e-6274ba7ad0a5.png">
This is with this PR using a dark theme:
<img width="315" alt="Screen Shot 2022-01-13 at 1 20 54 PM" src="https://user-images.githubusercontent.com/44776135/149396882-f04edeab-accb-4a99-9b04-2058b40f878c.png">
This is with this PR using a light theme:
<img width="315" alt="Screen Shot 2022-01-13 at 1 21 08 PM" src="https://user-images.githubusercontent.com/44776135/149396892-d31b5610-cf3d-4601-99e2-7ca5ff1ad77e.png">

