### PR TITLE
Implement `Open Error Location...` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "onCommand:vscode-objectscript.newFile.rule",
     "onCommand:vscode-objectscript.newFile.businessService",
     "onCommand:vscode-objectscript.newFile.dtl",
+    "onCommand:vscode-objectscript.openErrorLocation",
     "onLanguage:objectscript",
     "onLanguage:objectscript-int",
     "onLanguage:objectscript-class",
@@ -327,6 +328,10 @@
         {
           "command": "vscode-objectscript.showRESTDebugWebview",
           "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.openErrorLocation",
+          "when": "vscode-objectscript.connectActive && workspaceFolderCount != 0"
         }
       ],
       "view/title": [
@@ -1083,6 +1088,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.showRESTDebugWebview",
         "title": "Debug REST Service..."
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.openErrorLocation",
+        "title": "Open Error Location..."
       }
     ],
     "keybindings": [

--- a/src/commands/jumpToTagAndOffset.ts
+++ b/src/commands/jumpToTagAndOffset.ts
@@ -70,7 +70,7 @@ export async function openErrorLocation(): Promise<void> {
   // Prompt the user for a location
   const regex = /^(%?[\p{L}\d]+)?(?:\+(\d+))?\^(%?[\p{L}\d.]+)$/u;
   const location = await vscode.window.showInputBox({
-    title: "Enter the location to open.",
+    title: "Enter the location to open",
     ignoreFocusOut: true,
     placeHolder: "label+offset^routine",
     validateInput: (v) => (regex.test(v.trim()) ? undefined : "Input is not in the format 'label+offset^routine'"),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ import {
   mainSourceControlMenu,
 } from "./commands/studio";
 import { addServerNamespaceToWorkspace, pickServerAndNamespace } from "./commands/addServerNamespaceToWorkspace";
-import { jumpToTagAndOffset } from "./commands/jumpToTagAndOffset";
+import { jumpToTagAndOffset, openErrorLocation } from "./commands/jumpToTagAndOffset";
 import { connectFolderToServerNamespace } from "./commands/connectFolderToServerNamespace";
 import { DocumaticPreviewPanel } from "./commands/documaticPreviewPanel";
 
@@ -1207,6 +1207,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         return importLocalFilesToServerSideFolder(wsFolderUri);
       }
     }),
+    vscode.commands.registerCommand("vscode-objectscript.openErrorLocation", openErrorLocation),
 
     /* Anything we use from the VS Code proposed API */
     ...proposed


### PR DESCRIPTION
This PR fixes #1094 

The command is available in the command palette. When run, it prompts the user to enter an error location in the format `label+offset^routine`, then opens that location. 