### PR TITLE
Make WebSocket Terminal launchable from Command Palette and Server Manager tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "onCommand:vscode-objectscript.modifyWsFolder",
     "onCommand:vscode-objectscript.openErrorLocation",
     "onCommand:vscode-objectscript.launchWebSocketTerminal",
+    "onCommand:vscode-objectscript.intersystems-servermanager.webterminal",
     "onTerminalProfile:vscode-objectscript.webSocketTerminal",
     "onLanguage:objectscript",
     "onLanguage:objectscript-int",
@@ -98,6 +99,7 @@
     "onLanguage:xml",
     "onView:ObjectScriptExplorer",
     "onView:ObjectScriptProjectsExplorer",
+    "onView:intersystems-community_servermanager",
     "onFileSystem:isfs",
     "onFileSystem:isfs-readonly",
     "onFileSystem:objectscript",
@@ -349,6 +351,10 @@
         {
           "command": "vscode-objectscript.launchWebSocketTerminal",
           "when": "vscode-objectscript.connectActive"
+        },
+        {
+          "command": "vscode-objectscript.intersystems-servermanager.webterminal",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -473,6 +479,11 @@
           "command": "vscode-objectscript.explorer.project.closeOtherServerNs",
           "when": "view == ObjectScriptProjectsExplorer && viewItem == projectsServerNsNode:extra",
           "group": "inline@10"
+        },
+        {
+          "command": "vscode-objectscript.intersystems-servermanager.webterminal",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "group": "inline@1"
         }
       ],
       "editor/context": [
@@ -1130,6 +1141,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.launchWebSocketTerminal",
         "title": "Launch WebSocket Terminal"
+      },
+      {
+        "command": "vscode-objectscript.intersystems-servermanager.webterminal",
+        "title": "Launch WebSocket Terminal",
+        "icon": "$(terminal)"
       }
     ],
     "keybindings": [

--- a/src/commands/webSocketTerminal.ts
+++ b/src/commands/webSocketTerminal.ts
@@ -2,7 +2,8 @@ import * as vscode from "vscode";
 import WebSocket = require("ws");
 
 import { AtelierAPI } from "../api";
-import { currentFile, outputChannel } from "../utils";
+import { connectionTarget, currentFile, outputChannel } from "../utils";
+import { config, resolveConnectionSpec } from "../extension";
 
 const keys = {
   enter: "\r",
@@ -596,6 +597,7 @@ class WebSocketTerminal implements vscode.Pseudoterminal {
 function terminalConfigForUri(
   api: AtelierAPI,
   extensionUri: vscode.Uri,
+  targetUri: vscode.Uri,
   throwErrors = false
 ): vscode.ExtensionTerminalOptions | undefined {
   const reportError = (msg: string) => {
@@ -619,19 +621,60 @@ function terminalConfigForUri(
 
   return {
     name: api.config.serverName && api.config.serverName != "" ? api.config.serverName : "iris",
-    location: vscode.TerminalLocation.Panel,
+    location:
+      // Mimic what a built-in profile does. When it is the default and the Terminal tab is selected while empty,
+      // an terminal is always created in the Panel.
+      vscode.workspace.getConfiguration("terminal.integrated", targetUri).get("defaultLocation") === "editor" &&
+      vscode.window.terminals.length > 0
+        ? vscode.TerminalLocation.Editor
+        : vscode.TerminalLocation.Panel,
     pty: new WebSocketTerminal(api),
     isTransient: true,
     iconPath: vscode.Uri.joinPath(extensionUri, "images", "fileIcon.svg"),
   };
 }
 
-export async function launchWebSocketTerminal(extensionUri: vscode.Uri): Promise<void> {
+async function workspaceUriForTerminal() {
+  let uri: vscode.Uri;
+  const workspaceFolders = vscode.workspace.workspaceFolders || [];
+  if (workspaceFolders.length == 0) {
+    throw new Error("WebSocket Terminal requires an open workspace.");
+  } else if (workspaceFolders.length == 1) {
+    // Use the current connection
+    uri = workspaceFolders[0].uri;
+  } else {
+    // Pick from the workspace folders
+    uri = (
+      await vscode.window.showWorkspaceFolderPick({
+        ignoreFocusOut: true,
+        placeHolder: "Pick the workspace folder to get server connection information from",
+      })
+    )?.uri;
+  }
+  return uri;
+}
+
+export async function launchWebSocketTerminal(extensionUri: vscode.Uri, targetUri?: vscode.Uri): Promise<void> {
   // Determine the server to connect to
-  const api = new AtelierAPI(currentFile()?.uri);
+  if (targetUri) {
+    // Uri passed as command argument might be for a server we haven't yet resolve connection details such as password,
+    // so make sure that happens now if needed
+    const { configName } = connectionTarget(targetUri);
+    const serverName = targetUri.scheme === "file" ? config("conn", configName).server : configName;
+    await resolveConnectionSpec(serverName);
+  } else {
+    targetUri = currentFile()?.uri;
+    if (!targetUri) {
+      targetUri = await workspaceUriForTerminal();
+    }
+  }
+  const api = new AtelierAPI(targetUri);
+
+  // Guarantee we know the apiVersion of the server
+  await api.serverInfo();
 
   // Get the terminal configuration
-  const terminalOpts = terminalConfigForUri(api, extensionUri);
+  const terminalOpts = terminalConfigForUri(api, extensionUri, targetUri);
   if (terminalOpts) {
     // Launch the terminal
     const terminal = vscode.window.createTerminal(terminalOpts);
@@ -642,28 +685,13 @@ export async function launchWebSocketTerminal(extensionUri: vscode.Uri): Promise
 export class WebSocketTerminalProfileProvider implements vscode.TerminalProfileProvider {
   constructor(private readonly _extensionUri: vscode.Uri) {}
 
-  async provideTerminalProfile(token: vscode.CancellationToken): Promise<vscode.TerminalProfile> {
+  async provideTerminalProfile(_token: vscode.CancellationToken): Promise<vscode.TerminalProfile> {
     // Determine the server connection to use
-    let uri: vscode.Uri;
-    const workspaceFolders = vscode.workspace.workspaceFolders || [];
-    if (workspaceFolders.length == 0) {
-      throw new Error("WebSocket Terminal requires an open workspace.");
-    } else if (workspaceFolders.length == 1) {
-      // Use the current connection
-      uri = workspaceFolders[0].uri;
-    } else {
-      // Pick from the workspace folders
-      uri = (
-        await vscode.window.showWorkspaceFolderPick({
-          ignoreFocusOut: true,
-          placeHolder: "Pick the workspace folder to get server connection information from",
-        })
-      )?.uri;
-    }
+    const uri: vscode.Uri = await workspaceUriForTerminal();
 
     if (uri) {
       // Get the terminal configuration. Will throw if there's an error.
-      const terminalOpts = terminalConfigForUri(new AtelierAPI(uri), this._extensionUri, true);
+      const terminalOpts = terminalConfigForUri(new AtelierAPI(uri), this._extensionUri, uri, true);
       return new vscode.TerminalProfile(terminalOpts);
     } else {
       throw new Error("WebSocket Terminal requires a selected workspace folder.");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1311,7 +1311,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     ),
     vscode.commands.registerCommand(
       "vscode-objectscript.intersystems-servermanager.webterminal",
-      async (namespaceTreeItem) => {
+      (namespaceTreeItem) => {
         const idArray = namespaceTreeItem.id.split(":");
         const serverId = idArray[1];
         const namespace = idArray[3];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1309,6 +1309,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.launchWebSocketTerminal", () =>
       launchWebSocketTerminal(context.extensionUri)
     ),
+    vscode.commands.registerCommand(
+      "vscode-objectscript.intersystems-servermanager.webterminal",
+      async (namespaceTreeItem) => {
+        const idArray = namespaceTreeItem.id.split(":");
+        const serverId = idArray[1];
+        const namespace = idArray[3];
+        const targetUri = vscode.Uri.from({ scheme: "isfs", authority: `${serverId}:${namespace}` });
+        launchWebSocketTerminal(context.extensionUri, targetUri);
+      }
+    ),
     vscode.window.registerTerminalProfileProvider(
       "vscode-objectscript.webSocketTerminal",
       new WebSocketTerminalProfileProvider(context.extensionUri)


### PR DESCRIPTION
This PR fixes a bug with the command for launching a terminal. It also contributes launch buttons to namespaces in the Server Manager tree, and respects the `terminal.integrated.defaultLocation` setting.