### PR TITLE
Support non-ASCII characters in REST Debug query params

### DIFF
--- a/src/commands/restDebugPanel.ts
+++ b/src/commands/restDebugPanel.ts
@@ -430,11 +430,20 @@ export class RESTDebugPanel {
             });
 
             // Send the request
-            fetch(encodeURI(`${serverInfo}${message.webApp}${path}?${urlParams.toString()}`), {
+            fetch(`${encodeURI(`${serverInfo}${message.webApp}${path}`)}?${urlParams.toString()}`, {
               method: message.method,
               agent,
               body: hasBody ? message.bodyContent : undefined,
               headers,
+            }).catch((error) => {
+              outputChannel.appendLine(
+                typeof error == "string" ? error : error instanceof Error ? error.message : JSON.stringify(error)
+              );
+              vscode.window.showErrorMessage(
+                "Failed to send debugee REST request. Check 'ObjectScript' Output channel for details.",
+                "Dismiss"
+              );
+              vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
             });
 
             // Wait 500ms to allow the server to associate this request with the CSDPDEBUG id

--- a/src/commands/restDebugPanel.ts
+++ b/src/commands/restDebugPanel.ts
@@ -440,7 +440,7 @@ export class RESTDebugPanel {
                 typeof error == "string" ? error : error instanceof Error ? error.message : JSON.stringify(error)
               );
               vscode.window.showErrorMessage(
-                "Failed to send debugee REST request. Check 'ObjectScript' Output channel for details.",
+                "Failed to send debuggee REST request. Check 'ObjectScript' Output channel for details.",
                 "Dismiss"
               );
               vscode.debug.stopDebugging(vscode.debug.activeDebugSession);


### PR DESCRIPTION
This PR fixes #1078. It also improves error handling when the debuggee REST request couldn't be sent.