### PR TITLE
Try to fix CI failure since #1050

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           name: ${{ steps.set-version.outputs.name }}.vsix
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v0
+        uses: softprops/action-gh-release@v0.1.15
         if: runner.os == 'Linux'
         with:
           tag_name: v${{ steps.set-version.outputs.version }}
@@ -158,7 +158,7 @@ jobs:
           npx vsce package -o ${{ steps.set-version.outputs.name }}.vsix
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: softprops/action-gh-release@v0
+        uses: softprops/action-gh-release@v0.1.15
         if: runner.os == 'Linux'
         with:
           tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
           name: ${{ steps.set-version.outputs.name }}.vsix
       - name: Create Release
         id: create-release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v1
         if: runner.os == 'Linux'
         with:
           tag_name: v${{ steps.set-version.outputs.version }}
@@ -158,7 +158,7 @@ jobs:
           npx vsce package -o ${{ steps.set-version.outputs.name }}.vsix
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v1
         if: runner.os == 'Linux'
         with:
           tag_name: ${{ github.event.release.tag_name }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -108,7 +108,7 @@ jobs:
           name: ${{ steps.set-version.outputs.name }}.vsix
       - name: Create Pre-Release
         id: create-release
-        uses: softprops/action-gh-release@v0
+        uses: softprops/action-gh-release@v1
         if: runner.os == 'Linux'
         with:
           tag_name: v${{ steps.set-version.outputs.version }}
@@ -153,7 +153,7 @@ jobs:
           npx vsce package --pre-release -o ${{ steps.set-version.outputs.name }}.vsix
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: softprops/action-gh-release@v0
+        uses: softprops/action-gh-release@v1
         if: runner.os == 'Linux'
         with:
           tag_name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
beta workflow failed when updating my fork:
"Unable to resolve action `softprops/action-gh-release@v0`, unable to find version `v0`"