### PR TITLE
Show jobs config name in the attach to process debug menu

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -830,7 +830,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           .then((data) => Object.fromEntries(data.result.content.map((x) => [x.Job, x.ConfigName])))
           .catch((error) => {
             // Current namespace is not Interoperability-enabled, there is no Ens.Job_Enumerate procedure
-            if (error && error.errorText.includes("Table valued function 'ENS.JOB_ENUMERATE'(...) not found")) {
+            if (error && error.errorText.includes("'ENS.JOB_ENUMERATE'(...)")) {
               return {};
             }
 


### PR DESCRIPTION
This PR adds the jobs config name to the "Pick the process to attach to" menu items. This makes it easy to see and select the right Business Host to attach to. Without this, the user has to open the Management Portal, open the Production, select the Business Host and finally open the Jobs tab to see what the process pid is and then choose same pid in the "Pick the process to attach to" menu.

<img width="611" alt="image" src="https://user-images.githubusercontent.com/3678938/218164571-2aa458d8-25a6-4b44-a7ab-dce89c858b6c.png">
