### PR TITLE
Improve error message when debugging fails to start

### DIFF
--- a/docs/RunDebug.md
+++ b/docs/RunDebug.md
@@ -110,4 +110,6 @@ Clicking on the green arrow runs the currently selected debug configuration.
 
 When starting **objectscript launch** debug session, make sure that the file containing the **program** that you are debugging is open in your editor and is the active tab. VS Code will start a debug session with the server of the file in the active editor (the tab that the user is focused on).
 
+This extension uses WebSockets to communicate with the InterSystems server during debugging. If you are experiencing issues when trying to start a debugging session, check that the InterSystems server's web server allows WebSocket connections.
+
 Debugging commands and items on the **Run** menu function much as they do for other languages supported by VS Code. For information on VS Code debugging, see the documentation resources listed at the start of this section. 

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -128,8 +128,6 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       this._namespace = api.ns;
       this._url = api.xdebugUrl();
 
-      await api.serverInfo();
-
       const socket = new WebSocket(this._url, {
         headers: {
           cookie: this.cookies,
@@ -164,8 +162,14 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
 
       this.sendEvent(new InitializedEvent());
     } catch (error) {
+      let message = "Failed to start the debug session. ";
+      if (error instanceof Error && error.message == "Connection not active") {
+        message += "Server connection is inactive.";
+      } else {
+        message += "Check that the InterSystems server's web server supports WebSockets.";
+      }
       response.success = false;
-      response.message = "Debugger can not start";
+      response.message = message;
       this.sendResponse(response);
     }
   }


### PR DESCRIPTION
Multiple issues have been raised in past about being unable to start debug sessions that turned out to be caused by the user's web server configuration (#607, #773, #830, #891). This PR adds a line in the documentation about the WebSocket requirement and improves the error when debugging fails to start.