### PR TITLE
Use lowercase for workspace folder state connection keys

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -56,16 +56,13 @@ export class AtelierAPI {
   public get config(): ConnectionSettings {
     const { serverName, active = false, https = false, pathPrefix = "", username } = this._config;
     const ns = this.namespace || this._config.ns;
-    const host = this.externalServer
-      ? this._config.host
-      : workspaceState.get(this.configName + ":host", this._config.host);
-    const port = this.externalServer
-      ? this._config.port
-      : workspaceState.get(this.configName + ":port", this._config.port);
-    const password = workspaceState.get(this.configName + ":password", this._config.password);
-    const apiVersion = workspaceState.get(this.configName + ":apiVersion", DEFAULT_API_VERSION);
-    const docker = workspaceState.get(this.configName + ":docker", false);
-    const dockerService = workspaceState.get<string>(this.configName + ":dockerService");
+    const wsKey = this.configName.toLowerCase();
+    const host = this.externalServer ? this._config.host : workspaceState.get(wsKey + ":host", this._config.host);
+    const port = this.externalServer ? this._config.port : workspaceState.get(wsKey + ":port", this._config.port);
+    const password = workspaceState.get(wsKey + ":password", this._config.password);
+    const apiVersion = workspaceState.get(wsKey + ":apiVersion", DEFAULT_API_VERSION);
+    const docker = workspaceState.get(wsKey + ":docker", false);
+    const dockerService = workspaceState.get<string>(wsKey + ":dockerService");
     return {
       serverName,
       active,
@@ -195,7 +192,7 @@ export class AtelierAPI {
       this._config = {
         serverName,
         active: this.externalServer || conn.active,
-        apiVersion: workspaceState.get(this.configName + ":apiVersion", DEFAULT_API_VERSION),
+        apiVersion: workspaceState.get(this.configName.toLowerCase() + ":apiVersion", DEFAULT_API_VERSION),
         https: scheme === "https",
         ns,
         host,
@@ -429,8 +426,8 @@ export class AtelierAPI {
         authRequestMap.delete(target);
         panel.text = `${this.connInfo} $(debug-disconnect)`;
         panel.tooltip = "Disconnected";
-        workspaceState.update(this.configName + ":host", undefined);
-        workspaceState.update(this.configName + ":port", undefined);
+        workspaceState.update(this.configName.toLowerCase() + ":host", undefined);
+        workspaceState.update(this.configName.toLowerCase() + ":port", undefined);
         if (!checkingConnection) {
           setTimeout(() => checkConnection(false, undefined, true), 30000);
         }
@@ -455,8 +452,8 @@ export class AtelierAPI {
           };
         }
         return Promise.all([
-          workspaceState.update(this.configName + ":apiVersion", apiVersion),
-          workspaceState.update(this.configName + ":iris", data.version.startsWith("IRIS")),
+          workspaceState.update(this.configName.toLowerCase() + ":apiVersion", apiVersion),
+          workspaceState.update(this.configName.toLowerCase() + ":iris", data.version.startsWith("IRIS")),
         ]).then(() => info);
       }
     });

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -3,7 +3,6 @@ const { default: fetch } = require("node-fetch-cjs");
 
 import * as httpModule from "http";
 import * as httpsModule from "https";
-import * as url from "url";
 import * as vscode from "vscode";
 import * as Cache from "vscode-cache";
 import {
@@ -108,11 +107,9 @@ export class AtelierAPI {
             workspaceFolderName = parts[0];
             namespace = parts[1];
           } else {
-            const { query } = url.parse(wsOrFile.toString(true), true);
-            if (query) {
-              if (query.ns && query.ns !== "") {
-                namespace = query.ns.toString();
-              }
+            const params = new URLSearchParams(wsOrFile.query);
+            if (params.has("ns") && params.get("ns") != "") {
+              namespace = params.get("ns");
             }
           }
         } else {

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -100,14 +100,14 @@ export async function serverActions(): Promise<void> {
       rawLink,
     });
   }
-  if (workspaceState.get(workspaceFolder + ":docker", false)) {
+  if (workspaceState.get(workspaceFolder.toLowerCase() + ":docker", false)) {
     actions.push({
       id: "openDockerTerminal",
       label: "Open Terminal in Docker",
       detail: "Use docker-compose to start session inside configured service",
     });
   }
-  if (workspaceState.get(workspaceFolder + ":docker", false)) {
+  if (workspaceState.get(workspaceFolder.toLowerCase() + ":docker", false)) {
     actions.push({
       id: "openDockerShell",
       label: "Open Shell in Docker",

--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -95,7 +95,10 @@ export function registerExplorerOpen(): vscode.Disposable {
             projectsExplorerProvider.refresh();
           }
         } else {
-          throw error;
+          outputChannel.appendLine(
+            typeof error == "string" ? error : error instanceof Error ? error.message : JSON.stringify(error)
+          );
+          outputChannel.show();
         }
       }
     }
@@ -117,6 +120,7 @@ function wasDoubleClick(uri: vscode.Uri): boolean {
   };
   return result;
 }
+
 export class ObjectScriptExplorerProvider implements vscode.TreeDataProvider<NodeBase> {
   public onDidChange?: vscode.Event<vscode.Uri>;
   public onDidChangeTreeData: vscode.Event<NodeBase>;

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as url from "url";
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 
@@ -189,17 +188,15 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
 
   public provideTextDocumentContent(uri: vscode.Uri, token: vscode.CancellationToken): vscode.ProviderResult<string> {
     const api = new AtelierAPI(uri);
-    const query = url.parse(uri.toString(true), true).query;
-    const fileName = query && query.csp ? uri.path.substring(1) : uri.path.split("/").slice(1).join(".");
-    if (query) {
-      if (query.ns && query.ns !== "") {
-        const namespace = query.ns.toString();
-        api.setNamespace(namespace);
-      }
+    const params = new URLSearchParams(uri.query);
+    const fileName =
+      params.has("csp") && ["", "1"].includes(params.get("csp"))
+        ? uri.path.slice(1)
+        : uri.path.split("/").slice(1).join(".");
+    if (params.has("ns") && params.get("ns") != "") {
+      api.setNamespace(params.get("ns"));
     }
-    return api.getDoc(fileName).then((data) => {
-      return data.result.content.join("\n");
-    });
+    return api.getDoc(fileName).then((data) => data.result.content.join("\n"));
   }
 
   public update(uri: vscode.Uri, message?: string): void {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -357,7 +357,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           )
           .catch((error) => {
             // Throw all failures
-            if (error.errorText && error.errorText !== "") {
+            if (error && error.errorText && error.errorText !== "") {
               throw vscode.FileSystemError.Unavailable(error.errorText);
             }
             throw vscode.FileSystemError.Unavailable(uri);
@@ -562,7 +562,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       )
       .catch((error) => {
         // Throw all failures
-        if (error.errorText && error.errorText !== "") {
+        if (error && error.errorText && error.errorText !== "") {
           throw vscode.FileSystemError.Unavailable(error.errorText);
         }
         throw vscode.FileSystemError.Unavailable(error.message);
@@ -601,7 +601,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         .serverInfo()
         .then()
         .catch((error) => {
-          if (error.errorText && error.errorText !== "") {
+          if (error && error.errorText && error.errorText !== "") {
             throw vscode.FileSystemError.Unavailable(error.errorText);
           }
           throw vscode.FileSystemError.Unavailable(uri);
@@ -715,7 +715,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         if (error?.statusCode === 304 && cachedFile) {
           return cachedFile;
         }
-        if (error.errorText && error.errorText !== "") {
+        if (error && error.errorText && error.errorText !== "") {
           throw vscode.FileSystemError.FileNotFound(error.errorText);
         }
         throw vscode.FileSystemError.FileNotFound(uri);


### PR DESCRIPTION
This PR fixed #1049. `workspaceState` keys related to connection information are now stored in all lowercase to prevent misses based on key case. It also contains some small improvements:

* Fix error logging in `FileSystemProvider`.
* Log errors in `vscode-objectscript.explorer.open` to the Output channel.
* Replace calls to deprecated `url.parse()` method.