### PR TITLE
Use `vscode.workspace.fs.readFile()` in `TextSearchProvider`

### DIFF
--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -69,6 +69,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
         if (token.isCancellationRequested) {
           return;
         }
+        const decoder = new TextDecoder();
         const result = await Promise.allSettled(
           files.map(
             throttleRequests(async (file: SearchResult) => {
@@ -76,7 +77,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
                 throw new vscode.CancellationError();
               }
               const uri = DocumentContentProvider.getUri(file.doc, "", "", true, options.folder);
-              const content = await api.getDoc(file.doc).then((data) => <string[]>data.result.content);
+              const content = decoder.decode(await vscode.workspace.fs.readFile(uri)).split("\n");
               // Find all lines that we have matches on
               const lines = file.matches
                 .map((match: SearchMatch) => {


### PR DESCRIPTION
This is preferable to using `AtelierAPI.getDoc()` because the latter always fetches the full content of the document, while the former invokes the `FileSystemProvider`'s `readFile()` method and therefore benefits from its caching functionality.