### PR TITLE
Support a ${username} variable in Server Actions Menu custom entries

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -239,6 +239,7 @@ You can add custom entries to this list using the `objectscript.conn.links` conf
 - **${serverUrl}** - The full connection string for the server. For example, `http://localhost:52773/pathPrefix`
 - **${ns}** - The namespace that we are connected to, URL encoded. For example, `%25SYS` or `USER`
 - **${namespace}** - The raw `ns` parameter of the connection. For example, `sys` or `user`
+- **${username}** - The username you are connected as.
 - **${classname}** - The name of the currently opened class, or the empty string if the currently opened document is not a class.
 - **${classnameEncoded}** - URL encoded version of **\${classname}**.
 - **${project}** - The currently opened server-side project, or the empty string.

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -23,7 +23,7 @@ type ServerAction = { detail: string; id: string; label: string; rawLink?: strin
 export async function serverActions(): Promise<void> {
   const { apiTarget, configName: workspaceFolder } = connectionTarget();
   const api = new AtelierAPI(apiTarget);
-  const { active, host = "", ns = "", https, port = 0, pathPrefix, docker } = api.config;
+  const { active, host = "", ns = "", https, port = 0, pathPrefix, username, docker } = api.config;
   const explorerCount = (await explorerProvider.getChildren()).length;
   if (!explorerCount && (!docker || host === "")) {
     await vscode.commands.executeCommand("ObjectScriptExplorer.focus");
@@ -156,6 +156,7 @@ export async function serverActions(): Promise<void> {
       .replace("${serverAuth}", "")
       .replace("${ns}", nsEncoded)
       .replace("${namespace}", ns == "%SYS" ? "sys" : nsEncoded.toLowerCase())
+      .replace("${username}", username)
       .replace("${classname}", classname)
       .replace("${classnameEncoded}", classnameEncoded)
       .replace("${project}", project);


### PR DESCRIPTION
Like PR #1157 this adds a variable which some Studio add-ins rely upon being available in the `User` queryparam.

To use it, append `&User=${username}` to the relevant `objectscript.conn.links` entry.