### PR TITLE
Ignore `objectscript.conn.docker-compose` when running in dev container

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -177,10 +177,12 @@ export class AtelierAPI {
     if (config("intersystems.servers").has(serverName)) {
       this.externalServer = true;
     } else if (
-      !conn["docker-compose"] &&
+      !(conn["docker-compose"] && extensionContext.extension.extensionKind !== vscode.ExtensionKind.Workspace) &&
       conn.server &&
       config("intersystems.servers", workspaceFolderName).has(conn.server)
     ) {
+      // Connect to the server named in objectscript.conn
+      // unless a docker-compose conn object exists and this extension isn't running remotely (i.e. within the dev container)
       serverName = conn.server;
     } else {
       serverName = "";


### PR DESCRIPTION
The purpose of this PR is to enable an upcoming PR of mine for https://github.com/grongierisc/iris-python-template which will allow VS Code to connect remotely to that container as an alternative to the original way of using VS Code with it.

This change will mean that any `docker-compose` element of a (usually workspace-specific) `objectscript.conn` will be ignored when the extension is running in a remote extension host. A suitably-structured `objectscript.conn` written into the container by the workspace's `devcontainer.json` will instead create a within-container connection.