### PR TITLE
Use `DocumentSymbolProvider` for tag+offset status bar item

### DIFF
--- a/src/commands/jumpToTagAndOffset.ts
+++ b/src/commands/jumpToTagAndOffset.ts
@@ -8,7 +8,7 @@ export async function jumpToTagAndOffset(): Promise<void> {
   }
   const nameMatch = file.name.match(/(.*)\.(int|mac)$/i);
   if (!nameMatch) {
-    vscode.window.showWarningMessage("Jump to Tag and Offset only supports .int and .mac routines.");
+    vscode.window.showWarningMessage("Jump to Tag and Offset only supports .int and .mac routines.", "Dismiss");
     return;
   }
   const document = vscode.window.activeTextEditor?.document;


### PR DESCRIPTION
This PR fixes #957 

Call the `vscode.executeDocumentSymbolProvider` command and use the symbols to determine label+offset for the status bar item.

***NOTE:*** This PR won't fix the issue until the next Language Server version is released due to a dependency on chnages to its `DocumentSymbolProvider`.