### PR TITLE
Add `objectscript-int` language id for .int files (#823)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "onCommand:vscode-objectscript.hideExplorerForWorkspace",
     "onCommand:vscode-objectscript.showExplorerForWorkspace",
     "onLanguage:objectscript",
+    "onLanguage:objectscript-int",
     "onLanguage:objectscript-class",
     "onLanguage:objectscript-macros",
     "onLanguage:xml",
@@ -416,7 +417,15 @@
           "ObjectScript"
         ],
         "extensions": [
-          ".mac",
+          ".mac"
+        ]
+      },
+      {
+        "id": "objectscript-int",
+        "aliases": [
+          "ObjectScript INT"
+        ],
+        "extensions": [
           ".int"
         ]
       },
@@ -465,6 +474,11 @@
         }
       },
       {
+        "language": "objectscript-int",
+        "scopeName": "source.objectscript",
+        "path": "syntaxes/objectscript.tmLanguage.json"
+      },
+      {
         "language": "objectscript-class",
         "scopeName": "source.objectscript_class",
         "path": "syntaxes/objectscript-class.tmLanguage.json",
@@ -503,6 +517,10 @@
       {
         "language": "objectscript",
         "path": "./snippets/objectscript.json"
+      },
+      {
+        "language": "objectscript-int",
+        "path": "./snippets/objectscript-int.json"
       }
     ],
     "commands": [
@@ -1049,6 +1067,9 @@
     "breakpoints": [
       {
         "language": "objectscript"
+      },
+      {
+        "language": "objectscript-int"
       },
       {
         "language": "objectscript-class"

--- a/snippets/objectscript-int.json
+++ b/snippets/objectscript-int.json
@@ -1,0 +1,72 @@
+{
+  "ForOrder": {
+    "prefix": ["For"],
+    "body": [
+			"Set ${1:key} = \"\"",
+			"For {",
+				"\tSet $1 = \\$ORDER(${2:array}($1))",
+				"\tQuit:$1=\"\"",
+				"\t${3:// process $2($1)}",
+			"}"
+    ],
+    "description": "Iterate array with $Order"
+  },
+  "SQL Statement": {
+    "prefix": ["sql"],
+    "body": [
+      "Set rs = ##class(%SQL.Statement).%ExecDirect(,\"SELECT ${1:*} FROM ${2:table}\")",
+      "While rs.%Next() {",
+        "\t${0:Write rs.ID, !}",
+      "}"
+    ],
+    "description": "Prepare and execute SQL Query, then iterate result set 'rs'"
+  },
+  "For": {
+    "prefix": ["For"],
+    "body": [
+      "For ${1:i} = ${2:1}:${3:1}:${4:9} {",
+        "\t${0:Write $1, !}",
+      "}"
+    ],
+	  "description": "Typical For loop"
+  },
+  "For Each": {
+    "prefix": ["For"],
+    "body": [
+      "For ${1:value} = \"${2:Red}\",\"${3:Green}\",\"${4:Blue}\" {",
+        "\t${0:Write $1, !}",
+      "}"
+    ],
+	  "description": "Loop through series of values"
+  },
+  "Do While": {
+    "prefix": ["Do", "While"],
+    "body": [
+      "Do {",
+        "\t$0",
+      "} While (${1:1 /* condition */})"
+    ],
+	  "description": "Do While loop"
+  },
+  "While": {
+    "prefix": ["While"],
+    "body": [
+      "While (${1:1 /* condition */}) {",
+        "\t$0",
+      "}"
+    ],
+	  "description": "While loop"
+  },
+	"Try Catch": {
+		"prefix": ["Try"],
+		"body": [
+      "Try {",
+        "\t$0",
+      "}",
+      "Catch ex {",
+        "\tSet tSC=ex.AsStatus()",
+      "}"
+    ],
+		"description": "Try Catch"
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -601,7 +601,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   vscode.window.onDidChangeTextEditorSelection((event: vscode.TextEditorSelectionChangeEvent) => {
     posPanel.text = "";
     const document = event.textEditor.document;
-    if (document.languageId !== "objectscript") {
+    if (!["objectscript", "objectscript-int"].includes(document.languageId)) {
       return;
     }
     if (event.selections.length > 1 || !event.selections[0].isEmpty) {
@@ -685,23 +685,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
       }),
       vscode.languages.registerHoverProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-macros"),
+        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
         new ObjectScriptHoverProvider()
       ),
       vscode.languages.registerDocumentFormattingEditProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-macros"),
+        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
         new DocumentFormattingEditProvider()
       ),
       vscode.languages.registerDocumentRangeFormattingEditProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-macros"),
+        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
         new DocumentRangeFormattingEditProvider()
       ),
       vscode.languages.registerDefinitionProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-macros"),
+        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
         new ObjectScriptDefinitionProvider()
       ),
       vscode.languages.registerCompletionItemProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-macros"),
+        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
         new ObjectScriptCompletionItemProvider(),
         "$",
         "^",
@@ -713,7 +713,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         new ObjectScriptClassSymbolProvider()
       ),
       vscode.languages.registerDocumentSymbolProvider(
-        documentSelector("objectscript"),
+        documentSelector("objectscript", "objectscript-int"),
         new ObjectScriptRoutineSymbolProvider()
       )
     );
@@ -728,7 +728,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           new ObjectScriptClassFoldingRangeProvider()
         ),
         vscode.languages.registerFoldingRangeProvider(
-          documentSelector("objectscript"),
+          documentSelector("objectscript", "objectscript-int"),
           new ObjectScriptFoldingRangeProvider()
         )
       );

--- a/src/web-extension.ts
+++ b/src/web-extension.ts
@@ -25,6 +25,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     ),
     vscode.languages.setLanguageConfiguration("objectscript-class", getLanguageConfiguration("class")),
     vscode.languages.setLanguageConfiguration("objectscript", getLanguageConfiguration("routine")),
+    vscode.languages.setLanguageConfiguration("objectscript-int", getLanguageConfiguration("routine")),
     vscode.languages.setLanguageConfiguration("objectscript-macros", getLanguageConfiguration("routine"))
   );
 }


### PR DESCRIPTION
This PR fixes #823

Depends on https://github.com/intersystems/language-server/issues/217 so PR is being created as a draft.

When this extension falls back to TM grammar in the absence of LS (e.g. on web, currently) MAC syntax continues to be allowed in INTs because the new language id still uses the objectscript.tmLanguage.json file