### PR TITLE
Add `FileDecoration` for Generated files

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -75,6 +75,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.serverSideEditing"` | Allow editing code directly on the server after opening it from ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.serverSourceControl .disableOtherActionTriggers"` | Prevent server-side source control 'other action' triggers from firing. | `boolean` | `false` | |
 | `"objectscript.showExplorer"` | Show the ObjectScript Explorer view. | `boolean` | `true` | |
+| `"objectscript.showGeneratedFileDecorations"` | Controls whether a badge is shown in the file explorer and open editors view for generated files. | `boolean` | `true` | |
 | `"objectscript.studioActionDebugOutput"` | Log in JSON format the action that VS Code should perform as requested by the server. | `boolean` | `false` | Actions will be logged to the `ObjectScript` Output channel. |
 | `"objectscript.suppressCompileErrorMessages"` | Suppress popup messages about errors during compile, but still focus on Output view. | `boolean` | `false` | |
 | `"objectscript.suppressCompileMessages"` | Suppress popup messages about successful compile. | `boolean` | `true` | |

--- a/package.json
+++ b/package.json
@@ -1402,6 +1402,11 @@
           "description": "Automatically save a client-side InterSystems file on the server when saved in the editor.",
           "type": "boolean",
           "default": true
+        },
+        "objectscript.showGeneratedFileDecorations": {
+          "description": "Controls whether a badge is shown in the file explorer and open editors view for generated files.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,7 @@ import {
 import { NodeBase } from "./explorer/models/nodeBase";
 import { loadStudioColors, loadStudioSnippets } from "./commands/studioMigration";
 import { newFile, NewFileType } from "./commands/newFile";
-import { FileDecorationProvider } from "./providers/fileDecorationProvider";
+import { FileDecorationProvider } from "./providers/FileDecorationProvider";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 const extensionVersion = packageJson.version;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,6 +113,7 @@ import {
 import { NodeBase } from "./explorer/models/nodeBase";
 import { loadStudioColors, loadStudioSnippets } from "./commands/studioMigration";
 import { newFile, NewFileType } from "./commands/newFile";
+import { FileDecorationProvider } from "./providers/fileDecorationProvider";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 const extensionVersion = packageJson.version;
@@ -736,6 +737,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   openedClasses = workspaceState.get("openedClasses") ?? [];
 
+  // Create this here so we can fire its event
+  const fileDecorationProvider = new FileDecorationProvider();
+
   context.subscriptions.push(
     reporter,
     panel,
@@ -1181,6 +1185,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       newFile(NewFileType.BusinessService)
     ),
     vscode.commands.registerCommand("vscode-objectscript.newFile.dtl", () => newFile(NewFileType.DTL)),
+    vscode.window.registerFileDecorationProvider(fileDecorationProvider),
+    vscode.workspace.onDidOpenTextDocument((doc) => !doc.isUntitled && fileDecorationProvider.emitter.fire(doc.uri)),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed

--- a/src/providers/FileDecorationProvider.ts
+++ b/src/providers/FileDecorationProvider.ts
@@ -1,0 +1,65 @@
+import * as vscode from "vscode";
+import { currentFile } from "../utils";
+
+export class FileDecorationProvider implements vscode.FileDecorationProvider {
+  private _genBadge = String.fromCharCode(9965); // Gear
+  private _genTooltip = "Generated";
+  onDidChangeFileDecorations: vscode.Event<vscode.Uri>;
+
+  emitter = new vscode.EventEmitter<vscode.Uri>();
+
+  public constructor() {
+    this.onDidChangeFileDecorations = this.emitter.event;
+  }
+
+  provideFileDecoration(uri: vscode.Uri): vscode.FileDecoration | undefined {
+    let result: vscode.FileDecoration | undefined = undefined;
+
+    // Only provide decorations for files that are open and not untitled
+    const doc = vscode.workspace.textDocuments.find((d) => d.uri.toString() == uri.toString());
+    if (
+      doc != undefined &&
+      !doc.isUntitled &&
+      ["objectscript", "objectscript-class", "objectscript-int", "objectscript-macros"].includes(doc.languageId) &&
+      vscode.workspace
+        .getConfiguration("objectscript", vscode.workspace.getWorkspaceFolder(uri))
+        .get<boolean>("showGeneratedFileDecorations")
+    ) {
+      // Use the file's contents to check if it's generated
+      if (doc.languageId == "objectscript-class") {
+        for (let line = 0; line < doc.lineCount; line++) {
+          const lineText = doc.lineAt(line).text;
+          if (lineText.startsWith("Class ")) {
+            const clsMatch = lineText.match(/[[, ]{1}GeneratedBy *= *([^,\] ]+)/i);
+            if (clsMatch) {
+              // This class is generated
+              result = new vscode.FileDecoration(this._genBadge, `${this._genTooltip} by ${clsMatch[1]}`);
+            }
+            break;
+          }
+        }
+      } else {
+        const firstLine = doc.lineAt(0).text;
+        if (firstLine.startsWith("ROUTINE ") && firstLine.includes("Generated]")) {
+          // This routine is generated
+          let tooltip = this._genTooltip;
+          const file = currentFile(doc)?.name;
+          if (file) {
+            const macMatch = file.match(/^(.*)\.G[0-9]+\.mac$/);
+            const intMatch = file.match(/^(.*)\.[0-9]+\.int$/);
+            if (macMatch) {
+              tooltip += ` by ${macMatch[1]}.cls`;
+            } else if (intMatch) {
+              tooltip += ` by ${intMatch[1]}.cls`;
+            } else if (doc.languageId == "objectscript-int") {
+              tooltip += ` by ${file.slice(0, -3)}mac`;
+            }
+          }
+          result = new vscode.FileDecoration(this._genBadge, tooltip);
+        }
+      }
+    }
+
+    return result;
+  }
+}


### PR DESCRIPTION
This PR fixes #987. I added a "gear" `FileDecoration` for generated files that appears once it has been opened. I also added a setting for turning them off for people (like me) who see this as UI clutter rather than a valuable feature.