### PR TITLE
Add `SOAP Wizard` to Server Actions menu

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -247,8 +247,7 @@ An example links configuration looks like this:
 ```json
 "objectscript.conn": {
     "links": {
-        "Portal Explorer": "${serverUrl}/csp/sys/exp/%25CSP.UI.Portal.ClassList.zen?$NAMESPACE=${ns}",
-        "SOAP Wizard": "${serverUrl}/isc/studio/templates/%25ZEN.Template.AddInWizard.SOAPWizard.cls?$NAMESPACE=${ns}"
+        "Portal Explorer": "${serverUrl}/csp/sys/exp/%25CSP.UI.Portal.ClassList.zen?$NAMESPACE=${ns}"
     },
 }
 ```


### PR DESCRIPTION
This PR adds the `SOAP Wizard` to the Server Actions menu. We get a lot of questions about this wizard so it makes sense that we should link to it without requiring user configuration. If the user already manually added a link to it using the `objectscript.conn.links` setting, their menu item will be shown instead of our default one.