### PR TITLE
Improve CodeLenses

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -48,9 +48,10 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.conn.server"` | InterSystems server's name in Server Manager settings from which to get connection info. | `string` | `undefined` | Specify only `ns` and `active` when using this setting. See the [Server Manager README](https://github.com/intersystems-community/intersystems-servermanager) for more details. |
 | `"objectscript.conn.docker-compose"` | Configures the active server port using information from a file which must be named `docker-compose.yml` in the project's root directory. | `object` | `undefined` | |
 | `"objectscript.conn.docker-compose.service"` | InterSystems service's name in `docker-compose.yml`. | `string` | `undefined` | |
-| `"objectscript.conn.docker-compose .internalPort"` | InterSystems service's internal port in `docker-compose.yml`. | `object` | `undefined` | This should almost always be 52773 unless your IRIS server is configured in a non-standard way|
-| `"objectscript.debug.debugThisMethod"` | Show inline `Debug this method` CodeLens action for ClassMethods. | `boolean` | `true` | |
-| `"objectscript.explorer .alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer. | `boolean` | `false` | |
+| `"objectscript.conn.docker-compose.internalPort"` | InterSystems service's internal port in `docker-compose.yml`. | `object` | `undefined` | This should almost always be 52773 unless your IRIS server is configured in a non-standard way |
+| `"objectscript.debug.copyToClipboard"` | Show inline `Copy Invocation` CodeLens action for ClassMethods and Routine Labels. | `boolean` | `true` | |
+| `"objectscript.debug.debugThisMethod"` | Show inline `Debug` CodeLens action for ClassMethods and Routine Labels. | `boolean` | `true` | |
+| `"objectscript.explorer.alwaysShowServerCopy"` | Always show the server copy of a document in the ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.export.addCategory"` | Add a category folder to the beginning of the export path. | `boolean` or `object` | `false` | |
 | `"objectscript.export.atelier"` | Export source code as Atelier did it, with packages as subfolders. | `boolean` | `true` | This setting only affects classes, routines, include files and DFI files. |
 | `"objectscript.export.category"` | Category of source code to export: `CLS` = classes; `RTN` = routines; `CSP` = csp files; `OTH` = other. Default is `*` = all. | `string` or `object` | `"*"` | |
@@ -61,7 +62,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.export.generated"` | Export generated source code files, such as INTs generated from classes. | `boolean` | `false` | |
 | `"objectscript.export.map"` | Map file names before export, with regexp pattern as a key and replacement as a value. | `object` | `{}` | For example, `{  \"%(.*)\": \"_$1\" }` to make % classes or routines use underscore prefix instead. |
 | `"objectscript.export.mapped"` | Export source code files mapped from a non-default database. | `boolean` | `true` | |
-| `"objectscript.export .maxConcurrentConnections"` | Maximum number of concurrent export connections. | `number` | `0` | 0 = unlimited |
+| `"objectscript.export.maxConcurrentConnections"` | Maximum number of concurrent export connections. | `number` | `0` | 0 = unlimited |
 | `"objectscript.export.noStorage"` | Strip the storage definition on export. | `boolean` | `false` | Can be useful when working across multiple systems. |
 | `"objectscript.format.commandCase"` | Case for commands. | `"upper"`, `"lower"` or `"word"` | `"word"` | Has no effect if the `InterSystems Language Server` extension is installed and enabled. |
 | `"objectscript.format.functionCase"` | Case for system functions and system variables. | `"upper"`, `"lower"` or `"word"` | `"word"` | Has no effect if the `InterSystems Language Server` extension is installed and enabled. |

--- a/package.json
+++ b/package.json
@@ -1247,7 +1247,7 @@
         "objectscript.debug.debugThisMethod": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Show inline `Debug Method` CodeLens action for ClassMethods and Routine Labels."
