### PR TITLE
Add `objectscript.openClassContracted` setting

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -55,6 +55,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.format.functionCase"` | Case for system functions and system variables. | `"upper"`, `"lower"` or `"word"` | `"word"` | Has no effect if the `InterSystems Language Server` extension is installed and enabled. |
 | `"objectscript.ignoreInstallServerManager"` | Do not offer to install the [intersystems-community.servermanager](https://marketplace.visualstudio.com/items?itemName=intersystems-community.servermanager) extension. | `boolean` | `false` | |
 | `"objectscript.multilineMethodArgs"` | List method arguments on multiple lines, if the server supports it. | `boolean` | `false` | Only supported on IRIS 2019.1.2, 2020.1.1+, 2021.1.0+ and subsequent versions! On all other versions, this setting will have no effect. |
+| `"objectscript.openClassContracted"` | Automatically collapse all folding ranges when a class is opened for the first time. | `boolean` | `false` | |
 | `"objectscript.overwriteServerChanges"` | Overwrite a changed server version without confirmation when importing the local file. | `boolean` | `false` | |
 | `"objectscript.serverSideEditing"` | Allow editing code directly on the server after opening it from ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.serverSourceControl.disableOtherActionTriggers"` | Prevent server-side source control 'other action' triggers from firing. | `boolean` | `false` | |

--- a/package.json
+++ b/package.json
@@ -1067,6 +1067,11 @@
           "markdownDescription": "List method arguments on multiple lines, if the server supports it. **NOTE:** Only supported on IRIS 2019.1.2, 2020.1.1+, 2021.1.0+ and subsequent versions! On all other versions, this setting will have no effect.",
           "type": "boolean",
           "default": false
+        },
+        "objectscript.openClassContracted": {
+          "description": "Automatically collapse all folding ranges when a class is opened for the first time.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -738,7 +738,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     }
   }
 
-  // The URI's of all classes that have been opened. Used when objectscript.openClassContracted is true.
+  // The URIs of all classes that have been opened. Used when objectscript.openClassContracted is true.
   const openedClasses: string[] = [];
 
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -738,6 +738,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     }
   }
 
+  // The URI's of all classes that have been opened. Used when objectscript.openClassContracted is true.
+  const openedClasses: string[] = [];
+
   context.subscriptions.push(
     reporter,
     panel,
@@ -968,6 +971,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           })
       )
     ),
+    vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
+      if (
+        config("openClassContracted") &&
+        editor &&
+        editor.document.languageId === "objectscript-class" &&
+        !openedClasses.includes(editor.document.uri.toString())
+      ) {
+        openedClasses.push(editor.document.uri.toString());
+        vscode.commands.executeCommand("editor.foldAll");
+      }
+    }),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -974,20 +974,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       )
     ),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
+      const uri: string = editor.document.uri.toString();
       if (
         config("openClassContracted") &&
         editor &&
         editor.document.languageId === "objectscript-class" &&
-        !openedClasses.includes(editor.document.uri.toString())
+        !openedClasses.includes(uri)
       ) {
         vscode.commands.executeCommand("editor.foldAll");
-        openedClasses.push(editor.document.uri.toString());
+        openedClasses.push(uri);
       }
     }),
     vscode.workspace.onDidCloseTextDocument((doc: vscode.TextDocument) => {
-      const idx = openedClasses.indexOf(doc.uri.toString());
+      const uri: string = doc.uri.toString();
+      const idx: number = openedClasses.indexOf(uri);
       if (idx > -1) {
-        openedClasses.splice(openedClasses.indexOf(doc.uri.toString()), 1);
+        openedClasses.splice(idx, 1);
       }
     }),
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -738,9 +738,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     }
   }
 
-  // The URIs of all classes that have been opened. Used when objectscript.openClassContracted is true.
-  const openedClasses: string[] = [];
-
   context.subscriptions.push(
     reporter,
     panel,
@@ -972,14 +969,24 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       )
     ),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
+      const openedClasses: string[] = workspaceState.get("openedClasses") ?? [];
       if (
         config("openClassContracted") &&
         editor &&
         editor.document.languageId === "objectscript-class" &&
         !openedClasses.includes(editor.document.uri.toString())
       ) {
-        openedClasses.push(editor.document.uri.toString());
         vscode.commands.executeCommand("editor.foldAll");
+        openedClasses.push(editor.document.uri.toString());
+        workspaceState.update("openedClasses", openedClasses);
+      }
+    }),
+    vscode.workspace.onDidCloseTextDocument((doc: vscode.TextDocument) => {
+      const openedClasses: string[] = workspaceState.get("openedClasses") ?? [];
+      const idx = openedClasses.indexOf(doc.uri.toString());
+      if (idx > -1) {
+        openedClasses.splice(openedClasses.indexOf(doc.uri.toString()), 1);
+        workspaceState.update("openedClasses", openedClasses);
       }
     }),
 


### PR DESCRIPTION
This PR fixes #876 

When `objectscript.openClassContracted` is `true`, automatically collapse all folding ranges when a class is opened for the first time.