### PR TITLE
Don't switch Panel to Output tab when starting with proposed API enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -664,7 +664,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   if (proposed.length > 0) {
     outputChannel.appendLine(`${extensionId} version ${extensionVersion} activating with proposed APIs available.\n`);
-    outputChannel.show(true);
   }
 
   const languageServerExt =


### PR DESCRIPTION
This PR stops the extension from forcibly switching the Panel to show our Output channel whenever activating with proposed APIs enabled.