### PR TITLE
Remove reference to `objectscript.serverSideEditing`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1419,12 +1419,6 @@
           "type": "boolean",
           "description": "Suppress popup messages about errors during compile, but still focus on Output view."
         },
-        "objectscript.serverSideEditing": {
-          "default": false,
-          "type": "boolean",
-          "description": "Allow editing code directly on the server after opening it from ObjectScript Explorer.",
-          "deprecationMessage": "This setting is deprecated and will be removed in the next release."
-        },
         "objectscript.debug.debugThisMethod": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
We removed this setting in 2.10.0, but users will still see a deprecation notice for it rather than an "unknown setting" hover.