### PR TITLE
Add charset to REST Debug panel's Content-Type

### DIFF
--- a/src/commands/restDebugPanel.ts
+++ b/src/commands/restDebugPanel.ts
@@ -391,16 +391,18 @@ export class RESTDebugPanel {
             message.headersText.split(/\r?\n/).forEach((line) => {
               line = line.trim();
               if (line != "" && !line.startsWith("#")) {
-                headers[line.slice(0, line.indexOf(":")).trim()] = line.slice(line.indexOf(":") + 1).trim();
+                headers[line.slice(0, line.indexOf(":")).trim().toLowerCase()] = line
+                  .slice(line.indexOf(":") + 1)
+                  .trim();
               }
             });
             if (
-              headers["Authorization"] == undefined &&
+              headers["authorization"] == undefined &&
               typeof api.config.username === "string" &&
               typeof api.config.password === "string"
             ) {
               // Use the server connection's auth if the user didn't specify any
-              headers["Authorization"] = `Basic ${Buffer.from(`${api.config.username}:${api.config.password}`).toString(
+              headers["authorization"] = `Basic ${Buffer.from(`${api.config.username}:${api.config.password}`).toString(
                 "base64"
               )}`;
             }
@@ -410,16 +412,16 @@ export class RESTDebugPanel {
               // Set the Content-Type header using bodyType
               switch (message.bodyType) {
                 case "JSON":
-                  headers["Content-Type"] = "application/json";
+                  headers["content-type"] = "application/json; charset=utf-8";
                   break;
                 case "XML":
-                  headers["Content-Type"] = "application/xml";
+                  headers["content-type"] = "application/xml; charset=utf-8";
                   break;
                 case "Text":
-                  headers["Content-Type"] = "text/plain";
+                  headers["content-type"] = "text/plain; charset=utf-8";
                   break;
                 case "HTML":
-                  headers["Content-Type"] = "text/html";
+                  headers["content-yype"] = "text/html; charset=utf-8";
                   break;
               }
             }


### PR DESCRIPTION
This PR fixes #1091 

Generally, only `text/*` MIME types can contain the `charset` parameter but IRIS seems to respond to it for JSON so I added it for all types.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#structure_of_a_mime_type