### PR TITLE
Correctly use `http.proxyStrictSSL` setting

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -286,7 +286,7 @@ export class AtelierAPI {
     const agent = new http.Agent({
       keepAlive: true,
       maxSockets: 10,
-      rejectUnauthorized: https && config("http.proxyStrictSSL"),
+      rejectUnauthorized: https && vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),
     });
 
     let pathPrefix = this._config.pathPrefix || "";


### PR DESCRIPTION
See https://community.intersystems.com/post/vscode-objectscript-extension-trusting-self-signed-certificates#comment-186796