### PR TITLE
Colorize VSCode ObjectScript Output

### DIFF
--- a/package.json
+++ b/package.json
@@ -490,6 +490,11 @@
         "language": "objectscript-csp",
         "scopeName": "source.objectscript_csp",
         "path": "syntaxes/objectscript-csp.tmLanguage.json"
+      },
+      {
+        "language": "vscode-objectscript-output",
+        "scopeName": "source.vscode_objectscript_output",
+        "path": "syntaxes/vscode-objectscript-output.tmLanguage.json"
       }
     ],
     "snippets": [

--- a/package.json
+++ b/package.json
@@ -450,10 +450,7 @@
       },
       {
         "id": "vscode-objectscript-output",
-        "aliases": [],
-        "mimetypes": [
-          "text/x-vscode-objectscript-output"
-        ]
+        "aliases": []
       }
     ],
     "grammars": [

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "enableProposedApi": true,
   "enabledApiProposals": [
     "fileSearchProvider",
-    "textSearchProvider"
+    "textSearchProvider",
+    "outputChannelLanguage"
   ],
   "activationEvents": [
     "onDebug",
@@ -451,7 +452,7 @@
         "id": "vscode-objectscript-output",
         "aliases": [],
         "mimetypes": [
-          "text/x-code-output"
+          "text/x-vscode-objectscript-output"
         ]
       }
     ],

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,14 +4,19 @@ import { R_OK } from "constants";
 import * as url from "url";
 import { exec } from "child_process";
 import * as vscode from "vscode";
-import { config, schemas, workspaceState, terminals } from "../extension";
+import { config, schemas, workspaceState, terminals, extensionId } from "../extension";
 import { getCategory } from "../commands/export";
+const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 
 let latestErrorMessage = "";
 export const outputChannel: {
   resetError?(): void;
   appendError?(value: string, show?: boolean): void;
-} & vscode.OutputChannel = vscode.window.createOutputChannel("ObjectScript");
+} & vscode.OutputChannel =
+  typeof packageJson.enabledApiProposals === "object" &&
+  packageJson.enabledApiProposals.includes("outputChannelLanguage")
+    ? vscode.window.createOutputChannel("ObjectScript", "vscode-objectscript-output")
+    : vscode.window.createOutputChannel("ObjectScript");
 
 /// Append Error if no duplicates previous one
 outputChannel.appendError = (value: string, show = true): void => {

--- a/syntaxes/vscode-objectscript-output.tmLanguage.json
+++ b/syntaxes/vscode-objectscript-output.tmLanguage.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "vscode-objectscript-output",
+  "scopeName": "source.vscode_objectscript_output",
+  "patterns": [
+    {
+      "match": "^\\s*(?:\\> )?(?:ERROR).*\\#\\d+\\:",
+      "name": "invalid"
+    },
+    {
+      "match": "^\\s*(?:ERROR)\\s*\\:",
+      "name": "invalid"
+    },
+    {
+      "match": "^\\s*(?:Authorization error\\:)",
+      "name": "invalid"
+    },
+    {
+      "match": "^Detected \\d+ errors during compilation in \\S+",
+      "name": "invalid"
+    },
+    {
+      "match": "^Compilation finished successfully in \\S+",
+      "name": "markup.bold"
+    },
+    {
+      "match": "(?<=^Compiling (?:class|routine|file|table) \\:? ?)[^\\:\\s]+",
+      "name": "entity.name.class"
+    },
+    {
+      "match": "(?<=^Deleting (?:class|routine|file|table) )\\S+",
+      "name": "entity.name.class"
+    },
+    {
+      "match": "(?<=^Dropping orphaned procedure\\: )\\S+",
+      "name": "entity.name.class"
+    },
+    {
+      "match": "(?<=^\\s*ERROR\\:\\s*)\\S+",
+      "name": "entity.name.class"
+    },
+    {
+      "match": "\"(.*?)\"",
+      "name": "string.quoted"
+    },
+    {
+      "match": "'(.*?)'",
+      "name": "string.quoted"
+    },
+    {
+      "match": "\\b(((0|1)?[0-9][1-2]?)|(Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|Jul(y)?|Aug(ust)?|Sept(ember)?|Oct(ober)?|Nov(ember)?|Dec(ember)?))[/|\\-|\\.| ]([0-2]?[0-9]|[3][0-1])[/|\\-|\\.| ]((19|20)?[0-9]{2})\\b",
+      "name": "constant.numeric"
+    },
+    {
+      "match": "\\b((19|20)?[0-9]{2}[/|\\-|\\.| ](((0|1)?[0-9][1-2]?)|(Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|Jul(y)?|Aug(ust)?|Sept(ember)?|Oct(ober)?|Nov(ember)?|Dec(ember)?))[/|\\-|\\.| ]([0-2]?[0-9]|[3][0-1]))\\b",
+      "name": "constant.numeric"
+    },
+    {
+      "match": "\\b([0-2]?[0-9]|[3][0-1])[/|\\-|\\.| ](((0|1)?[0-9][1-2]?)|(Jan(uary)?|Feb(ruary)?|Mar(ch)?|Apr(il)?|May|Jun(e)?|Jul(y)?|Aug(ust)?|Sept(ember)?|Oct(ober)?|Nov(ember)?|Dec(ember)?))[/|\\-|\\.| ]((19|20)?[0-9]{2})\\b",
+      "name": "constant.numeric"
+    },
+    {
+      "match": "\\b([0|1]?[0-9]|2[0-3])\\:[0-5][0-9](\\:[0-5][0-9])?( ?(?i:(a|p)m?))?( ?[+-]?[0-9]*)?\\b",
+      "name": "constant.numeric"
+    },
+    {
+      "match": "\\b\\d+\\.?\\d*?\\b",
+      "name": "constant.numeric"
+    },
+    {
+      "match": "\\b(?i:(0?x)?[0-9a-f][0-9a-f]+)\\b",
+      "name": "constant.numeric"
+    }
+  ]
+}

