### PR TITLE
Debugger improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,28 +1,25 @@
 {
   "name": "vscode-objectscript",
-  "version": "2.6.1-SNAPSHOT",
+  "version": "2.8.2-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "2.6.1-SNAPSHOT",
+      "version": "2.8.2-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.8.3",
-        "await-notify": "^1.0.1",
+        "@vscode/debugadapter": "^1.61.0",
+        "@vscode/debugprotocol": "^1.61.0",
+        "@xmldom/xmldom": "^0.8.8",
         "core-js": "^3.6.5",
-        "domexception": "^2.0.1",
         "glob": "^7.1.6",
         "iconv-lite": "^0.6.0",
         "istextorbinary": "^6.0.0",
-        "mkdirp": "^1.0.4",
         "node-cmd": "^5.0.0",
         "node-fetch-cjs": "3.1.1",
         "vscode-cache": "^0.3.0",
-        "vscode-debugadapter": "^1.41.0",
-        "vscode-debugprotocol": "^1.41.0",
         "vscode-extension-telemetry": "^0.1.6",
         "ws": "^7.4.6"
       },
@@ -36,6 +33,7 @@
         "@types/xmldom": "^0.1.29",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
         "@typescript-eslint/parser": "^4.32.0",
+        "@vscode/dts": "^0.4.0",
         "@vscode/test-electron": "^2.1.5",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
@@ -51,7 +49,6 @@
         "ts-loader": "^7.0.5",
         "typescript": "^4.4.3",
         "vscode-debugadapter-testsupport": "^1.41.0",
-        "vscode-dts": "^0.3.2",
         "webpack": "^5.76.0",
         "webpack-cli": "^4.5.0"
       },
@@ -624,6 +621,78 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "node_modules/@vscode/debugadapter": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.61.0.tgz",
+      "integrity": "sha512-VDGLUFDVAdnftUebZe4uQCIFUbJ7rTc2Grps4D/CXl+qyzTZSQLv5VADEOZ6kBYG4SvlnMLql5vPQ0G6XvUCvQ==",
+      "dependencies": {
+        "@vscode/debugprotocol": "1.61.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@vscode/debugprotocol": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.61.0.tgz",
+      "integrity": "sha512-K/kF27jIStVFqlmUaGc2u+Dj8IR7YdEiSqShWr7MWhDudqpAW7uu7XMwoFwjpuC9LSaVwJMIX7EFC5OJ/RmnDQ=="
+    },
+    "node_modules/@vscode/dts": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@vscode/dts/-/dts-0.4.0.tgz",
+      "integrity": "sha512-m28fZnyS9PlzVvYHppyC3Q98U2RFIZO2srnBMvyupPBY5QkSxoNIjTV9roLaU7kE+gc+HXczH8XHPETUkt9IAA==",
+      "dev": true,
+      "dependencies": {
+        "https-proxy-agent": "^7.0.0",
+        "minimist": "^1.2.8",
+        "prompts": "^2.4.2"
+      },
+      "bin": {
+        "dts": "index.js"
+      }
+    },
+    "node_modules/@vscode/dts/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@vscode/dts/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vscode/dts/node_modules/https-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
@@ -822,9 +891,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
+      "integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1068,11 +1137,6 @@
       "bin": {
         "semver": "bin/semver"
       }
-    },
-    "node_modules/await-notify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-      "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
     },
     "node_modules/axe-core": {
       "version": "4.3.5",
@@ -1578,17 +1642,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "dependencies": {
-        "webidl-conversions": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/duplexer2": {
@@ -3437,20 +3490,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-      "dev": true
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/mocha": {
@@ -4891,15 +4936,6 @@
       "resolved": "https://registry.npmjs.org/vscode-cache/-/vscode-cache-0.3.0.tgz",
       "integrity": "sha1-fMOWZOvZnTcDAwaLibxMlWFGZ8A="
     },
-    "node_modules/vscode-debugadapter": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.50.0.tgz",
-      "integrity": "sha512-KHtwd6uHOqB1C2/1hpKQcD4JY/88QXkieubzKQfT1PTLztnoM53Pz+pTNgH+VXrGDI50BzjLV6YOluPTufUaMQ==",
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "vscode-debugprotocol": "1.50.1"
-      }
-    },
     "node_modules/vscode-debugadapter-testsupport": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.50.0.tgz",
