### PR TITLE
Add `objectscript.explorer.alwaysShowServerCopy` setting

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -41,7 +41,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.compileOnSave"` | Automatically compile an InterSystems file when saved in the editor. | `boolean` | `true` | |
 | `"objectscript.conn"` | Configures the active server connection. | `object` | `undefined` | See the [Configuration page](../configuration/#config-server-conn) for more details on configuring server connections. |
 | `"objectscript.debug.debugThisMethod"` | Show inline `Debug this method` CodeLens action for ClassMethods. | `boolean` | `true` | |
-| `"objectscript.explorer.alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer, like the Atelier Server Explorer tab. | `boolean` | `false` | |
+| `"objectscript.explorer.alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.export.addCategory"` | Add a category folder to the beginning of the export path. | `boolean` or `object` | `false` | |
 | `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | |
 | `"objectscript.export.category"` | Category of source code to export: `CLS` = classes; `RTN` = routines; `CSP` = csp files; `OTH` = other. Default is `*` = all. | `string` or `object` | `"*"` | |

--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -41,6 +41,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.compileOnSave"` | Automatically compile an InterSystems file when saved in the editor. | `boolean` | `true` | |
 | `"objectscript.conn"` | Configures the active server connection. | `object` | `undefined` | See the [Configuration page](../configuration/#config-server-conn) for more details on configuring server connections. |
 | `"objectscript.debug.debugThisMethod"` | Show inline `Debug this method` CodeLens action for ClassMethods. | `boolean` | `true` | |
+| `"objectscript.explorer.alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer, like the Atelier Server Explorer tab. | `boolean` | `false` | |
 | `"objectscript.export.addCategory"` | Add a category folder to the beginning of the export path. | `boolean` or `object` | `false` | |
 | `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | |
 | `"objectscript.export.category"` | Category of source code to export: `CLS` = classes; `RTN` = routines; `CSP` = csp files; `OTH` = other. Default is `*` = all. | `string` or `object` | `"*"` | |

--- a/package.json
+++ b/package.json
@@ -1074,7 +1074,7 @@
           "default": false
         },
         "objectscript.explorer.alwaysShowServerCopy": {
-          "description": "Always show the server copy of a document in the ObjectScript Explorer, like the Atelier Server Explorer tab.",
+          "description": "Always show the server copy of a document in the ObjectScript Explorer.",
           "type": "boolean",
           "default": false
         }

--- a/package.json
+++ b/package.json
@@ -1072,6 +1072,11 @@
           "description": "Automatically collapse all folding ranges when a class is opened for the first time.",
           "type": "boolean",
           "default": false
+        },
+        "objectscript.explorer.alwaysShowServerCopy": {
+          "description": "Always show the server copy of a document in the ObjectScript Explorer, like the Atelier Server Explorer tab.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/explorer/models/classNode.ts
+++ b/src/explorer/models/classNode.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
 import { NodeBase, NodeOptions } from "./nodeBase";
+import { config } from "../../extension";
 
 export class ClassNode extends NodeBase {
   public static readonly contextValue: string = "dataNode:classNode";
@@ -12,15 +13,24 @@ export class ClassNode extends NodeBase {
     const displayName: string = this.label;
     const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
     const isLocalFile = itemUri.scheme === "file";
+    const showServerCopy: boolean = config("explorer.alwaysShowServerCopy", this.workspaceFolder);
+    const serverCopyUri = DocumentContentProvider.getUri(
+      this.fullName,
+      this.workspaceFolder,
+      this.namespace,
+      undefined,
+      undefined,
+      true
+    );
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [itemUri],
+        arguments: [isLocalFile && !showServerCopy ? itemUri : serverCopyUri],
         command: "vscode-objectscript.explorer.open",
         title: "Open Class",
       },
-      resourceUri: isLocalFile ? itemUri : undefined,
+      resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: "dataNode:classNode",
       label: `${displayName}`,
       tooltip: isLocalFile ? undefined : this.fullName,

--- a/src/explorer/models/classNode.ts
+++ b/src/explorer/models/classNode.ts
@@ -33,7 +33,7 @@ export class ClassNode extends NodeBase {
       resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: "dataNode:classNode",
       label: `${displayName}`,
-      tooltip: isLocalFile ? undefined : this.fullName,
+      tooltip: isLocalFile && !showServerCopy ? undefined : this.fullName,
     };
   }
 }

--- a/src/explorer/models/cspFileNode.ts
+++ b/src/explorer/models/cspFileNode.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
 import { NodeBase, NodeOptions } from "./nodeBase";
