### PR TITLE
Support `objectscript` and `objectscript-class` in Markdown fenced codeblocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -601,6 +601,12 @@
       {
         "id": "vscode-objectscript-output",
         "aliases": []
+      },
+      {
+        "id": "objectscript-injection"
+      },
+      {
+        "id": "objectscript-class-injection"
       }
     ],
     "grammars": [
@@ -648,6 +654,28 @@
         "language": "vscode-objectscript-output",
         "scopeName": "source.vscode_objectscript_output",
         "path": "syntaxes/vscode-objectscript-output.tmLanguage.json"
+      },
+      {
+        "language": "objectscript-injection",
+        "scopeName": "markdown.objectscript.codeblock",
+        "path": "./syntaxes/objectscript_codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.objectscript": "objectscript"
+        }
+      },
+      {
+        "language": "objectscript-class-injection",
+        "scopeName": "markdown.objectscript_class.codeblock",
+        "path": "./syntaxes/objectscript-class_codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ],
+        "embeddedLanguages": {
+          "meta.embedded.block.objectscript_class": "objectscript-class"
+        }
       }
     ],
     "snippets": [

--- a/syntaxes/objectscript-class_codeblock.json
+++ b/syntaxes/objectscript-class_codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#objectscript-class-code-block"
+		}
+	],
+	"repository": {
+		"objectscript-class-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(objectscript-class)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.objectscript_class",
+					"patterns": [
+						{
+							"include": "source.objectscript_class"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.objectscript_class.codeblock"
+}

--- a/syntaxes/objectscript_codeblock.json
+++ b/syntaxes/objectscript_codeblock.json
@@ -1,0 +1,45 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"patterns": [
+		{
+			"include": "#objectscript-code-block"
+		}
+	],
+	"repository": {
+		"objectscript-code-block": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(objectscript)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.objectscript",
+					"patterns": [
+						{
+							"include": "source.objectscript"
+						}
+					]
+				}
+			]
+		}
+	},
+	"scopeName": "markdown.objectscript.codeblock"
+}


### PR DESCRIPTION
Prompted by https://community.intersystems.com/post/syntax-highlighting-vs-code-markdown

Implemented using information at https://github.com/mjbvz/vscode-fenced-code-block-grammar-injection-example

Leverages the TextMate grammars which we fall back to when Language Server isn't available.

Coloring shows in the text as it is being edited, but unfortunately doesn't carry through to preview.

![image](https://user-images.githubusercontent.com/6726799/181563796-7e1f8b38-a812-4931-bd4b-25b10de238c2.png)


Markdown text for above example:

    # Embedding ObjectScript code and Class Definitions into Markdown
    
    MAC or INT code example:

    ```objectscript
     //create the object
     set diagnosis=##class(MyApp.Clinical.PatDiagnosis).%New()
    
     //set a couple of properties by using special variables
     set diagnosis.Date=$SYSTEM.SYS.TimeStamp()
     set diagnosis.EnteredBy=$username
     set status=diagnosis.%Save()
     //always check the returned status
     if $$$ISERR(status) {do $System.Status.DisplayError(status) quit status}
    ```
    
    Complete class definition example:
    
    ```objectscript-class
    Class GORIENT.VariableScopeDemo
    {
    
    ClassMethod Add(arg1 As %Numeric, arg2 As %Numeric) As %Numeric
    {
        Set ans=arg1+arg2
        Quit ans
    }
    
    ClassMethod Demo1()
    {
       set x=..Add(1,2)
       write x
    }
    
    ClassMethod Demo2()
    {
       set x=..Add(2,4)
       write x
    }
    
    }
    ```
