### PR TITLE
Merge 1.4.1 release changes into prerelease branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [1.4.1] 14-Jan-2022
+- Fixes
+  - Version 1.4.0 is failing to activate (#827)
+
 ## [1.4.0] 14-Jan-2022
 - Enhancements
   - Make `Ctrl / Cmd+T` lookup (Open Symbol by Name) check all servers connected to a multi-root workspace (#815)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [1.4.0] 14-Jan-2022
+- Enhancements
+  - Make `Ctrl / Cmd+T` lookup (Open Symbol by Name) check all servers connected to a multi-root workspace (#815)
+  - Improve exporting (#818)
+  - Improve client-side DFI workflow (#808)
+  - Improve behavior when no Source Control class is enabled (#171)
+- Fixes
+  - Displace incorrectly-published pre-release version.
+  - Point to correct line when debugging through code with multi-line method arguments (#804)
+  - Show menu options from correct namespace for `Studio Actions` in ObjectScript Explorer (#812)
+  - Fix `Attempted Edit` Studio Action handling (#781)
+  - Properly return options for the Server Command menu for isfs-readonly files (#811)
+  - Remove `vscode-objectscript-output` language from selector (#805)
+
 ## [1.2.2] 07-Dec-2021
 - Fixes
   - Exporting not working with new version 1.2.1 (#799)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a pre-release which improves security as follows:
 - Export of existing server sources into a working folder:
   - open Command Palette (<kbd>F1</kbd> or <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd>)
   - start typing 'ObjectScript'
-  - choose `ObjectScript: Export Sources`
+  - choose `ObjectScript: Export Code from Server`
   - press <kbd>Enter</kbd>
 - Save and compile a class:
   - press <kbd>⌘</kbd>/<kbd>Ctrl</kbd>+<kbd>F7</kbd>
@@ -62,8 +62,8 @@ To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
 	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `1.2.2`, look for `1.2.3-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-1.2.3-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `1.4.0`, look for `1.4.1-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+	- Download the VSIX file (for example `vscode-objectscript-1.4.1-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
 	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `1.4.0`, look for `1.4.1-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-1.4.1-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `1.4.1`, look for `1.4.2-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+	- Download the VSIX file (for example `vscode-objectscript-1.4.2-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):

--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -45,7 +45,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | |
 | `"objectscript.export.category"` | Category of source code to export: `CLS` = classes; `RTN` = routines; `CSP` = csp files; `OTH` = other. Default is `*` = all. | `string` or `object` | `"*"` | |
 | `"objectscript.export.dontExportIfNoChanges"` | Do not rewrite the local file if the content is identical to what came from the server. | `boolean` | `false` | |
-| `"objectscript.export.filter"` | SQL filter to limit what to export. | `string` | `""` | |
+| `"objectscript.export.filter"` | SQL filter to limit what to export. | `string` | `""` | The filter is applied to document names using the [LIKE predicate](https://irisdocs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_like) (i.e. `Name LIKE '%filter%'`). |
 | `"objectscript.export.folder"` | Folder for exported source code within workspace. | `string` | `"src"` | |
 | `"objectscript.export.generated"` | Export generated source code files, such as INTs generated from classes. | `boolean` | `false` | |
 | `"objectscript.export.map"` | Map file names before export, with regexp pattern as a key and replacement as a value. | `object` | `{}` | For example, `{  \"%(.*)\": \"_$1\" }` to make % classes or routines use underscore prefix instead. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "1.3.2021121001",
+  "version": "1.5.2022011402",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "1.3.2021121001",
+      "version": "1.5.2022011402",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-objectscript",
   "displayName": "InterSystems ObjectScript",
   "description": "InterSystems ObjectScript language support for Visual Studio Code",
-  "version": "1.5.2022011401",
+  "version": "1.5.2022011402",
   "icon": "images/logo.png",
   "aiKey": "9cd75d51-697c-406c-a929-2bcf46e97c64",
   "categories": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-objectscript",
   "displayName": "InterSystems ObjectScript",
   "description": "InterSystems ObjectScript language support for Visual Studio Code",
-  "version": "1.3.2022011401",
+  "version": "1.5.2022011401",
   "icon": "images/logo.png",
   "aiKey": "9cd75d51-697c-406c-a929-2bcf46e97c64",
   "categories": [
@@ -232,6 +232,10 @@
         {
           "command": "vscode-objectscript.showClassDocumentationPreview",
           "when": "editorLangId == objectscript-class"
+        },
+        {
+          "command": "vscode-objectscript.exportCurrentFile",
+          "when": "resourceScheme == objectscript && vscode-objectscript.connectActive"
         }
       ],
       "view/title": [
@@ -332,6 +336,11 @@
           "command": "vscode-objectscript.compileOnly",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
           "group": "objectscript@7"
+        },
+        {
+          "command": "vscode-objectscript.exportCurrentFile",
+          "when": "resourceScheme == objectscript && vscode-objectscript.connectActive",
+          "group": "objectscript@8"
         }
       ],
       "editor/title": [
@@ -439,6 +448,7 @@
       },
       {
         "id": "vscode-objectscript-output",
+        "aliases": [],
         "mimetypes": [
           "text/x-code-output"
         ]
@@ -495,7 +505,7 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.export",
-        "title": "Export Sources",
+        "title": "Export Code from Server",
         "enablement": "!isWeb"
       },
       {
@@ -693,6 +703,12 @@
         "title": "Show Class Documentation Preview",
         "enablement": "!isWeb",
         "icon": "$(open-preview)"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.exportCurrentFile",
+        "title": "Export Current File from Server",
+        "enablement": "!isWeb"
       }
     ],
     "keybindings": [
@@ -893,7 +909,7 @@
               "type": "boolean"
             },
             "filter": {
-              "description": "SQL filter to limit what to export.",
+              "markdownDescription": "SQL filter to limit what to export. The filter is applied to document names using the [LIKE predicate](https://irisdocs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_like) (i.e. `Name LIKE '%filter%'`).",
               "type": "string"
             },
             "category": {

--- a/src/explorer/models/rootNode.ts
+++ b/src/explorer/models/rootNode.ts
@@ -6,7 +6,6 @@ import { RoutineNode } from "./routineNode";
 import { AtelierAPI } from "../../api";
 import { ClassNode } from "./classNode";
 import { CSPFileNode } from "./cspFileNode";
-import { StudioOpenDialog } from "../../queries";
 
 type IconPath =
   | string
@@ -58,9 +57,12 @@ export class RootNode extends NodeBase {
     return this.getItems(path, this._category);
   }
 
-  public getList(path: string, category: string, flat: boolean): Promise<(StudioOpenDialog & { fullName: string })[]> {
-    const sql = "CALL %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?)";
-    // const sql = "CALL %Library.RoutineMgr_StudioOpenDialog(?,,,,,,?)";
+  public getList(
+    path: string,
+    category: string,
+    flat: boolean
+  ): Promise<{ Name: string; Type: string; fullName: string }[]> {
+    const sql = "SELECT Name, Type FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?)";
     let spec = "";
     switch (category) {
       case "CLS":
@@ -102,7 +104,7 @@ export class RootNode extends NodeBase {
         return content;
       })
       .then((data) =>
-        data.map((el: StudioOpenDialog) => {
+        data.map((el: { Name: string; Type: number }) => {
           let fullName = el.Name;
           if (this instanceof PackageNode) {
             fullName = this.fullName + "." + el.Name;
@@ -110,7 +112,8 @@ export class RootNode extends NodeBase {
             fullName = this.fullName + "/" + el.Name;
           }
           return {
-            ...el,
+            Name: el.Name,
+            Type: String(el.Type),
             fullName,
           };
         })

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import {
   compileOnly,
 } from "./commands/compile";
 import { deleteExplorerItems } from "./commands/delete";
-import { exportAll, exportExplorerItems } from "./commands/export";
+import { exportAll, exportCurrentFile, exportExplorerItems } from "./commands/export";
 import { serverActions } from "./commands/serverActions";
 import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
@@ -652,18 +652,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   const diagnosticProvider = new ObjectScriptDiagnosticProvider();
 
-  // Gather the proposed APIs we will register to use when building with enableProposedApi = true
+  // Gather the proposed APIs we will register to use when building with enabledApiProposals != []
   const proposed = [
-    packageJson.enableProposedApi && typeof vscode.workspace.registerFileSearchProvider === "function"
+    packageJson.enabledApiProposals.includes("fileSearchProvider") &&
+    typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerFileSearchProvider === "function"
+    packageJson.enabledApiProposals.includes("fileSearchProvider") &&
+    typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_READONLY_SCHEMA, new FileSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerTextSearchProvider === "function"
+    packageJson.enabledApiProposals.includes("textSearchProvider") &&
+    typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_SCHEMA, new TextSearchProvider())
       : null,
-    packageJson.enableProposedApi && typeof vscode.workspace.registerTextSearchProvider === "function"
+    packageJson.enabledApiProposals.includes("textSearchProvider") &&
+    typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_READONLY_SCHEMA, new TextSearchProvider())
       : null,
   ].filter(notNull);
@@ -947,6 +951,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.showClassDocumentationPreview", () =>
       DocumaticPreviewPanel.create(context.extensionUri)
     ),
+    vscode.commands.registerCommand("vscode-objectscript.exportCurrentFile", exportCurrentFile),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -654,18 +654,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   // Gather the proposed APIs we will register to use when building with enabledApiProposals != []
   const proposed = [
+    typeof packageJson.enabledApiProposals === "object" &&
     packageJson.enabledApiProposals.includes("fileSearchProvider") &&
     typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_SCHEMA, new FileSearchProvider())
       : null,
+    typeof packageJson.enabledApiProposals === "object" &&
     packageJson.enabledApiProposals.includes("fileSearchProvider") &&
     typeof vscode.workspace.registerFileSearchProvider === "function"
       ? vscode.workspace.registerFileSearchProvider(FILESYSTEM_READONLY_SCHEMA, new FileSearchProvider())
       : null,
+    typeof packageJson.enabledApiProposals === "object" &&
     packageJson.enabledApiProposals.includes("textSearchProvider") &&
     typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_SCHEMA, new TextSearchProvider())
       : null,
+    typeof packageJson.enabledApiProposals === "object" &&
     packageJson.enabledApiProposals.includes("textSearchProvider") &&
     typeof vscode.workspace.registerTextSearchProvider === "function"
       ? vscode.workspace.registerTextSearchProvider(FILESYSTEM_READONLY_SCHEMA, new TextSearchProvider())

--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -1,6 +1,5 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
-import { currentWorkspaceFolder } from "../utils";
 import { DocumentContentProvider } from "./DocumentContentProvider";
 
 export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
@@ -27,59 +26,154 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
     "SELECT Name, Parent->ID AS Parent, 'projection' AS Type FROM %Dictionary.ProjectionDefinition" +
     ") WHERE %SQLUPPER Name %MATCHES ?";
 
-  public provideWorkspaceSymbols(query: string): vscode.ProviderResult<vscode.SymbolInformation[]> {
+  private sqlNoSystem: string =
+    "SELECT dict.Name, dict.Parent, dict.Type FROM (" +
+    "SELECT Name, Parent->ID AS Parent, 'method' AS Type FROM %Dictionary.MethodDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'property' AS Type FROM %Dictionary.PropertyDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'parameter' AS Type FROM %Dictionary.ParameterDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'index' AS Type FROM %Dictionary.IndexDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'foreignkey' AS Type FROM %Dictionary.ForeignKeyDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'xdata' AS Type FROM %Dictionary.XDataDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'query' AS Type FROM %Dictionary.QueryDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'trigger' AS Type FROM %Dictionary.TriggerDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'storage' AS Type FROM %Dictionary.StorageDefinition" +
+    " UNION ALL %PARALLEL " +
+    "SELECT Name, Parent->ID AS Parent, 'projection' AS Type FROM %Dictionary.ProjectionDefinition" +
+    ") AS dict, (" +
+    "SELECT Name FROM %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?)" +
+    ") AS sod WHERE %SQLUPPER dict.Name %MATCHES ? AND {fn CONCAT(dict.Parent,'.cls')} = sod.Name";
+
+  private queryResultToSymbols(data: any, folderUri: vscode.Uri) {
+    const result = [];
+    const uris: Map<string, vscode.Uri> = new Map();
+    for (const element of data.result.content) {
+      const kind: vscode.SymbolKind = (() => {
+        switch (element.Type) {
+          case "query":
+          case "method":
+            return vscode.SymbolKind.Method;
+          case "parameter":
+            return vscode.SymbolKind.Constant;
+          case "index":
+            return vscode.SymbolKind.Key;
+          case "xdata":
+          case "storage":
+            return vscode.SymbolKind.Struct;
+          case "property":
+          default:
+            return vscode.SymbolKind.Property;
+        }
+      })();
+
+      let uri: vscode.Uri;
+      if (uris.has(element.Parent)) {
+        uri = uris.get(element.Parent);
+      } else {
+        uri = DocumentContentProvider.getUri(`${element.Parent}.cls`, undefined, undefined, undefined, folderUri);
+        uris.set(element.Parent, uri);
+      }
+
+      result.push({
+        name: element.Name,
+        containerName:
+          element.Type === "foreignkey" ? "ForeignKey" : element.Type.charAt(0).toUpperCase() + element.Type.slice(1),
+        kind,
+        location: {
+          uri,
+        },
+      });
+    }
+    return result;
+  }
+
+  public async provideWorkspaceSymbols(query: string): Promise<vscode.SymbolInformation[]> {
     if (query.length === 0) {
       return null;
     }
+    // Convert query to a %MATCHES compatible pattern
     let pattern = "";
     for (let i = 0; i < query.length; i++) {
       const char = query.charAt(i);
       pattern += char === "*" || char === "?" ? `*\\${char}` : `*${char}`;
     }
-    const workspace = currentWorkspaceFolder();
-    const api = new AtelierAPI(workspace);
-    return api.actionQuery(this.sql, [pattern.toUpperCase() + "*"]).then((data) => {
-      const result = [];
-      const uris: Map<string, vscode.Uri> = new Map();
-      for (const element of data.result.content) {
-        const kind: vscode.SymbolKind = (() => {
-          switch (element.Type) {
-            case "query":
-            case "method":
-              return vscode.SymbolKind.Method;
-            case "parameter":
-              return vscode.SymbolKind.Constant;
-            case "index":
-              return vscode.SymbolKind.Key;
-            case "xdata":
-            case "storage":
-              return vscode.SymbolKind.Struct;
-            case "property":
-            default:
-              return vscode.SymbolKind.Property;
-          }
-        })();
-
-        let uri: vscode.Uri;
-        if (uris.has(element.Parent)) {
-          uri = uris.get(element.Parent);
-        } else {
-          uri = DocumentContentProvider.getUri(`${element.Parent}.cls`, workspace);
-          uris.set(element.Parent, uri);
-        }
-
-        result.push({
-          name: element.Name,
-          containerName:
-            element.Type === "foreignkey" ? "ForeignKey" : element.Type.charAt(0).toUpperCase() + element.Type.slice(1),
-          kind,
-          location: {
-            uri,
-          },
+    pattern = pattern.toUpperCase() + "*";
+    // Filter the folders to search so we don't query the same ns on the same server twice
+    const serversToQuery: {
+      api: AtelierAPI;
+      uri: vscode.Uri;
+      system: boolean;
+    }[] = [];
+    for (const folder of vscode.workspace.workspaceFolders) {
+      const folderApi = new AtelierAPI(folder.uri);
+      const found = serversToQuery.findIndex(
+        (server) =>
+          server.api.config.host.toLowerCase() === folderApi.config.host.toLowerCase() &&
+          server.api.config.port === folderApi.config.port &&
+          server.api.config.pathPrefix.toLowerCase() === folderApi.config.pathPrefix.toLowerCase() &&
+          server.api.config.ns.toLowerCase() === folderApi.config.ns.toLowerCase()
+      );
+      if (found === -1) {
+        serversToQuery.push({
+          api: folderApi,
+          uri: folder.uri,
+          system: true,
         });
+      } else if (serversToQuery[found].uri.scheme.startsWith("isfs") && !folder.uri.scheme.startsWith("isfs")) {
+        // If we have multiple folders connected to the same server and ns
+        // and one is not isfs, keep the non-isfs one
+        serversToQuery[found].uri = folder.uri;
       }
-      return result;
+    }
+    serversToQuery.map((server) => {
+      if (server.api.config.ns.toLowerCase() !== "%sys") {
+        const found = serversToQuery.findIndex(
+          (server2) =>
+            server2.api.config.host.toLowerCase() === server.api.config.host.toLowerCase() &&
+            server2.api.config.port === server.api.config.port &&
+            server2.api.config.pathPrefix.toLowerCase() === server.api.config.pathPrefix.toLowerCase() &&
+            server2.api.config.ns.toLowerCase() === "%sys"
+        );
+        if (found !== -1) {
+          server.system = false;
+        }
+      }
+      return server;
     });
+    return Promise.allSettled(
+      serversToQuery
+        .map((server) => {
+          // Set the system property so we don't show system items multiple times if this
+          // workspace is connected to both the %SYS and a non-%SYS namespace on the same server
+          if (server.api.config.ns.toLowerCase() !== "%sys") {
+            const found = serversToQuery.findIndex(
+              (server2) =>
+                server2.api.config.host.toLowerCase() === server.api.config.host.toLowerCase() &&
+                server2.api.config.port === server.api.config.port &&
+                server2.api.config.pathPrefix.toLowerCase() === server.api.config.pathPrefix.toLowerCase() &&
+                server2.api.config.ns.toLowerCase() === "%sys"
+            );
+            if (found !== -1) {
+              server.system = false;
+            }
+          }
+          return server;
+        })
+        .map((server) =>
+          server.system
+            ? server.api.actionQuery(this.sql, [pattern]).then((data) => this.queryResultToSymbols(data, server.uri))
+            : server.api
+                .actionQuery(this.sqlNoSystem, ["*.cls", "1", "1", "0", "1", "0", "0", pattern])
+                .then((data) => this.queryResultToSymbols(data, server.uri))
+        )
+    ).then((results) => results.flatMap((result) => (result.status === "fulfilled" ? result.value : [])));
   }
 
   resolveWorkspaceSymbol(symbol: vscode.SymbolInformation): vscode.ProviderResult<vscode.SymbolInformation> {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -29,7 +29,7 @@ async function main() {
     installExtension("intersystems-community.servermanager");
     installExtension("intersystems.language-server");
 
-    const launchArgs = ["-n", workspace];
+    const launchArgs = ["-n", workspace, "--enable-proposed-api", "intersystems-community.vscode-objectscript"];
 
     // Download VS Code, unzip it and run the integration test
     await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs });


### PR DESCRIPTION
Earlier I created a new branch called **prerelease** from the source that I erroneously published manually to Marketplace today as 1.3.2022011401 after a `vsce package` command that omitted the `--pre-release` switch.

This PR updates that branch with the fixes and enhancements we released today as 1.4.1

The prerelease branch is intended to be long-living. In future it'd be good to add CI so we can publish pre-releases more automatically from this, which should ensure the `--pre-release` switch doesn't get forgotten again.