+          "markdownDescription": "Show inline `Debug` CodeLens action for ClassMethods and Routine Labels."
         },
         "objectscript.debug.copyToClipboard": {
           "type": "boolean",

--- a/src/providers/ObjectScriptCodeLensProvider.ts
+++ b/src/providers/ObjectScriptCodeLensProvider.ts
@@ -7,27 +7,27 @@ export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
     document: vscode.TextDocument,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.CodeLens[]> {
-    const result = new Array<vscode.CodeLens>();
-
-    if (document.fileName.toLowerCase().endsWith(".cls")) {
-      result.push(...this.classMethods(document));
+    if (document.languageId == "objectscript-class") {
+      return this.classMethods(document);
     }
-    if (document.fileName.toLowerCase().endsWith(".mac")) {
-      result.push(...this.routineLabels(document));
+    if (["objectscript", "objectscript-int"].includes(document.languageId)) {
+      return this.routineLabels(document);
     }
-    return result;
+    return [];
   }
 
   private classMethods(document: vscode.TextDocument): vscode.CodeLens[] {
     const file = currentFile(document);
     const result = new Array<vscode.CodeLens>();
 
-    if (!file.name.match(/\.cls$/i)) {
-      return result;
-    }
     const className = file.name.split(".").slice(0, -1).join(".");
 
     const { debugThisMethod, copyToClipboard } = config("debug");
+    if (!debugThisMethod && !copyToClipboard) {
+      // Return early if both types are turned off
+      return result;
+    }
+
     const pattern = /(?:^ClassMethod\s)([^(]+)\((.*)/i;
     let inComment = false;
     for (let i = 0; i < document.lineCount; i++) {
@@ -63,51 +63,44 @@ export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
     return result;
   }
 
-  private routineLabels(document: vscode.TextDocument): vscode.CodeLens[] {
+  private async routineLabels(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
     const file = currentFile(document);
     const result = new Array<vscode.CodeLens>();
 
-    if (!file.name.match(/\.mac$/i)) {
-      return result;
-    }
     const routineName = file.name.split(".").slice(0, -1).join(".");
 
     const { debugThisMethod, copyToClipboard } = config("debug");
+    if (!debugThisMethod && !copyToClipboard) {
+      // Return early if both types are turned off
+      return result;
+    }
 
     debugThisMethod && result.push(this.addDebugThisMethod(0, [`^${routineName}`, false]));
     copyToClipboard && result.push(this.addCopyToClipboard(0, [`^${routineName}`]));
 
-    let inComment = false;
-    for (let i = 1; i < document.lineCount; i++) {
-      const line = document.lineAt(i);
-      const text = this.stripLineComments(line.text);
+    const symbols: vscode.DocumentSymbol[] = await vscode.commands.executeCommand(
+      "vscode.executeDocumentSymbolProvider",
+      document.uri
+    );
+    symbols
+      .filter((symbol) => symbol.kind === vscode.SymbolKind.Method)
+      .forEach((symbol) => {
+        const line = symbol.selectionRange.start.line;
+        const labelMatch = document.lineAt(line).text.match(/^(\w[^(\n\s]+)(?:\(([^)]*)\))?/i);
+        if (labelMatch) {
+          const [, name, parens] = labelMatch;
 
-      if (text.match(/\/\*/)) {
-        inComment = true;
-      }
-
-      if (inComment) {
-        if (text.match(/\*\//)) {
-          inComment = false;
+          debugThisMethod && result.push(this.addDebugThisMethod(line, [`${name}^${routineName}`, parens !== "()"]));
+          copyToClipboard && result.push(this.addCopyToClipboard(line, [`${name}^${routineName}`]));
         }
-        continue;
-      }
-
-      const labelMatch = text.match(/^(\w[^(\n\s]+)(?:\(([^)]*)\))?/i);
-      if (labelMatch) {
-        const [, name, parens] = labelMatch;
-
-        debugThisMethod && result.push(this.addDebugThisMethod(i, [`${name}^${routineName}`, parens !== "()"]));
-        copyToClipboard && result.push(this.addCopyToClipboard(i, [`${name}^${routineName}`]));
-      }
-    }
+      });
 
     return result;
   }
 
   private addDebugThisMethod(line: number, args: any[]) {
     return new vscode.CodeLens(new vscode.Range(line, 0, line, 80), {
-      title: `Debug this Method`,
+      title: `Debug`,
       command: "vscode-objectscript.debug",
       arguments: args,
     });


### PR DESCRIPTION
* Fixes #996 
* Adds CodeLenses for INT routines
* Adds documentation for `objectscript.debug.copyToClipboard`
* Shortens debug CodeLens name from `Debug this method` to `Debug`