@@ -4912,21 +4948,8 @@
     "node_modules/vscode-debugprotocol": {
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.50.1.tgz",
-      "integrity": "sha512-kIHIipklHnSjBm2KkRqTJLKL2FMZlJl0+/qpJt2y62YOamMNwcxNATnXXRgAwnzKKRMweqp93tJ83UTJ8+O7SQ=="
-    },
-    "node_modules/vscode-dts": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/vscode-dts/-/vscode-dts-0.3.2.tgz",
-      "integrity": "sha512-vL6p3MYuRgyvztEyK/X+7KH8JqMrqzxSvZZi8e0eMubCj2v0POmypitJ93EcHSkZbULA2mCK6mdp5bZ5Re/bZw==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0",
-        "prompts": "^2.1.0",
-        "rimraf": "^3.0.0"
-      },
-      "bin": {
-        "vscode-dts": "index.js"
-      }
+      "integrity": "sha512-kIHIipklHnSjBm2KkRqTJLKL2FMZlJl0+/qpJt2y62YOamMNwcxNATnXXRgAwnzKKRMweqp93tJ83UTJ8+O7SQ==",
+      "dev": true
     },
     "node_modules/vscode-extension-telemetry": {
       "version": "0.1.7",
@@ -4950,14 +4973,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/webpack": {
@@ -5717,6 +5732,60 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vscode/debugadapter": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.61.0.tgz",
+      "integrity": "sha512-VDGLUFDVAdnftUebZe4uQCIFUbJ7rTc2Grps4D/CXl+qyzTZSQLv5VADEOZ6kBYG4SvlnMLql5vPQ0G6XvUCvQ==",
+      "requires": {
+        "@vscode/debugprotocol": "1.61.0"
+      }
+    },
+    "@vscode/debugprotocol": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.61.0.tgz",
+      "integrity": "sha512-K/kF27jIStVFqlmUaGc2u+Dj8IR7YdEiSqShWr7MWhDudqpAW7uu7XMwoFwjpuC9LSaVwJMIX7EFC5OJ/RmnDQ=="
+    },
+    "@vscode/dts": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@vscode/dts/-/dts-0.4.0.tgz",
+      "integrity": "sha512-m28fZnyS9PlzVvYHppyC3Q98U2RFIZO2srnBMvyupPBY5QkSxoNIjTV9roLaU7kE+gc+HXczH8XHPETUkt9IAA==",
+      "dev": true,
+      "requires": {
+        "https-proxy-agent": "^7.0.0",
+        "minimist": "^1.2.8",
+        "prompts": "^2.4.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+          "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+          "dev": true,
+          "requires": {
+            "debug": "^4.3.4"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.0.tgz",
+          "integrity": "sha512-0euwPCRyAPSgGdzD1IVN9nJYHtBhJwb6XPfbpQcYbPCwrBidX6GzxmchnaF4sfF/jPb74Ojx5g4yTg3sixlyPw==",
+          "dev": true,
+          "requires": {
+            "agent-base": "^7.0.2",
+            "debug": "4"
+          }
+        }
+      }
+    },
     "@vscode/test-electron": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.5.tgz",
@@ -5899,9 +5968,9 @@
       "requires": {}
     },
     "@xmldom/xmldom": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
-      "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
+      "integrity": "sha512-0LNz4EY8B/8xXY86wMrQ4tz6zEHZv9ehFMJPm8u2gq5lQ71cfRKdaKyxfJAx5aUoyzx0qzgURblTisPGgz3d+Q=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -6082,11 +6151,6 @@
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         }
       }
-    },
-    "await-notify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/await-notify/-/await-notify-1.0.1.tgz",
-      "integrity": "sha1-C0gTOyLlJBgeEVV2ZRhfKi885Hw="
     },
     "axe-core": {
       "version": "4.3.5",
@@ -6461,14 +6525,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "domexception": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
-      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
-      "requires": {
-        "webidl-conversions": "^5.0.0"
       }
     },
     "duplexer2": {
@@ -7840,15 +7896,10 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
     "mocha": {
       "version": "9.2.2",
@@ -8898,15 +8949,6 @@
       "resolved": "https://registry.npmjs.org/vscode-cache/-/vscode-cache-0.3.0.tgz",
       "integrity": "sha1-fMOWZOvZnTcDAwaLibxMlWFGZ8A="
     },
-    "vscode-debugadapter": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/vscode-debugadapter/-/vscode-debugadapter-1.50.0.tgz",
-      "integrity": "sha512-KHtwd6uHOqB1C2/1hpKQcD4JY/88QXkieubzKQfT1PTLztnoM53Pz+pTNgH+VXrGDI50BzjLV6YOluPTufUaMQ==",
-      "requires": {
-        "mkdirp": "^1.0.4",
-        "vscode-debugprotocol": "1.50.1"
-      }
-    },
     "vscode-debugadapter-testsupport": {
       "version": "1.50.0",
       "resolved": "https://registry.npmjs.org/vscode-debugadapter-testsupport/-/vscode-debugadapter-testsupport-1.50.0.tgz",
@@ -8919,18 +8961,8 @@
     "vscode-debugprotocol": {
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/vscode-debugprotocol/-/vscode-debugprotocol-1.50.1.tgz",
-      "integrity": "sha512-kIHIipklHnSjBm2KkRqTJLKL2FMZlJl0+/qpJt2y62YOamMNwcxNATnXXRgAwnzKKRMweqp93tJ83UTJ8+O7SQ=="
-    },
-    "vscode-dts": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/vscode-dts/-/vscode-dts-0.3.2.tgz",
-      "integrity": "sha512-vL6p3MYuRgyvztEyK/X+7KH8JqMrqzxSvZZi8e0eMubCj2v0POmypitJ93EcHSkZbULA2mCK6mdp5bZ5Re/bZw==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0",
-        "prompts": "^2.1.0",
-        "rimraf": "^3.0.0"
-      }
+      "integrity": "sha512-kIHIipklHnSjBm2KkRqTJLKL2FMZlJl0+/qpJt2y62YOamMNwcxNATnXXRgAwnzKKRMweqp93tJ83UTJ8+O7SQ==",
+      "dev": true
     },
     "vscode-extension-telemetry": {
       "version": "0.1.7",
@@ -8949,11 +8981,6 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
-    },
-    "webidl-conversions": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-      "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
     },
     "webpack": {
       "version": "5.76.0",

--- a/package.json
+++ b/package.json
@@ -1590,7 +1590,11 @@
                   "number",
                   "string"
                 ],
