### PR TITLE
Add `Switch Namespace` option to Server Actions menu for local workspace folders

### DIFF
--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -73,7 +73,7 @@ export async function serverActions(): Promise<void> {
         break;
       }
       case "switchNamespace": {
-        // NOTE: List of all namespaces except the current one as it doens't make sense to allow switching to the current one
+        // NOTE: List of all namespaces except the current one as it doesn't make sense to allow switching to the current one
         const allNamespaces: string[] | undefined = await api
           .serverInfo()
           .then((data) =>

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -95,7 +95,7 @@ export async function serverActions(): Promise<void> {
         }
 
         if (!allNamespaces.length) {
-          vscode.window.showErrorMessage(`Server returned an empty namespace list.`, "Dismiss");
+          vscode.window.showErrorMessage(`You don't have access to any other namespaces.`, "Dismiss");
           return;
         }
 

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -76,7 +76,9 @@ export async function serverActions(): Promise<void> {
         // NOTE: List of all namespaces except the current one as it doens't make sense to allow switching to the current one
         const allNamespaces: string[] | undefined = await api
           .serverInfo()
-          .then((data) => data.result.content.namespaces.filter((ns) => ns !== api.config.ns))
+          .then((data) =>
+            data.result.content.namespaces.filter((ns) => ns.toLowerCase() !== api.config.ns.toLowerCase())
+          )
           .catch((error) => {
             let message = `Failed to fetch a list of namespaces.`;
             if (error && error.errorText && error.errorText !== "") {


### PR DESCRIPTION
This PR adds a "Switch namespace" option to the server action menu. Triggering this will show a quick pick menu with all available namespaces in the server and will do the switch if user selects one. This functionality is useful when doing local development without server-side editing on a server that has multiple namespaces.