### PR TITLE
Fix uncaught errors

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -140,7 +140,7 @@ What do you want to do?`,
             return Promise.reject();
           });
       } else {
-        if (error.errorText && error.errorText !== "") {
+        if (error && error.errorText && error.errorText !== "") {
           outputChannel.appendLine("\n" + error.errorText);
           vscode.window
             .showErrorMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1095,7 +1095,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           return importAndCompile(false, file, config("compileOnSave"));
         }
       } else if (file.uri.scheme === "file") {
-        if (isImportableLocalFile(file)) {
+        if (isImportableLocalFile(file) && new AtelierAPI(file.uri).active) {
           // This local file is part of a CSP application
           // or matches our export settings, so import it on save
           return importFileOrFolder(file.uri, true);


### PR DESCRIPTION
Uncaught errors are reported when the extension tries to import a local file on save when the connection is inactive because `AtelierAPI.request()` rejects without an error value. This PR adds a check for an active connection before the import is attempted.