### PR TITLE
Fix issue with copying class file overwriting inheritance

### DIFF
--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -28,7 +28,9 @@ export function generateFileContent(fileName: string, sourceContent: Buffer): { 
     while (sourceLines.length > 0) {
       const nextLine = sourceLines.shift();
       if (nextLine.startsWith("Class ")) {
-        content.push(...preamble, `Class ${className}`, ...sourceLines);
+        const classLine = nextLine.split(" ");
+        classLine[1] = className;
+        content.push(...preamble, classLine.join(" "), ...sourceLines);
         break;
       }
       preamble.push(nextLine);


### PR DESCRIPTION
This PR fixes an issue with copying a class file overwriting inheritance. Previously, dragging an existing cls file into the project will overwrite existing inheritance code (... Extends %Persistent ...).