-                "description": "The CSP debug ID to use to identify the target process. If provided, 'processId' is ignored."
+                "description": "The CSP debug ID to use to identify the target process. If provided, 'processId' and 'stopOnEntry' are ignored."
+              },
+              "stopOnEntry": {
+                "type": "boolean",
+                "description": "Automatically stop target after attach. If not specified, target does not stop."
               }
             }
           }
@@ -1679,7 +1683,7 @@
     "test": "node ./out/test/runTest.js",
     "lint": "eslint src/**",
     "lint-fix": "eslint --fix src/**",
-    "download-api": "vscode-dts dev 1.66.0",
+    "download-api": "dts dev 1.66.0",
     "postinstall": "npm run download-api"
   },
   "devDependencies": {
@@ -1692,6 +1696,7 @@
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
+    "@vscode/dts": "^0.4.0",
     "@vscode/test-electron": "^2.1.5",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^14.2.1",
@@ -1707,24 +1712,20 @@
     "ts-loader": "^7.0.5",
     "typescript": "^4.4.3",
     "vscode-debugadapter-testsupport": "^1.41.0",
-    "vscode-dts": "^0.3.2",
     "webpack": "^5.76.0",
     "webpack-cli": "^4.5.0"
   },
   "dependencies": {
-    "@xmldom/xmldom": "^0.8.3",
-    "await-notify": "^1.0.1",
+    "@xmldom/xmldom": "^0.8.8",
     "core-js": "^3.6.5",
-    "domexception": "^2.0.1",
     "glob": "^7.1.6",
     "iconv-lite": "^0.6.0",
     "istextorbinary": "^6.0.0",
-    "mkdirp": "^1.0.4",
     "node-cmd": "^5.0.0",
     "node-fetch-cjs": "3.1.1",
     "vscode-cache": "^0.3.0",
-    "vscode-debugadapter": "^1.41.0",
-    "vscode-debugprotocol": "^1.41.0",
+    "@vscode/debugadapter": "^1.61.0",
+    "@vscode/debugprotocol": "^1.61.0",
     "vscode-extension-telemetry": "^0.1.6",
     "ws": "^7.4.6"
   }

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -282,8 +282,7 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       // so send one right away, regardless of the stopOnEntry value
       await this._connection.sendRunCommand();
     }
-    if (this._stopOnEntry && !this._isCsp) {
-      // This can only be true for attach requests, but ignore it for CSP attaches
+    if (this._stopOnEntry && !this._isLaunch && !this._isCsp) {
       // Tell VS Code that we're stopped
       this.sendResponse(response);
       const event: DebugProtocol.StoppedEvent = new StoppedEvent("entry", this._connection.id);


### PR DESCRIPTION
* Fixes #1169 by implementing workaround described in https://github.com/microsoft/vscode/issues/185785#issuecomment-1601337997
* Fixes #1170 
* For `attach` requests, wait for the target process to break before attempting to set breakpoints.
* De-emphasize stack frames with source code that isn't available (for example, system classes that art deployed) so they aren't auto-opened when the target breaks. (required VS Code version 1.80 and above due to https://github.com/microsoft/vscode/issues/184640)
* Implemented `stopOnEntry` property for non-CSP `attach` requests.
* Upgrade to `@vscode` versions of the debug adapter and debug protocol modules.
* Always send `detach` command for disconnect requests, regardless of request type.
* Properly run the target process for non-CSP `attach` requests when configuration is done. In that case, the server ignores the first `run` command, so we need to send two.