### PR TITLE
Use query instead of index for class Deployed checks

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -17,6 +17,7 @@ import {
   currentFile,
   CurrentFile,
   currentFileFromContent,
+  isClassDeployed,
   notNull,
   outputChannel,
   throttleRequests,
@@ -73,10 +74,7 @@ export async function checkChangedOnServer(file: CurrentFile, force = false): Pr
 async function importFile(file: CurrentFile, ignoreConflict?: boolean, skipDeplCheck = false): Promise<any> {
   const api = new AtelierAPI(file.uri);
   if (file.name.split(".").pop().toLowerCase() === "cls" && !skipDeplCheck) {
-    const result = await api.actionQuery("SELECT Deployed FROM %Dictionary.ClassDefinition WHERE Name = ?", [
-      file.name.slice(0, -4),
-    ]);
-    if (result.result.content[0].Deployed) {
+    if (await isClassDeployed(file.name, api)) {
       vscode.window.showErrorMessage(`Cannot import ${file.name} because it is deployed on the server.`, "Dismiss");
       return Promise.reject();
     }

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -73,8 +73,10 @@ export async function checkChangedOnServer(file: CurrentFile, force = false): Pr
 async function importFile(file: CurrentFile, ignoreConflict?: boolean, skipDeplCheck = false): Promise<any> {
   const api = new AtelierAPI(file.uri);
   if (file.name.split(".").pop().toLowerCase() === "cls" && !skipDeplCheck) {
-    const result = await api.actionIndex([file.name]);
-    if (result.result.content[0].content.depl) {
+    const result = await api.actionQuery("SELECT Deployed FROM %Dictionary.ClassDefinition WHERE Name = ?", [
+      file.name.slice(0, -4),
+    ]);
+    if (result.result.content[0].Deployed) {
       vscode.window.showErrorMessage(`Cannot import ${file.name} because it is deployed on the server.`, "Dismiss");
       return Promise.reject();
     }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -5,7 +5,13 @@ import { Directory } from "./Directory";
 import { File } from "./File";
 import { fireOtherStudioAction, OtherStudioAction } from "../../commands/studio";
 import { projectContentsFromUri, studioOpenDialogFromURI } from "../../utils/FileProviderUtil";
-import { notNull, outputChannel, redirectDotvscodeRoot, workspaceFolderOfUri } from "../../utils/index";
+import {
+  isClassDeployed,
+  notNull,
+  outputChannel,
+  redirectDotvscodeRoot,
+  workspaceFolderOfUri,
+} from "../../utils/index";
 import { config, workspaceState } from "../../extension";
 import { addIsfsFileToProject, modifyProject } from "../../commands/project";
 import { DocumentContentProvider } from "../DocumentContentProvider";
@@ -313,10 +319,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         // But first check cases for which we should fail the write and leave the document dirty if changed.
         if (!csp && fileName.split(".").pop().toLowerCase() === "cls") {
           // Check if the class is deployed
-          const result = await api.actionQuery("SELECT Deployed FROM %Dictionary.ClassDefinition WHERE Name = ?", [
-            fileName.slice(0, -4),
-          ]);
-          if (result.result.content[0].Deployed) {
+          if (await isClassDeployed(fileName, api)) {
             throw new Error("Cannot overwrite a deployed class");
           }
           // Check if the class name and file name match

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -551,6 +551,15 @@ export async function fileExists(file: vscode.Uri): Promise<boolean> {
   }
 }
 
+/** Check if class `cls` is Deployed in using server connection `api`. */
+export async function isClassDeployed(cls: string, api: AtelierAPI): Promise<boolean> {
+  return api
+    .actionQuery("SELECT Deployed FROM %Dictionary.ClassDefinition WHERE Name = ?", [
+      cls.slice(-4).toLowerCase() == ".cls" ? cls.slice(0, -4) : cls,
+    ])
+    .then((data) => data.result.content[0].Deployed > 0);
+}
+
 // ---------------------------------------------------------------------
 // Source: https://github.com/amsterdamharu/lib/blob/master/src/index.js
 


### PR DESCRIPTION
The Index API transfers a lot of data that is not needed to check if a class is deployed. It is much more efficient to query `%Dictionary.ClassDefinition` directly.