### PR TITLE
Fix opening of `isfs` files from ObjectScript Explorer

### DIFF
--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -58,7 +58,7 @@ export function registerExplorerOpen(): vscode.Disposable {
           await vscode.window.showTextDocument(uri, { preview: usePreview });
         } else {
           // This allows use of binary editors such as the Luna Paint extension.
-          await vscode.workspace.fs.stat(uri);
+          await vscode.workspace.fs.readFile(uri);
           await vscode.commands.executeCommand("vscode.open", uri, { preview: usePreview });
         }
       } catch (error) {


### PR DESCRIPTION
This PR fixes #1068. I had to change the `stat()` call to `readFile()` because `readFile()` is allowed to create intermediate folders while `stat()` isn't.