### PR TITLE
Debugging's websocket should ignore self-signed cert error when `http.proxyStrictSSL` is `false`

### DIFF
--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -148,6 +148,7 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       this._url = api.xdebugUrl();
 
       const socket = new WebSocket(this._url, {
+        rejectUnauthorized: vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),
         headers: {
           cookie: this.cookies,
         },


### PR DESCRIPTION
This PR fixes #1136 by making debug's secure websocket check the same setting as the extension does for its REST requests over https to a webserver that uses a self-signed certificate.