### PR TITLE
Add command to export Studio project contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -755,6 +755,12 @@
         "command": "vscode-objectscript.exportCurrentFile",
         "title": "Export Current File from Server",
         "enablement": "!isWeb"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.exportStudioProject",
+        "title": "Export Studio Project Contents from Server",
+        "enablement": "!isWeb"
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "onCommand:vscode-objectscript.connectFolderToServerNamespace",
     "onCommand:vscode-objectscript.hideExplorerForWorkspace",
     "onCommand:vscode-objectscript.showExplorerForWorkspace",
+    "onCommand:vscode-objectscript.exportStudioProject",
     "onLanguage:objectscript",
     "onLanguage:objectscript-int",
     "onLanguage:objectscript-class",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,7 @@ import {
   compileOnly,
 } from "./commands/compile";
 import { deleteExplorerItems } from "./commands/delete";
-import { exportAll, exportCurrentFile, exportExplorerItems, getCategory } from "./commands/export";
+import { exportAll, exportCurrentFile, exportExplorerItems, exportStudioProject, getCategory } from "./commands/export";
 import { serverActions } from "./commands/serverActions";
 import { subclass } from "./commands/subclass";
 import { superclass } from "./commands/superclass";
@@ -992,6 +992,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         openedClasses.splice(idx, 1);
       }
     }),
+    vscode.commands.registerCommand("vscode-objectscript.exportStudioProject", exportStudioProject),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed


### PR DESCRIPTION
This PR fixes #851 

This PR adds a new command that allows the user to export the files (and optionally breakpoints) contained in a Studio project to a workspace folder on their local file system. This is intended to make migrating from Studio to a client-side workflow much easier.

I tested this using a simple project that contained a class, mac routine CSP folder, and a 2 breakpoints:

```
^oddPROJECT("FIX_851")=$lb("2022-02-11 14:08:07.5016053","","","","",,"","","","","","","","")
^oddPROJECT("FIX_851","BP","ColorJSON.MAC",9)=$lb("","")
^oddPROJECT("FIX_851","BP","User.Test.CLS","cos+1")=$lb("","")
^oddPROJECT("FIX_851","Items","ColorJSON.MAC","MAC")=$lb(,"")
^oddPROJECT("FIX_851","Items","User.Test","CLS")=$lb(,"")
^oddPROJECT("FIX_851","Items","csp/user","DIR")=$lb(,"")
```