### PR TITLE
Allow serverForUri to return password for unnamed server (#837)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ on:
     branches:
       - master
   release:
+    branches:
+      - master
     types:
       - released
 jobs:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -968,11 +968,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       const { apiTarget } = connectionTarget(uri);
       const api = new AtelierAPI(apiTarget);
 
-      // We explicitly no longer expose the password.
+      // We explicitly no longer expose the password for named servers.
       // API client extensions can use Server Manager 3's authentication provider to get this,
       // which will require user consent.
 
-      const { serverName, active, host = "", https, port, pathPrefix, username, ns = "", apiVersion } = api.config;
+      const {
+        serverName,
+        active,
+        host = "",
+        https,
+        port,
+        pathPrefix,
+        username,
+        password,
+        ns = "",
+        apiVersion,
+      } = api.config;
       return {
         serverName,
         active,
@@ -981,7 +992,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         port,
         pathPrefix,
         username,
-        password: undefined,
+        password: serverName === "" ? password : undefined,
         namespace: ns,
         apiVersion: active ? apiVersion : undefined,
       };


### PR DESCRIPTION
This PR fixes #837

@isc-bsaviano please use the dev VSIX to verify that this meets the need without exposing passwords that may have come from Server Manager's authentication provider.