### PR TITLE
Improve `TextSearchProvider`

### DIFF
--- a/src/api/atelier.d.ts
+++ b/src/api/atelier.d.ts
@@ -45,7 +45,7 @@ export interface ServerInfo {
 
 export interface SearchMatch {
   text: string;
-  line?: number;
+  line?: string | number;
   member?: string;
   attr?: string;
   attrline?: number;

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -2,7 +2,23 @@ import * as vscode from "vscode";
 import { SearchResult, SearchMatch } from "../../api/atelier";
 import { AtelierAPI } from "../../api";
 import { DocumentContentProvider } from "../DocumentContentProvider";
-import { outputChannel } from "../../utils";
+import { notNull, outputChannel, throttleRequests } from "../../utils";
+import { config } from "../../extension";
+import { fileSpecFromURI } from "../../utils/FileProviderUtil";
+
+/**
+ * Convert an `attrline` in a description to a line number in `document`.
+ */
+function descLineToDocLine(content: string[], attrline: number, line: number): number {
+  let result = 0;
+  for (let i = line - 1; i >= 0; i--) {
+    if (!content[i].startsWith("///")) {
+      result = i;
+      break;
+    }
+  }
+  return result + attrline;
+}
 
 export class TextSearchProvider implements vscode.TextSearchProvider {
   /**
@@ -21,7 +37,15 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
     const api = new AtelierAPI(options.folder);
     let counter = 0;
     if (!api.enabled) {
-      return null;
+      return {
+        message: {
+          text: "An active server connection is required for searching `isfs` folders.",
+          type: vscode.TextSearchCompleteMessageType.Warning,
+        },
+      };
+    }
+    if (token.isCancellationRequested) {
+      return;
     }
     return api
       .actionSearch({
@@ -29,59 +53,180 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
         regex: query.isRegExp,
         word: query.isWordMatch,
         case: query.isCaseSensitive,
+        files: fileSpecFromURI(options.folder),
         // If options.maxResults is null the search is supposed to return an unlimited number of results
-        // Since there's no way for us to pass "unlimited" to the server, I choose a very large number
+        // Since there's no way for us to pass "unlimited" to the server, I chose a very large number
         max: options.maxResults ?? 100000,
       })
       .then((data) => data.result)
-      .then((files: SearchResult[]) =>
-        files.map(async (file) => {
-          const fileName = file.doc;
-          const uri = DocumentContentProvider.getUri(fileName, "", "", true, options.folder);
-          try {
-            const document = await vscode.workspace.openTextDocument(uri);
-            return {
-              ...file,
-              uri,
-              document,
-            };
-          } catch (_ex) {
-            return null;
-          }
-        })
-      )
-      .then((files) => Promise.all(files))
-      .then((files) => {
-        files.forEach((file) => {
-          const { uri, document, matches } = file;
-          matches.forEach((match: SearchMatch) => {
-            const { text, member } = match;
-            let { line } = match;
-            if (member) {
-              const memberMatchPattern = new RegExp(`((?:Class)?Method|Property|XData|Query|Trigger) ${member}`, "i");
-              for (let i = 0; i < document.lineCount; i++) {
-                const text = document.lineAt(i).text;
-                if (text.match(memberMatchPattern)) {
-                  line = line ? line + i + 1 : i;
-                }
+      .then(async (files: SearchResult[]) => {
+        if (token.isCancellationRequested) {
+          return;
+        }
+        const result = await Promise.allSettled(
+          files.map(
+            throttleRequests(async (file: SearchResult) => {
+              if (token.isCancellationRequested) {
+                throw new vscode.CancellationError();
               }
-            }
-            progress.report({
-              uri,
-              lineNumber: line || 1,
-              text,
+              const uri = DocumentContentProvider.getUri(file.doc, "", "", true, options.folder);
+              const content = await api.getDoc(file.doc).then((data) => <string[]>data.result.content);
+              // Find all lines that we have matches on
+              const lines = file.matches
+                .map((match: SearchMatch) => {
+                  let line = Number(match.line);
+                  if (match.member !== undefined) {
+                    // This is an attribute of a class member
+                    const memberMatchPattern = new RegExp(
+                      `^((?:Class|Client)?Method|Property|XData|Query|Trigger|Parameter|Relationship|Index|ForeignKey|Storage|Projection) ${match.member}`
+                    );
+                    for (let i = 0; i < content.length; i++) {
+                      if (content[i].match(memberMatchPattern)) {
+                        let memend = i + 1;
+                        if (
+                          config("multilineMethodArgs", api.configName) &&
+                          content[i].match(/^(?:Class|Client)?Method|Query /)
+                        ) {
+                          // The class member definition is on multiple lines so update the end
+                          for (let j = i + 1; j < content.length; j++) {
+                            if (content[j].trim() === "{") {
+                              memend = j;
+                              break;
+                            }
+                          }
+                        }
+                        if (match.attr === undefined) {
+                          if (match.line === undefined) {
+                            // This is in the class member definition
+                            line = i;
+                          } else {
+                            // This is in the implementation
+                            line = memend + Number(match.line);
+                          }
+                        } else {
+                          if (match.attrline === undefined) {
+                            // This is in the class member definition
+                            line = 1;
+                          } else {
+                            if (match.attr === "Description") {
+                              // This is in the description
+                              line = descLineToDocLine(content, match.attrline, i);
+                            } else {
+                              // This is in the implementation
+                              line = memend + match.attrline;
+                            }
+                          }
+                        }
+                        break;
+                      }
+                    }
+                  } else if (match.attr !== undefined) {
+                    if (match.attr === "IncludeCode") {
+                      // This is in the Include line
+                      for (let i = 0; i < content.length; i++) {
+                        if (content[i].match(/^Include /)) {
+                          line = i;
+                          break;
+                        }
+                      }
+                    } else if (match.attr === "IncludeGenerator") {
+                      // This is in the IncludeGenerator line
+                      for (let i = 0; i < content.length; i++) {
+                        if (content[i].match(/^IncludeGenerator/)) {
+                          line = i;
+                          break;
+                        }
+                      }
+                    } else if (match.attr === "Import") {
+                      // This is in the Import line
+                      for (let i = 0; i < content.length; i++) {
+                        if (content[i].match(/^Import/)) {
+                          line = i;
+                          break;
+                        }
+                      }
+                    } else {
+                      // This is in the class definition
+                      const classMatchPattern = new RegExp(`^Class ${file.doc.slice(0, file.doc.lastIndexOf("."))}`);
+                      for (let i = 0; i < content.length; i++) {
+                        if (content[i].match(classMatchPattern)) {
+                          if (match.attrline) {
+                            // This is in the class description
+                            line = descLineToDocLine(content, match.attrline, i);
+                          } else {
+                            line = i;
+                          }
+                          break;
+                        }
+                      }
+                    }
+                  }
+                  return typeof line === "number" ? line : null;
+                })
+                .filter(notNull);
+              // Filter out duplicates and compute all matches for each one
+              [...new Set(lines)].forEach((line) => {
+                const text = content[line];
+                const regex = new RegExp(
+                  query.isRegExp ? query.pattern : query.pattern.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&"),
+                  query.isCaseSensitive ? "g" : "gi"
+                );
+                let regexMatch: RegExpExecArray;
+                const matchRanges: vscode.Range[] = [];
+                const previewRanges: vscode.Range[] = [];
+                while ((regexMatch = regex.exec(text)) !== null && counter < options.maxResults) {
+                  const start = regexMatch.index;
+                  const end = start + regexMatch[0].length;
+                  matchRanges.push(new vscode.Range(line, start, line, end));
+                  previewRanges.push(new vscode.Range(0, start, 0, end));
+                  counter++;
+                }
+                if (matchRanges.length && previewRanges.length) {
+                  progress.report({
+                    uri,
+                    ranges: matchRanges,
+                    preview: {
+                      text,
+                      matches: previewRanges,
+                    },
+                  });
+                }
+              });
+            })
+          )
+        );
+        if (token.isCancellationRequested) {
+          return;
+        }
+        let message: vscode.TextSearchCompleteMessage;
+        const rejected = result.filter((r) => r.status == "rejected").length;
+        if (rejected > 0) {
+          outputChannel.appendLine("Search errors:");
+          result
+            .filter((r) => r.status == "rejected")
+            .forEach((r: PromiseRejectedResult) => {
+              outputChannel.appendLine(typeof r.reason == "object" ? r.reason.toString() : String(r.reason));
             });
-            counter++;
-            if (counter >= options.maxResults) {
-              return;
-            }
-          });
-        });
-        return { limitHit: counter >= options.maxResults };
+          message = {
+            text: `Failed to display results from ${rejected} file${
+              rejected > 1 ? "s" : ""
+            }. Check \`ObjectScript\` Output channel for details.`,
+            type: vscode.TextSearchCompleteMessageType.Warning,
+          };
+        }
+        return {
+          limitHit: counter >= options.maxResults,
+          message,
+        };
       })
       .catch((error) => {
-        outputChannel.appendLine(error);
-        return null;
+        outputChannel.appendLine(typeof error == "object" ? error.toString() : String(error));
+        return {
+          message: {
+            text: "An error occurred during the search. Check `ObjectScript` Output channel for details.",
+            type: vscode.TextSearchCompleteMessageType.Warning,
+          },
+        };
       });
   }
 }

--- a/src/utils/FileProviderUtil.ts
+++ b/src/utils/FileProviderUtil.ts
@@ -2,20 +2,12 @@ import * as vscode from "vscode";
 import * as url from "url";
 import { AtelierAPI } from "../api";
 
-export function studioOpenDialogFromURI(
-  uri: vscode.Uri,
-  overrides: { flat?: boolean; filter?: string; type?: string } = { flat: false, filter: "", type: "" }
-): Promise<any> {
-  const api = new AtelierAPI(uri);
-  if (!api.active) {
-    return;
-  }
-  const sql = `CALL %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?)`;
+export function fileSpecFromURI(uri: vscode.Uri, overrideType?: string): string {
   const { query } = url.parse(uri.toString(true), true);
   const csp = query.csp === "" || query.csp === "1";
   const type =
-    overrides.type && overrides.type != ""
-      ? overrides.type
+    overrideType && overrideType != ""
+      ? overrideType
       : query.type && query.type != ""
       ? query.type.toString()
       : csp
@@ -50,7 +42,20 @@ export function studioOpenDialogFromURI(
   } else {
     specOpts = "*.cls,*.inc,*.mac,*.int";
   }
-  const spec = csp ? folder + specOpts : folder.length > 1 ? folder.slice(1) + "/" + specOpts : specOpts;
+  return csp ? folder + specOpts : folder.length > 1 ? folder.slice(1) + "/" + specOpts : specOpts;
+}
+
+export function studioOpenDialogFromURI(
+  uri: vscode.Uri,
+  overrides: { flat?: boolean; filter?: string; type?: string } = { flat: false, filter: "", type: "" }
+): Promise<any> {
+  const api = new AtelierAPI(uri);
+  if (!api.active) {
+    return;
+  }
+  const sql = `CALL %Library.RoutineMgr_StudioOpenDialog(?,?,?,?,?,?,?,?)`;
+  const { query } = url.parse(uri.toString(true), true);
+  const spec = fileSpecFromURI(uri, overrides.type);
   const notStudio = "0";
   const dir = "1";
   const orderBy = "1";


### PR DESCRIPTION
This PR fixes #849 and fixes #856

Changes made:
- Use `AtelierAPI.getDoc()` instead of `vscode.workspace.openTextDocument()` to get the document contents.
- Limit the number of documents being processed at once so the server doesn’t get overloaded.
- Check the `CancellationToken` and stop if the search was cancelled.
- Return correct line when `multilineMethodArgs` is set.
- Add better support for resolving a line from all class member/attribute combinations.
- Support multiple matches on a single line.
- Use the `filter` and `type` isfs query parameters to avoid searching files that the user doesn’t have in their folder.
- Return useful warning messages and properly log errors.
- Fix the type definition for `SearchMatch`.
