### PR TITLE
Make folder-specific settings for ISFS folder work again

### DIFF
--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -145,7 +145,11 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-    uri = redirectDotvscodeRoot(uri);
+    const redirectedUri = redirectDotvscodeRoot(uri);
+    if (redirectedUri.path !== uri.path) {
+      // When redirecting the /.vscode subtree we must fill in as-yet-unvisited folders to fix https://github.com/intersystems-community/vscode-objectscript/issues/1143
+      return this._lookup(redirectedUri, true);
+    }
     return this._lookup(uri);
   }
 


### PR DESCRIPTION
This PR fixes #1143 

In 2.8.0 an ISFS folder whose server was [configured to support folder-specific settings](https://intersystems-community.github.io/vscode-objectscript/serverside/#configuring-storage-for-folder-specific-settings) was ignoring its settings.

To verify, create an ISFS workspace, open a class or routine, and  add this folder-specific setting:
```json
{
    "editor.fontSize": 24
}

```

Confirm that the font size increases. Then reload the workspace and confirm the code reloads at the larger size. Prior to this fix the reload would show standard-size font.