### PR TITLE
Fix uncaught errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1013,15 +1013,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       )
     ),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
-      const uri: string = editor.document.uri.toString();
-      if (
-        config("openClassContracted") &&
-        editor &&
-        editor.document.languageId === "objectscript-class" &&
-        !openedClasses.includes(uri)
-      ) {
-        vscode.commands.executeCommand("editor.foldLevel1");
-        openedClasses.push(uri);
+      if (config("openClassContracted") && editor && editor.document.languageId === "objectscript-class") {
+        const uri: string = editor.document.uri.toString();
+        if (!openedClasses.includes(uri)) {
+          vscode.commands.executeCommand("editor.foldLevel1");
+          openedClasses.push(uri);
+        }
       }
     }),
     vscode.workspace.onDidCloseTextDocument((doc: vscode.TextDocument) => {


### PR DESCRIPTION
This PR fixes uncaught errors that are reported in the VS Code extension view UI:

<img width="817" alt="Screen Shot 2022-04-22 at 8 45 26 AM" src="https://user-images.githubusercontent.com/44776135/164717106-d3de3f66-0ca1-47a0-803c-baba23c8bd9a.png">

The errors are caused by the `onDidChangeActiveTextEditor()` handler for the  `openClassContracted` setting, which is trying to read the `document`, property of the `TextEditor` argument which may be `undefined`.