### PR TITLE
Prompt user to enable proposed APIs if server-side folder is open

### DIFF
--- a/docs/SettingsReference.md
+++ b/docs/SettingsReference.md
@@ -78,6 +78,7 @@ The extensions in the InterSystems ObjectScript Extension Pack provide many sett
 | `"objectscript.serverSourceControl .disableOtherActionTriggers"` | Prevent server-side source control 'other action' triggers from firing. | `boolean` | `false` | |
 | `"objectscript.showExplorer"` | Show the ObjectScript Explorer view. | `boolean` | `true` | |
 | `"objectscript.showGeneratedFileDecorations"` | Controls whether a badge is shown in the file explorer and open editors view for generated files. | `boolean` | `true` | |
+| `"objectscript.showProposedApiPrompt"` | Controls whether a prompt to enable VS Code proposed APIs is shown when a server-side workspace folder is opened. | `boolean` | `true` | |
 | `"objectscript.studioActionDebugOutput"` | Log in JSON format the action that VS Code should perform as requested by the server. | `boolean` | `false` | Actions will be logged to the `ObjectScript` Output channel. |
 | `"objectscript.suppressCompileErrorMessages"` | Suppress popup messages about errors during compile, but still focus on Output view. | `boolean` | `false` | |
 | `"objectscript.suppressCompileMessages"` | Suppress popup messages about successful compile. | `boolean` | `true` | |

--- a/package.json
+++ b/package.json
@@ -1477,6 +1477,11 @@
           "description": "Controls whether a badge is shown in the file explorer and open editors view for generated files.",
           "type": "boolean",
           "default": true
+        },
+        "objectscript.showProposedApiPrompt": {
+          "description": "Controls whether a prompt to enable VS Code proposed APIs is shown when a server-side workspace folder is opened.",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -563,7 +563,7 @@ function proposedApiPrompt(active: boolean, added?: readonly vscode.WorkspaceFol
     // Prompt the user with the proposed api install instructions
     vscode.window
       .showInformationMessage(
-        "[Searching across](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files) and [quick opening](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_quick-open) server-side files requires [VS Code proposed APIs](https://code.visualstudio.com/api/advanced-topics/using-proposed-api). Show the directions to enable?",
+        "[Searching across](https://code.visualstudio.com/docs/editor/codebasics#_search-across-files) and [quick opening](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_quick-open) server-side files requires [VS Code proposed APIs](https://code.visualstudio.com/api/advanced-topics/using-proposed-api). Show the instructions?",
         "Yes",
         "Later",
         "Never"


### PR DESCRIPTION
This PR adds a prompt to open the "Enable Proposed API" README directions when the workspace contains an `isfs` or `isfs-readonly` folder upon activation, or one is added.