### PR TITLE
Fix importing of web app files

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -14,13 +14,12 @@ import {
 } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import {
+  cspAppsForUri,
   currentFile,
   CurrentFile,
   currentFileFromContent,
-  currentWorkspaceFolder,
   outputChannel,
   throttleRequests,
-  uriOfWorkspaceFolder,
 } from "../utils";
 import { PackageNode } from "../explorer/models/packageNode";
 import { NodeBase } from "../explorer/models/nodeBase";
@@ -423,10 +422,7 @@ export async function importFolder(uri: vscode.Uri, noCompile = false): Promise<
     return importFiles([uripath], noCompile);
   }
   let globpattern = "*.{cls,inc,int,mac}";
-  const workspace = currentWorkspaceFolder();
-  const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;
-  const folderPathNoWorkspaceArr = uripath.replace(workspacePath + path.sep, "").split(path.sep);
-  if (folderPathNoWorkspaceArr.includes("csp")) {
+  if (cspAppsForUri(uri).findIndex((cspApp) => uri.path.includes(cspApp + "/") || uri.path.endsWith(cspApp)) != -1) {
     // This folder is a CSP application, so import all files
     // We need to include eveything becuase CSP applications can
     // include non-InterSystems files

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -196,6 +196,13 @@ export function getResolvedConnectionSpec(key: string, dflt: any): any {
   return resolvedConnSpecs.has(key) ? resolvedConnSpecs.get(key) : dflt;
 }
 
+/**
+ * A map of all CSP web apps in a server-namespace.
+ * The key is either `serverName:ns`, or `host:port/pathPrefix:ns`, lowercase.
+ * The value is an array of CSP apps as returned by GET %25SYS/cspapps.
+ */
+export const cspApps: Map<string, string[]> = new Map();
+
 export async function checkConnection(clearCookies = false, uri?: vscode.Uri): Promise<void> {
   // Do nothing if already checking the connection
   if (checkingConnection) {
@@ -282,7 +289,7 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
   checkingConnection = true;
   return api
     .serverInfo()
-    .then((info) => {
+    .then(async (info) => {
       panel.text = api.connInfo;
       panel.tooltip = `Connected${pathPrefix ? " to " + pathPrefix : ""} as ${username}`;
       const hasHS = info.result.content.features.find((el) => el.name === "HEALTHSHARE" && el.enabled) !== undefined;
@@ -291,6 +298,15 @@ export async function checkConnection(clearCookies = false, uri?: vscode.Uri): P
           serverVersion: info.result.content.version,
           healthshare: hasHS ? "yes" : "no",
         });
+      // Update CSP web app cache if required
+      const key = (
+        api.config.serverName && api.config.serverName != ""
+          ? `${api.config.serverName}:${api.config.ns}`
+          : `${api.config.host}:${api.config.port}${api.config.pathPrefix}:${api.config.ns}`
+      ).toLowerCase();
+      if (!cspApps.has(key)) {
+        cspApps.set(key, await api.getCSPApps().then((data) => data.result.content || []));
+      }
       return;
     })
     .catch((error) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,8 +4,9 @@ import { R_OK } from "constants";
 import * as url from "url";
 import { exec } from "child_process";
 import * as vscode from "vscode";
-import { config, schemas, workspaceState, terminals, extensionContext } from "../extension";
+import { config, schemas, workspaceState, terminals, extensionContext, cspApps } from "../extension";
 import { getCategory } from "../commands/export";
+import { AtelierAPI } from "../api";
 
 let latestErrorMessage = "";
 export const outputChannel: {
@@ -57,6 +58,19 @@ export interface ConnectionTarget {
 }
 
 /**
+ * Get a list of all CSP web apps in the server-namespace that `uri` is connected to.
+ */
+export function cspAppsForUri(uri: vscode.Uri): string[] {
+  const api = new AtelierAPI(uri);
+  const key = (
+    api.config.serverName && api.config.serverName != ""
+      ? `${api.config.serverName}:${api.config.ns}`
+      : `${api.config.host}:${api.config.port}${api.config.pathPrefix}:${api.config.ns}`
+  ).toLowerCase();
+  return cspApps.get(key) ?? [];
+}
+
+/**
  * Determine the server name of a local non-ObjectScript file (any file that's not CLS,MAC,INT,INC).
  * @param localPath The full path to the file on disk.
  * @param workspace The workspace the file is in.
@@ -66,7 +80,8 @@ function getServerDocName(localPath: string, workspace: string, fileExt: string)
   const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;
   const filePathNoWorkspaceArr = localPath.replace(workspacePath + path.sep, "").split(path.sep);
   if (fileExt !== "dfi") {
-    return filePathNoWorkspaceArr.slice(filePathNoWorkspaceArr.indexOf("csp")).join("/");
+    const uri = vscode.Uri.file(localPath);
+    return uri.path.slice(uri.path.indexOf(cspAppsForUri(uri).find((cspApp) => uri.path.includes(cspApp + "/"))));
   }
   const { atelier, folder, addCategory } = config("export", workspace);
   const root = [
@@ -91,9 +106,7 @@ export function isImportableLocalFile(file: vscode.TextDocument): boolean {
   const workspace = currentWorkspaceFolder(file);
   const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;
   const filePathNoWorkspaceArr = file.fileName.replace(workspacePath + path.sep, "").split(path.sep);
-  if (filePathNoWorkspaceArr.includes("csp")) {
-    return true;
-  } else if (file.uri.path.toLowerCase().endsWith(".dfi")) {
+  if (file.uri.path.toLowerCase().endsWith(".dfi")) {
     // This is a DFI file, so make sure it matches our export settings
     const { atelier, folder, addCategory } = config("export", workspace);
     const expectedRoot = [
@@ -109,6 +122,8 @@ export function isImportableLocalFile(file: vscode.TextDocument): boolean {
         return true;
       }
     }
+  } else {
+    return cspAppsForUri(file.uri).findIndex((cspApp) => file.uri.path.includes(cspApp + "/")) != -1;
   }
   return false;
 }


### PR DESCRIPTION
This PR fixes #777

Whenever the connection is checked I cache the list of available web apps in a server-namespace and use this list to determine if a local non-CSP/CSR file can be imported as a web app file.