### PR TITLE
Fix `TextSearchProvider` for csp folders

### DIFF
--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -70,7 +70,6 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
           query: "",
         });
       }
-      return uri;
     } else {
       const conn = config("conn", workspaceFolder);
       const localFile = this.getAsFile(name, workspaceFolder);
@@ -132,8 +131,9 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
         });
       }
     }
+    const params = new URLSearchParams(uri.query);
     if (namespace && namespace !== "") {
-      if (isCsp) {
+      if (isCsp && !params.has("csp")) {
         uri = uri.with({
           query: `ns=${namespace}&csp=1`,
         });
@@ -142,7 +142,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
           query: `ns=${namespace}`,
         });
       }
-    } else if (isCsp) {
+    } else if (isCsp && !params.has("csp")) {
       uri = uri.with({
         query: "csp=1",
       });

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -60,7 +60,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
         .join(/cls|mac|int|inc/i.test(fileExt) ? "/" : ".");
       name = fileName + "." + fileExt;
       uri = wFolderUri.with({
-        path: `/${name}`,
+        path: !name.startsWith("/") ? `/${name}` : name,
       });
       vfs = true;
       scheme = wFolderUri.scheme;
@@ -70,6 +70,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
           query: "",
         });
       }
+      return uri;
     } else {
       const conn = config("conn", workspaceFolder);
       const localFile = this.getAsFile(name, workspaceFolder);

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -133,10 +133,17 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     }
     const params = new URLSearchParams(uri.query);
     if (namespace && namespace !== "") {
-      if (isCsp && !params.has("csp")) {
-        uri = uri.with({
-          query: `ns=${namespace}&csp=1`,
-        });
+      if (isCsp) {
+        if (params.has("csp")) {
+          params.set("ns", namespace);
+          uri = uri.with({
+            query: params.toString(),
+          });
+        } else {
+          uri = uri.with({
+            query: `ns=${namespace}&csp=1`,
+          });
+        }
       } else {
         uri = uri.with({
           query: `ns=${namespace}`,

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -168,7 +168,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
                       }
                     }
                   }
-                  return typeof line === "number" ? line : null;
+                  return typeof line === "number" ? (file.doc.includes("/") ? line - 1 : line) : null;
                 })
                 .filter(notNull);
               // Filter out duplicates and compute all matches for each one

--- a/src/utils/FileProviderUtil.ts
+++ b/src/utils/FileProviderUtil.ts
@@ -34,7 +34,7 @@ export function fileSpecFromURI(uri: vscode.Uri, overrideType?: string): string 
     }
   } // otherwise, reference the type to get the desired files.
   else if (csp) {
-    specOpts = "*";
+    specOpts = folder.length > 1 ? "*" : "*.cspall";
   } else if (type === "rtn") {
     specOpts = "*.inc,*.mac,*.int";
   } else if (type === "cls") {


### PR DESCRIPTION
Previously the `TextSearchProvider` wouldn't work for csp folders because the generated URIs were malformed. This PR fixes that issue and changed the StudioOpenDialog file spec for the root csp folder from `*` to `*.cspall` so only files in csp directories are searched. 