### PR TITLE
Remove `objectscript.serverSideEditing` setting

### DIFF
--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -64,9 +64,6 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     wFolderUri?: vscode.Uri,
     forceServerCopy = false
   ): vscode.Uri {
-    if (vfs === undefined) {
-      vfs = config("serverSideEditing");
-    }
     let scheme = vfs ? FILESYSTEM_SCHEMA : OBJECTSCRIPT_FILE_SCHEMA;
     const isCsp = name.includes("/");
 


### PR DESCRIPTION
This setting was deprecated in #1116. 