### PR TITLE
Switch to `node-fetch-cjs` (fixes #841)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "vscode-objectscript",
       "version": "1.4.2-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
@@ -16,7 +17,7 @@
         "glob": "^7.1.6",
         "iconv-lite": "^0.6.0",
         "mkdirp": "^1.0.4",
-        "node-fetch": "3.1.1",
+        "node-fetch-cjs": "3.1.1",
         "vscode-cache": "^0.3.0",
         "vscode-debugadapter": "^1.41.0",
         "vscode-debugprotocol": "^1.41.0",
@@ -1367,14 +1368,6 @@
       "integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
       "dev": true
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -2184,27 +2177,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2268,17 +2240,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -3594,15 +3555,10 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/node-fetch": {
+    "node_modules/node-fetch-cjs": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
-      },
+      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.1.1.tgz",
+      "integrity": "sha512-YOMqQ94r/1o95JS3yFye1czAVY6i3xreA6tsNnloLCKJKbfFMxgkhsLH0yYI0vWXBZmEQ80l66ue6UqFAgVv2g==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -4922,14 +4878,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -6287,11 +6235,6 @@
       "integrity": "sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==",
       "dev": true
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -6914,14 +6857,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "fetch-blob": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.1.3.tgz",
-      "integrity": "sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==",
-      "requires": {
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -6970,14 +6905,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
       "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
       "dev": true
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -7923,15 +7850,10 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node-fetch": {
+    "node-fetch-cjs": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.1.1.tgz",
-      "integrity": "sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.3",
-        "formdata-polyfill": "^4.0.10"
-      }
+      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.1.1.tgz",
+      "integrity": "sha512-YOMqQ94r/1o95JS3yFye1czAVY6i3xreA6tsNnloLCKJKbfFMxgkhsLH0yYI0vWXBZmEQ80l66ue6UqFAgVv2g=="
     },
     "node-releases": {
       "version": "2.0.1",
@@ -8904,11 +8826,6 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.0.tgz",
-      "integrity": "sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA=="
     },
     "webidl-conversions": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1189,7 +1189,7 @@
     "glob": "^7.1.6",
     "iconv-lite": "^0.6.0",
     "mkdirp": "^1.0.4",
-    "node-fetch": "3.1.1",
+    "node-fetch-cjs": "3.1.1",
     "vscode-cache": "^0.3.0",
     "vscode-debugadapter": "^1.41.0",
     "vscode-debugprotocol": "^1.41.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,8 +1,6 @@
-// import fetch from "node-fetch";
-// mod.cjs
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const fetch = (...args) => import("node-fetch").then(({ default: fetch }) => fetch(...args));
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { default: fetch } = require("node-fetch-cjs");
+
 import * as httpModule from "http";
 import * as httpsModule from "https";
 import * as url from "url";


### PR DESCRIPTION
This PR fixes #841

A recent security upgrade of node-fetch broke our webpacked VSIX. Solution is to use the node-fetch-cjs wrapper, a helper for CommonJS projects.

In the future, when VS Code get a newer Node.JS version by moving to a newer Electron we may be able to switch back to using node-fetch if required.