### PR TITLE
Deprecate confusing `objectscript.serverSideEditing` setting

### DIFF
--- a/docs/ServerSide.md
+++ b/docs/ServerSide.md
@@ -178,7 +178,6 @@ Use **File > New File** to create a new file. Add content similar to the followi
     }
   ],
   "settings": {
-    "objectscript.serverSideEditing": true
   }
 }
 ```
@@ -220,8 +219,7 @@ Example with connection to different namespaces on the same server.
       "password": "SYS",
       "ns": "MYAPP",
       "port": 52773,
-    },
-    "objectscript.serverSideEditing": true
+    }
   }
 }
 ```

--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -73,7 +73,6 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.openClassContracted"` | Automatically collapse all class member folding ranges when a class is opened for the first time. | `boolean` | `false` | |
 | `"objectscript.overwriteServerChanges"` | Overwrite a changed server version without confirmation when importing the local file. | `boolean` | `false` | |
 | `"objectscript.projects.webAppFileExtensions"` | When browsing a virtual workspace folder that has a project query parameter, all files with these extensions will be automatically treated as web application files. Extensions added here will be appended to the default list and should **NOT** include a dot. | `string[]` | `[]` | Default extensions: `["csp","csr","ts","js","css","scss","sass","less","html","json","md","markdown","png","svg","jpeg","jpg","ico","xml","txt"]` |
-| `"objectscript.serverSideEditing"` | Allow editing code directly on the server after opening it from ObjectScript Explorer. | `boolean` | `false` | |
 | `"objectscript.serverSourceControl .disableOtherActionTriggers"` | Prevent server-side source control 'other action' triggers from firing. | `boolean` | `false` | |
 | `"objectscript.showExplorer"` | Show the ObjectScript Explorer view. | `boolean` | `true` | |
 | `"objectscript.showGeneratedFileDecorations"` | Controls whether a badge is shown in the file explorer and open editors view for generated files. | `boolean` | `true` | |

--- a/package.json
+++ b/package.json
@@ -1396,11 +1396,6 @@
           "type": "boolean",
           "description": "Suppress popup messages about errors during compile, but still focus on Output view."
         },
-        "objectscript.serverSideEditing": {
-          "default": false,
-          "type": "boolean",
-          "description": "Allow editing code directly on the server after opening it from ObjectScript Explorer."
-        },
         "objectscript.debug.debugThisMethod": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -1396,6 +1396,12 @@
           "type": "boolean",
           "description": "Suppress popup messages about errors during compile, but still focus on Output view."
         },
+        "objectscript.serverSideEditing": {
+          "default": false,
+          "type": "boolean",
+          "description": "Allow editing code directly on the server after opening it from ObjectScript Explorer.",
+          "deprecationMessage": "This setting is deprecated and will be removed in the next release."
+        },
         "objectscript.debug.debugThisMethod": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -443,8 +443,7 @@ export async function checkConnection(
           explorerProvider.refresh();
           projectsExplorerProvider.refresh();
           // Refreshing Files Explorer also switches to it, so only do this if the uri is part of the workspace,
-          // otherwise files opened from ObjectScript Explorer (objectscript:// or isfs:// depending on the "objectscript.serverSideEditing" setting)
-          // will cause an unwanted switch.
+          // otherwise files opened from ObjectScript Explorer (objectscript://) will cause an unwanted switch.
           if (uri && schemas.includes(uri.scheme) && vscode.workspace.getWorkspaceFolder(uri)) {
             vscode.commands.executeCommand("workbench.files.action.refreshFilesExplorer");
           }

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -64,6 +64,9 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     wFolderUri?: vscode.Uri,
     forceServerCopy = false
   ): vscode.Uri {
+    if (vfs === undefined) {
+      vfs = config("serverSideEditing");
+    }
     let scheme = vfs ? FILESYSTEM_SCHEMA : OBJECTSCRIPT_FILE_SCHEMA;
     const isCsp = name.includes("/");
 

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -64,9 +64,6 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     wFolderUri?: vscode.Uri,
     forceServerCopy = false
   ): vscode.Uri {
-    if (vfs === undefined) {
-      vfs = config("serverSideEditing");
-    }
     let scheme = vfs ? FILESYSTEM_SCHEMA : OBJECTSCRIPT_FILE_SCHEMA;
     const isCsp = name.includes("/");
 
@@ -198,7 +195,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     }
     const data = await api.getDoc(fileName);
     if (Buffer.isBuffer(data.result.content)) {
-      return "\nThis is a binary file.\n\nTo access its contents, export it to the local file system.\nAlternatively, enable the 'objectscript.serverSideEditing' setting.";
+      return "\nThis is a binary file.\n\nTo access its contents, export it to the local file system.";
     } else {
       return data.result.content.join("\n");
     }


### PR DESCRIPTION
This PR fixes #1115 