### PR TITLE
Don't split dots in names of 'other' files into folders on export

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -43,7 +43,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.debug.debugThisMethod"` | Show inline `Debug this method` CodeLens action for ClassMethods. | `boolean` | `true` | |
 | `"objectscript.explorer.alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.export.addCategory"` | Add a category folder to the beginning of the export path. | `boolean` or `object` | `false` | |
-| `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | |
+| `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | This setting only affects classes, routines, include files and DFI files. |
 | `"objectscript.export.category"` | Category of source code to export: `CLS` = classes; `RTN` = routines; `CSP` = csp files; `OTH` = other. Default is `*` = all. | `string` or `object` | `"*"` | |
 | `"objectscript.export.dontExportIfNoChanges"` | Do not rewrite the local file if the content is identical to what came from the server. | `boolean` | `false` | |
 | `"objectscript.export.exactFilter"` | SQL filter to limit what to export. | `string` | `""` | The filter is applied to document names using the [LIKE predicate](https://irisdocs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_like) (i.e. `Name LIKE 'exactFilter'`). If provided, `objectscript.export.filter` is ignored. |

--- a/package.json
+++ b/package.json
@@ -1117,7 +1117,7 @@
               "additionalProperties": false
             },
             "atelier": {
-              "description": "Export source code as Atelier did it, with packages as subfolders.",
+              "description": "Export source code as Atelier did it, with packages as subfolders. This setting only affects classes, routines, include files and DFI files.",
               "type": "boolean"
             },
             "generated": {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -52,7 +52,7 @@ export const getFileName = (
       fileNameArray = name.split("-");
       fileNameArray.push(fileNameArray.pop().slice(0, -4));
       fileExt = "dfi";
-    } else {
+    } else if (/\.(?:cls|mac|int|inc)$/.test(name)) {
       // This is a class, routine or include file
       if (map) {
         for (const pattern of Object.keys(map)) {
@@ -64,6 +64,11 @@ export const getFileName = (
       }
       fileNameArray = name.split(".");
       fileExt = fileNameArray.pop().toLowerCase();
+    } else {
+      // This is some other type of file (LUT,HL7,...)
+      const lastDot = name.lastIndexOf(".");
+      fileNameArray = [name.slice(0, lastDot)];
+      fileExt = name.slice(lastDot + 1);
     }
     const cat = addCategory ? getCategory(name, addCategory) : null;
     if (split) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -80,35 +80,40 @@ export function cspAppsForUri(uri: vscode.Uri): string[] {
 function getServerDocName(localPath: string, workspace: string, fileExt: string): string {
   const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;
   const filePathNoWorkspaceArr = localPath.replace(workspacePath + path.sep, "").split(path.sep);
-  if (fileExt !== "dfi") {
-    const uri = vscode.Uri.file(localPath);
-    return uri.path.slice(uri.path.indexOf(cspAppsForUri(uri).find((cspApp) => uri.path.includes(cspApp + "/"))));
+  const uri = vscode.Uri.file(localPath);
+  const cspIdx = uri.path.indexOf(cspAppsForUri(uri).find((cspApp) => uri.path.includes(cspApp + "/")));
+  if (cspIdx != -1) {
+    return uri.path.slice(cspIdx);
+  } else {
+    const { atelier, folder, addCategory } = config("export", workspace);
+    const root = [
+      typeof folder === "string" && folder.length ? folder : null,
+      addCategory ? getCategory(localPath, addCategory) : null,
+    ]
+      .filter(notNull)
+      .join(path.sep);
+    let filePath = filePathNoWorkspaceArr.join(path.sep).slice(root.length + path.sep.length);
+    if (fileExt == "dfi" && atelier) {
+      filePath = filePath.replaceAll(path.sep, "-");
+    }
+    return filePath;
   }
-  const { atelier, folder, addCategory } = config("export", workspace);
-  const root = [
-    typeof folder === "string" && folder.length ? folder : null,
-    addCategory ? getCategory(localPath, addCategory) : null,
-  ]
-    .filter(notNull)
-    .join(path.sep);
-  let filePath = filePathNoWorkspaceArr.join(path.sep).slice(root.length + path.sep.length);
-  if (atelier) {
-    filePath = filePath.replaceAll(path.sep, "-");
-  }
-  return filePath;
 }
 
 /**
  * Determine if this non-ObjectScript local file is importable
- * (i.e. is part of a CSP application or is a DFI file).
+ * (i.e. is part of a CSP application or matches our export settings).
  * @param file The file to check.
  */
 export function isImportableLocalFile(file: vscode.TextDocument): boolean {
   const workspace = currentWorkspaceFolder(file);
   const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;
   const filePathNoWorkspaceArr = file.fileName.replace(workspacePath + path.sep, "").split(path.sep);
-  if (file.uri.path.toLowerCase().endsWith(".dfi")) {
-    // This is a DFI file, so make sure it matches our export settings
+  const isCSP = cspAppsForUri(file.uri).findIndex((cspApp) => file.uri.path.includes(cspApp + "/")) != -1;
+  if (isCSP) {
+    return true;
+  } else {
+    // Check if this file matches our export settings
     const { atelier, folder, addCategory } = config("export", workspace);
     const expectedRoot = [
       typeof folder === "string" && folder.length ? folder : null,
@@ -119,14 +124,17 @@ export function isImportableLocalFile(file: vscode.TextDocument): boolean {
     let filePath = filePathNoWorkspaceArr.join(path.sep);
     if (filePath.startsWith(expectedRoot)) {
       filePath = filePath.slice(expectedRoot.length + path.sep.length);
-      if ((atelier && !filePath.includes("-")) || !atelier) {
+      if (file.uri.path.toLowerCase().endsWith(".dfi")) {
+        // DFI files can be split using the atelier setting
+        if ((atelier && !filePath.includes("-")) || !atelier) {
+          return true;
+        }
+      } else {
         return true;
       }
     }
-  } else {
-    return cspAppsForUri(file.uri).findIndex((cspApp) => file.uri.path.includes(cspApp + "/")) != -1;
+    return false;
   }
-  return false;
 }
 
 export function currentFileFromContent(fileName: string, content: string): CurrentFile {


### PR DESCRIPTION
This PR fixes #536, fixes #866, fixes #930

If this PR is merged, 'other' files will have dots in their file names retained regardless of the `export.atelier` setting. This fixes issues with importing exported 'other' files and with exported 'other' files having their names mangled by our package-splitting code. 