### PR TITLE
Improve message to help resolve scenario where isfs user lacks %DB_IRISSYS:READ

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "2.10.1-SNAPSHOT",
+  "version": "2.10.2-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "2.10.1-SNAPSHOT",
+      "version": "2.10.2-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -259,9 +259,10 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         if (error) {
           console.log(error);
           if (error.errorText.includes(" #5540:")) {
+            const nsUpper = api.config.ns.toUpperCase();
             const message = `User '${api.config.username}' cannot list ${
-              csp ? "web application" : "namespace"
-            } contents. To resolve this, execute the following SQL in the ${api.config.ns.toUpperCase()} namespace:\n\t GRANT EXECUTE ON %Library.RoutineMgr_StudioOpenDialog TO ${
+              csp ? `web application '${uri.path}'` : "namespace"
+            } contents. If they do not have READ permission on the default code database of the ${nsUpper} namespace then grant it and retry. If the problem remains then execute the following SQL in that namespace:\n\t GRANT EXECUTE ON %Library.RoutineMgr_StudioOpenDialog TO ${
               api.config.username
             }`;
             outputChannel.appendError(message);


### PR DESCRIPTION
If an isfs user only holds the out-of-the-box %Developer role they aren't able to access the %SYS namespace, which is the home of the webapp providing folder-specific settings storage. This scenario was producing a misleading message advising a SQL GRANT statement to be run. This PR improves the message to help identify the problem.