+import { config } from "../../extension";
 
 export class CSPFileNode extends NodeBase {
   public static readonly contextValue: string = "dataNode:cspFileNode";
@@ -12,15 +13,24 @@ export class CSPFileNode extends NodeBase {
     const displayName: string = this.label;
     const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
     const isLocalFile = itemUri.scheme === "file";
+    const showServerCopy: boolean = config("explorer.alwaysShowServerCopy", this.workspaceFolder);
+    const serverCopyUri = DocumentContentProvider.getUri(
+      this.fullName,
+      this.workspaceFolder,
+      this.namespace,
+      undefined,
+      undefined,
+      true
+    );
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [itemUri],
+        arguments: [isLocalFile && !showServerCopy ? itemUri : serverCopyUri],
         command: "vscode-objectscript.explorer.open",
         title: "Open File",
       },
-      resourceUri: isLocalFile ? itemUri : undefined,
+      resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: CSPFileNode.contextValue,
       label: `${displayName}`,
       tooltip: isLocalFile ? undefined : this.fullName,

--- a/src/explorer/models/cspFileNode.ts
+++ b/src/explorer/models/cspFileNode.ts
@@ -33,7 +33,7 @@ export class CSPFileNode extends NodeBase {
       resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: CSPFileNode.contextValue,
       label: `${displayName}`,
-      tooltip: isLocalFile ? undefined : this.fullName,
+      tooltip: isLocalFile && !showServerCopy ? undefined : this.fullName,
     };
   }
 }

--- a/src/explorer/models/packageNode.ts
+++ b/src/explorer/models/packageNode.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import { RootNode } from "./rootNode";
 import { NodeOptions } from "./nodeBase";
 import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
+import { config } from "../../extension";
 
 export class PackageNode extends RootNode {
   public constructor(label: string, fullName: string, category: string, options: NodeOptions) {
@@ -12,10 +13,11 @@ export class PackageNode extends RootNode {
     const displayName: string = this.label;
     const localFolderPath = DocumentContentProvider.getAsFolder(this.fullName, this.workspaceFolder, "cls");
     const localUri = localFolderPath ? vscode.Uri.file(localFolderPath) : undefined;
+    const showServerCopy: boolean = config("explorer.alwaysShowServerCopy", this.workspaceFolder);
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
-      resourceUri: !this.extraNode ? localUri : undefined,
+      resourceUri: !this.extraNode && !showServerCopy ? localUri : undefined,
       contextValue: this.contextValue,
       label: `${displayName}`,
       tooltip: this.fullName,

--- a/src/explorer/models/routineNode.ts
+++ b/src/explorer/models/routineNode.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import { DocumentContentProvider } from "../../providers/DocumentContentProvider";
 import { NodeBase, NodeOptions } from "./nodeBase";
+import { config } from "../../extension";
 
 export class RoutineNode extends NodeBase {
   public static readonly contextValue: string = "dataNode:routineNode";
@@ -12,15 +13,24 @@ export class RoutineNode extends NodeBase {
     const displayName: string = this.label;
     const itemUri = DocumentContentProvider.getUri(this.fullName, this.workspaceFolder, this.namespace);
     const isLocalFile = itemUri.scheme === "file";
+    const showServerCopy: boolean = config("explorer.alwaysShowServerCopy", this.workspaceFolder);
+    const serverCopyUri = DocumentContentProvider.getUri(
+      this.fullName,
+      this.workspaceFolder,
+      this.namespace,
+      undefined,
+      undefined,
+      true
+    );
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
       command: {
-        arguments: [itemUri],
+        arguments: [isLocalFile && !showServerCopy ? itemUri : serverCopyUri],
         command: "vscode-objectscript.explorer.open",
         title: "Open Routine",
       },
-      resourceUri: isLocalFile ? itemUri : undefined,
+      resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: "dataNode:routineNode",
       label: `${displayName}`,
       tooltip: isLocalFile ? undefined : this.fullName,

--- a/src/explorer/models/routineNode.ts
+++ b/src/explorer/models/routineNode.ts
@@ -33,7 +33,7 @@ export class RoutineNode extends NodeBase {
       resourceUri: isLocalFile && !showServerCopy ? itemUri : undefined,
       contextValue: "dataNode:routineNode",
       label: `${displayName}`,
-      tooltip: isLocalFile ? undefined : this.fullName,
+      tooltip: isLocalFile && !showServerCopy ? undefined : this.fullName,
     };
   }
 }


### PR DESCRIPTION
This PR fixes #494 

I verified that the explorer works properly with the new setting enabled or disabled, and that the LS's go to definition provider still opens the local copy of the file regardless of the new setting's value.