### PR TITLE
Fix typo in Projects Explorer welcome text

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,12 +119,12 @@
       },
       {
         "view": "ObjectScriptProjectsExplorer",
-        "contents": "To view or edit projects, create a virual workspace folder to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Add Server Namespace to Workspace](command:vscode-objectscript.addServerNamespaceToWorkspace)",
+        "contents": "To view or edit projects, create a virtual workspace folder to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Add Server Namespace to Workspace](command:vscode-objectscript.addServerNamespaceToWorkspace)",
         "when": "vscode-objectscript.projectsExplorerRootCount == 0 && workspaceFolderCount <= 0"
       },
       {
         "view": "ObjectScriptProjectsExplorer",
-        "contents": "To view or edit projects, create a virual workspace folder to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Add Server Namespace to Workspace](command:vscode-objectscript.addServerNamespaceToWorkspace)\nOr connect a local workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)",
+        "contents": "To view or edit projects, create a virtual workspace folder to [edit or view code directly on an InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Add Server Namespace to Workspace](command:vscode-objectscript.addServerNamespaceToWorkspace)\nOr connect a local workspace folder to an [InterSystems server](https://intersystems-community.github.io/vscode-objectscript/serverside/).\n[Choose Server and Namespace](command:vscode-objectscript.connectFolderToServerNamespace)",
         "when": "vscode-objectscript.projectsExplorerRootCount == 0 && workspaceFolderCount > 0"
       }
     ],


### PR DESCRIPTION
"virual" -> "virtual"