--- a/syntaxes/vscode-objectscript-output.tmLanguage.json
+++ b/syntaxes/vscode-objectscript-output.tmLanguage.json
@@ -36,6 +36,14 @@
       "name": "entity.name.class"
     },
     {
+      "match": "(?<=^(?:Class|Routine|File|Table) )\\S+(?= is up-to-date\\.)",
+      "name": "entity.name.class"
+    },
+    {
+      "match": "\\S+(?= is up to date\\. Compile of this item skipped\\.)",
+      "name": "entity.name.class"
+    },
+    {
       "match": "(?<=^\\s*ERROR\\:\\s*)\\S+",
       "name": "entity.name.class"
     },


### PR DESCRIPTION
This PR adds functionality to colorize the VSCode ObjectScript output window, including displaying different colors for:
- Successful compilation
- Errored compilation
- Individual errors ('ERROR:', etc. prefixes)
- ObjectScript authorization error
- Classes/routines/file names in compilation status
- Quoted strings, numbers, dates/times

Examples:
![colorize-output-1](https://user-images.githubusercontent.com/5865451/149788316-9eefe25b-23ed-4ed7-a43a-32d29e48aa91.JPG)
![colorize-output-2](https://user-images.githubusercontent.com/5865451/149788332-3975719d-e60d-4b56-b1f5-07ce87c594fd.JPG)
![colorize-output-3](https://user-images.githubusercontent.com/5865451/149788388-c8caaeff-8671-4d7f-953e-dc79ff56d7a1.JPG)
![colorize-output-4](https://user-images.githubusercontent.com/5865451/149788400-c7a3866a-49fd-40cc-bb74-8e0bb10de52c.jpg)
![colorize-output-5](https://user-images.githubusercontent.com/5865451/149788407-75873960-1c34-45af-92ae-71ddedbf7bdd.jpg)

