### PR TITLE
Finalize `outputChannelLanguage` API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@types/glob": "^7.1.2",
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.0.14",
-        "@types/vscode": "^1.43.0",
+        "@types/vscode": "^1.66.0",
         "@types/ws": "^7.2.5",
         "@types/xmldom": "^0.1.29",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
@@ -53,7 +53,7 @@
         "webpack-cli": "^4.5.0"
       },
       "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.66.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -353,9 +353,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "node_modules/@types/ws": {
@@ -5430,9 +5430,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.62.0.tgz",
-      "integrity": "sha512-iGlQJ1w5e3qPUryroO6v4lxg3ql1ztdTCwQW3xEwFawdyPLoeUSv48SYfMwc7kQA7h6ThUqflZIjgKAykeF9oA==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "@types/ws": {

--- a/package.json
+++ b/package.json
@@ -47,13 +47,11 @@
     }
   ],
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.66.0"
   },
-  "enableProposedApi": true,
   "enabledApiProposals": [
     "fileSearchProvider",
-    "textSearchProvider",
-    "outputChannelLanguage"
+    "textSearchProvider"
   ],
   "activationEvents": [
     "onDebug",
@@ -1208,14 +1206,14 @@
     "test": "node ./out/test/runTest.js",
     "lint": "eslint src/**",
     "lint-fix": "eslint --fix src/**",
-    "download-api": "vscode-dts dev 1.65.0",
+    "download-api": "vscode-dts dev 1.66.0",
     "postinstall": "npm run download-api"
   },
   "devDependencies": {
     "@types/glob": "^7.1.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.0.14",
-    "@types/vscode": "^1.43.0",
+    "@types/vscode": "^1.66.0",
     "@types/ws": "^7.2.5",
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^4.32.0",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,19 +4,14 @@ import { R_OK } from "constants";
 import * as url from "url";
 import { exec } from "child_process";
 import * as vscode from "vscode";
-import { config, schemas, workspaceState, terminals, extensionId, extensionContext } from "../extension";
+import { config, schemas, workspaceState, terminals, extensionContext } from "../extension";
 import { getCategory } from "../commands/export";
-const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 
 let latestErrorMessage = "";
 export const outputChannel: {
   resetError?(): void;
   appendError?(value: string, show?: boolean): void;
-} & vscode.OutputChannel =
-  typeof packageJson.enabledApiProposals === "object" &&
-  packageJson.enabledApiProposals.includes("outputChannelLanguage")
-    ? vscode.window.createOutputChannel("ObjectScript", "vscode-objectscript-output")
-    : vscode.window.createOutputChannel("ObjectScript");
+} & vscode.OutputChannel = vscode.window.createOutputChannel("ObjectScript", "vscode-objectscript-output");
 
 /// Append Error if no duplicates previous one
 outputChannel.appendError = (value: string, show = true): void => {


### PR DESCRIPTION
VS Code 1.66 was released and with it the `outputChannelLanguage` API was finalized. We should use the new finalized API so everyone will get their Output channel colorized.