### PR TITLE
CI release action must only publish one type of vsix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,6 @@ on:
     branches:
       - master
   release:
-    branches:
-      - master
     types:
       - released
 jobs:
@@ -25,9 +23,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+    outputs:
+      taggedbranch: ${{ steps.find-branch.outputs.taggedbranch }}
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Find which branch the release tag points at
+        id: find-branch
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        shell: bash
+        run: |
+          git fetch --depth=1 origin +refs/heads/*:refs/heads/*
+          set -x
+          TAGGEDBRANCH=$(git for-each-ref --points-at=${{github.sha}} --format='%(refname:lstrip=2)' refs/heads/)
+          echo ::set-output name=taggedbranch::$TAGGEDBRANCH
       - name: Set an output
         id: set-version
         if: runner.os == 'Linux'
@@ -67,7 +76,7 @@ jobs:
         run: |
           npx vsce package -o ${{ steps.set-version.outputs.name }}.vsix
       - uses: actions/upload-artifact@v2
-        if: runner.os == 'Linux'
+        if: (runner.os == 'Linux') && (github.event_name != 'release')
         with:
           name: ${{ steps.set-version.outputs.name }}.vsix
           path: ${{ steps.set-version.outputs.name }}.vsix
@@ -122,9 +131,9 @@ jobs:
           asset_name: ${{ steps.set-version.outputs.name }}.vsix
           asset_content_type: application/zip
   publish:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'release' && needs.build.outputs.taggedbranch == 'master'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -14,8 +14,6 @@ on:
     branches:
       - prerelease
   release:
-    branches:
-      - prerelease
     types:
       - released
 jobs:
@@ -25,9 +23,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
+    outputs:
+      taggedbranch: ${{ steps.find-branch.outputs.taggedbranch }}
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+      - name: Find which branch the release tag points at
+        id: find-branch
+        if: github.event_name == 'release' && runner.os == 'Linux'
+        shell: bash
+        run: |
+          git fetch --depth=1 origin +refs/heads/*:refs/heads/*
+          set -x
+          TAGGEDBRANCH=$(git for-each-ref --points-at=${{github.sha}} --format='%(refname:lstrip=2)' refs/heads/)
+          echo ::set-output name=taggedbranch::$TAGGEDBRANCH
       - name: Set an output
         id: set-version
         if: runner.os == 'Linux'
@@ -67,7 +76,7 @@ jobs:
         run: |
           npx vsce package --pre-release -o ${{ steps.set-version.outputs.name }}.vsix
       - uses: actions/upload-artifact@v2
-        if: runner.os == 'Linux'
+        if: (runner.os == 'Linux') && (github.event_name != 'release')
         with:
           name: ${{ steps.set-version.outputs.name }}.vsix
           path: ${{ steps.set-version.outputs.name }}.vsix
@@ -122,9 +131,9 @@ jobs:
           asset_name: ${{ steps.set-version.outputs.name }}.vsix
           asset_content_type: application/zip
   publish:
-    if: github.event_name == 'release'
-    runs-on: ubuntu-latest
     needs: build
+    if: github.event_name == 'release' && needs.build.outputs.taggedbranch == 'prerelease'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Publish either a pre-release or an ordinary one, depending on whether the release was tagged in the prerelease branch or the master branch.
