### PR TITLE
Hide WebSocket Terminal button on incompatible servers (requires Server Manager 3.4.2+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
         },
         {
           "command": "vscode-objectscript.intersystems-servermanager.webterminal",
-          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/",
+          "when": "view == intersystems-community_servermanager && viewItem =~ /namespace$/ && (viewItem > 6 || !(viewItem =~ /^\\d+/))",
           "group": "inline@1"
         }
       ],


### PR DESCRIPTION
This PR implements #1204 

When used with a version of Server Manager containing https://github.com/intersystems-community/intersystems-servermanager/pull/207 the WebSocket Terminal button should only appear on namespaces of servers that are 2023.2 or greater.

When used with earlier Server Managers the button should continue to display on all servers' namespaces. As before, clicking it on a pre-2023.2 server will produce an error notification.