### PR TITLE
Compile asynchronously

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -634,7 +634,7 @@ export class AtelierAPI {
 
   /**
    * Recursive function that calls `pollAsync()` repeatedly until we get a result or the user cancels the request.
-   * The wait time between requests starts at 50ms and increases exponentially, with a max wait of 30 seconds.
+   * The wait time between requests starts at 50ms and increases exponentially, with a max wait of 15 seconds.
    */
   private async getAsyncResult(id: string, wait: number, token: vscode.CancellationToken): Promise<Atelier.Response> {
     const pollResp = await this.pollAsync(id);
@@ -650,8 +650,7 @@ export class AtelierAPI {
         // The user cancelled the request, so cancel it on the server
         return this.verifiedCancel(id);
       }
-      const nextWait = wait < 25000 ? wait ** 1.1 : 30000;
-      return this.getAsyncResult(id, nextWait, token);
+      return this.getAsyncResult(id, wait < 10000 ? wait ** 1.075 : 15000, token);
     }
     return pollResp;
   }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -16,7 +16,7 @@ import {
   schemas,
   checkingConnection,
 } from "../extension";
-import { currentWorkspaceFolder, outputConsole } from "../utils";
+import { currentWorkspaceFolder, outputChannel, outputConsole } from "../utils";
 
 const DEFAULT_API_VERSION = 1;
 import * as Atelier from "./atelier";
@@ -622,6 +622,9 @@ export class AtelierAPI {
    * The wait time between requests is 1 second.
    */
   private async verifiedCancel(id: string): Promise<Atelier.Response> {
+    outputChannel.appendLine(
+      "\nWARNING: Compilation was cancelled. Partially-compiled documents may result in unexpected behavior."
+    );
     let cancelResp = await this.cancelAsync(id);
     while (cancelResp.result.retryafter) {
       await new Promise((resolve) => {


### PR DESCRIPTION
This PR removes the use of the synchronous `/action/compile` API and instead uses the `/work` endpoints to compile documents. We've had reports internally of users running into `504 Gateway Timeout` errors when compiling a class took more than 60 seconds. While the users could increase the timeout, they could always run up against it again in the future. Using this approach ensures that the extension will not break, regardless of how long compilation on the server may take.

I'm leaving this as a draft until the people who ran into the gateway timeout issue internally verify that this works for them.