### PR TITLE
Add 'Start debugging current method' option to launch configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1522,7 +1522,8 @@
           }
         },
         "variables": {
-          "PickProcess": "vscode-objectscript.pickProcess"
+          "PickProcess": "vscode-objectscript.pickProcess",
+          "CurrentMethod": "vscode-objectscript.currentMethod"
         },
         "initialConfigurations": [
           {


### PR DESCRIPTION
This PR adds a new variable/command to the objectscript launch configuration settings, which will allow the user to start debugging the current ClassMethod. I.e. allows user to press "Start debugging" / F5 to run the function of which the cursor in currently inside.

```
{
    "type": "objectscript",
    "request": "launch",
    "name": "ObjectScript: Debug current method",
    "program": "${command:CurrentMethod}"
},
````