### PR TITLE
Prepare next release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## [2.4.4] 27-Feb-2023
+## [2.6.0] 27-Feb-2023
 - Enhancements
-  - Implement async server-side search (#1045)
+  - Implement async server-side search (#1045) (requires [proposed API enabled](https://github.com/intersystems-community/vscode-objectscript#enable-proposed-apis) and InterSystems IRIS 2023.1+)
   - Add `Switch Namespace` option to Server Actions menu for local workspace folders (#1065) (contributed by @ollitanska)
   - Document Studio keyboard shortcut equivalents (#1076)
   - Improve `isfs` folder creation/modification UX (#1090)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [2.4.4] 27-Feb-2023
+- Enhancements
+  - Implement async server-side search (#1045)
+  - Add `Switch Namespace` option to Server Actions menu for local workspace folders (#1065) (contributed by @ollitanska)
+  - Document Studio keyboard shortcut equivalents (#1076)
+  - Improve `isfs` folder creation/modification UX (#1090)
+  - Implement `Open Error Location...` command (#1095)
+- Fixes
+  - Use webview toolkit in Documatic panel (#1074)
+  - Fix isfs folder deletion (#1080)
+  - Support non-ASCII characters in REST Debug query params (#1081)
+  - Fall back to Index for deployed check if query fails (#1083)
+  - Correctly set breakpoints in methods with quoted names (#1086)
+  - Properly handle other files and packages in server-side projects (#1087)
+  - Add charset to REST Debug panel's Content-Type (#1092)
+  - Fix namespace pick when trying to connect without permissions on `%SYS` (#1097)
+  - Fix server-side search in compiler keywords and values (#1102)
+  - Upgrade vulnerable dependencies.
+
 ## [2.4.3] 02-Feb-2023
 - Fixes
   - Fix deployed check (#1071)

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
 	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `2.4.4`, look for `2.4.5-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-2.4.5-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `2.6.0`, look for `2.6.1-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+	- Download the VSIX file (for example `vscode-objectscript-2.6.1-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
 	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `2.4.3`, look for `2.4.4-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-2.4.4-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `2.4.4`, look for `2.4.5-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+	- Download the VSIX file (for example `vscode-objectscript-2.4.5-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-objectscript",
   "displayName": "InterSystems ObjectScript",
   "description": "InterSystems ObjectScript language support for Visual Studio Code",
-  "version": "2.4.4-SNAPSHOT",
+  "version": "2.6.0-SNAPSHOT",
   "icon": "images/logo.png",
   "aiKey": "9cd75d51-697c-406c-a929-2bcf46e97c64",
   "categories": [


### PR DESCRIPTION
The next version is currently set for 2.4.4 but the change list is pretty big so if you want to bump it to 2.6.0 I can do that.