### PR TITLE
Remove `isWeb` clauses from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
     "viewsWelcome": [
       {
         "view": "explorer",
-        "contents": "Begin local ObjectScript development by opening a folder or cloning a repository. Then switch to the new ObjectScript view in the Activity Bar.\nYou can also create a new workspace to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.addServerNamespaceToWorkspace)",
-        "when": "!isWeb"
+        "contents": "Begin local ObjectScript development by opening a folder or cloning a repository. Then switch to the new ObjectScript view in the Activity Bar.\nYou can also create a new workspace to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.addServerNamespaceToWorkspace)"
       },
       {
         "view": "ObjectScriptExplorer",
@@ -549,8 +548,7 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.export",
-        "title": "Export Code from Server",
-        "enablement": "!isWeb"
+        "title": "Export Code from Server"
       },
       {
         "category": "ObjectScript",
@@ -668,8 +666,7 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.serverActions",
-        "title": "Server Actions...",
-        "enablement": "!isWeb"
+        "title": "Server Actions..."
       },
       {
         "category": "ObjectScript",
@@ -706,20 +703,17 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.addServerNamespaceToWorkspace",
-        "title": "Add Server Namespace to Workspace...",
-        "enablement": "!isWeb"
+        "title": "Add Server Namespace to Workspace..."
       },
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.connectFolderToServerNamespace",
-        "title": "Connect Folder to Server Namespace...",
-        "enablement": "!isWeb"
+        "title": "Connect Folder to Server Namespace..."
       },
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.hideExplorerForWorkspace",
-        "title": "Hide Explorer for Workspace",
-        "enablement": "!isWeb"
+        "title": "Hide Explorer for Workspace"
       },
       {
         "category": "ObjectScript",
@@ -745,14 +739,12 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.showClassDocumentationPreview",
         "title": "Show Class Documentation Preview",
-        "enablement": "!isWeb",
         "icon": "$(open-preview)"
       },
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.exportCurrentFile",
-        "title": "Export Current File from Server",
-        "enablement": "!isWeb"
+        "title": "Export Current File from Server"
       }
     ],
     "keybindings": [
@@ -760,19 +752,19 @@
         "command": "vscode-objectscript.compile",
         "key": "Ctrl+F7",
         "mac": "Cmd+F7",
-        "when": "!isWeb && editorLangId =~ /^objectscript/"
+        "when": "editorLangId =~ /^objectscript/"
       },
       {
         "command": "vscode-objectscript.compileAll",
         "key": "Ctrl+Shift+F7",
         "mac": "Cmd+Shift+F7",
-        "when": "!isWeb && editorLangId =~ /^objectscript/"
+        "when": "editorLangId =~ /^objectscript/"
       },
       {
         "command": "vscode-objectscript.viewOthers",
         "key": "Ctrl+Shift+V",
         "mac": "Cmd+Shift+V",
-        "when": "!isWeb && editorLangId =~ /^objectscript/"
+        "when": "editorLangId =~ /^objectscript/"
       }
     ],
     "configuration": {
@@ -1083,7 +1075,7 @@
         {
           "id": "ObjectScriptExplorer",
           "name": "Explorer",
-          "when": "!isWeb && workspaceFolderCount != 0 && config.objectscript.showExplorer == true"
+          "when": "workspaceFolderCount != 0 && config.objectscript.showExplorer == true"
         }
       ]
     },
@@ -1113,7 +1105,6 @@
         "label": "ObjectScript Debug",
         "program": "./out/debug/debugAdapter.js",
         "runtime": "node",
-        "when": "!isWeb",
         "configurationAttributes": {
           "launch": {
             "required": [],


### PR DESCRIPTION
This PR fixes #911 

I reviewed the [VS Code docs for when clauses](https://code.visualstudio.com/api/references/when-clause-contexts#available-contexts) and this clause is true when the VS Code UI is running a browser, not the extension. We should remove this so the extension works as intended when it's installed in an environment like code-server.

