### PR TITLE
Fix uncaught errors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -661,19 +661,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands
       .executeCommand<vscode.DocumentSymbol[]>("vscode.executeDocumentSymbolProvider", document.uri)
       .then((symbols) => {
-        const cursor = event.selections[0].active;
-        if (symbols.length == 0 || cursor.isBefore(symbols[0].range.start)) {
-          pos = cursor.line - 1;
-        } else {
-          for (const symbol of symbols) {
-            if (symbol.range.contains(cursor)) {
-              label = symbol.name;
-              pos = cursor.line - symbol.range.start.line;
-              break;
+        if (symbols != undefined) {
+          const cursor = event.selections[0].active;
+          if (symbols.length == 0 || cursor.isBefore(symbols[0].range.start)) {
+            pos = cursor.line - 1;
+          } else {
+            for (const symbol of symbols) {
+              if (symbol.range.contains(cursor)) {
+                label = symbol.name;
+                pos = cursor.line - symbol.range.start.line;
+                break;
+              }
             }
           }
+          posPanel.text = `${label}${pos > 0 ? "+" + pos : ""}^${routine}`;
         }
-        posPanel.text = `${label}${pos > 0 ? "+" + pos : ""}^${routine}`;
       });
   });
 

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -45,7 +45,7 @@ export function generateFileContent(fileName: string, sourceContent: Buffer): { 
   } else if (["int", "inc", "mac"].includes(fileExt)) {
     sourceLines.shift();
     const routineName = fileName.split(".").slice(0, -1).join(".");
-    const routineType = `[ type = ${fileExt}]`;
+    const routineType = fileExt != "mac" ? `[Type=${fileExt.toUpperCase()}]` : "";
     return {
       content: [`ROUTINE ${routineName} ${routineType}`, ...sourceLines],
       enc: false,


### PR DESCRIPTION
This PR fixes #965 

Unfortunately there isn't a way to fix the created file getting wiped error without turning off the stub generation in `onDidCreateFiles()` entirely.