### PR TITLE
Expand allowed Unicode characters in class names

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -14,6 +14,7 @@ import {
 } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import {
+  classNameRegex,
   cspAppsForUri,
   CurrentBinaryFile,
   currentFile,
@@ -23,6 +24,7 @@ import {
   isClassDeployed,
   notNull,
   outputChannel,
+  routineNameTypeRegex,
   throttleRequests,
 } from "../utils";
 import { PackageNode } from "../explorer/models/packageNode";
@@ -770,12 +772,12 @@ export async function importLocalFilesToServerSideFolder(wsFolderUri: vscode.Uri
           let ext = "";
           if (uri.path.split(".").pop().toLowerCase() == "cls") {
             // Allow Unicode letters
-            const match = content.match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+            const match = content.match(classNameRegex);
             if (match) {
               [, docName, ext = "cls"] = match;
             }
           } else {
-            const match = content.match(/^ROUTINE ([^\s]+)(?:\s*\[\s*Type\s*=\s*\b([a-z]{3})\b)?/i);
+            const match = content.match(routineNameTypeRegex);
             if (match) {
               [, docName, ext = "mac"] = match;
             } else {

--- a/src/commands/documaticPreviewPanel.ts
+++ b/src/commands/documaticPreviewPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode";
+import { classNameRegex } from "../utils";
 
 /**
  * The schema of the message that gets sent to the webview.
@@ -59,7 +60,7 @@ export class DocumaticPreviewPanel {
 
     // Get the name of the current class
     let clsname = "";
-    const match = openDoc.getText().match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+    const match = openDoc.getText().match(classNameRegex);
     if (match) {
       [, clsname] = match;
     }
@@ -282,7 +283,7 @@ export class DocumaticPreviewPanel {
 
           // Get the name of the current class
           let clsname = "";
-          const match = editor.document.getText().match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+          const match = editor.document.getText().match(classNameRegex);
           if (match) {
             [, clsname] = match;
           }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -6,6 +6,7 @@ import { File } from "./File";
 import { fireOtherStudioAction, OtherStudioAction } from "../../commands/studio";
 import { projectContentsFromUri, studioOpenDialogFromURI } from "../../utils/FileProviderUtil";
 import {
+  classNameRegex,
   isClassDeployed,
   notNull,
   outputChannel,
@@ -348,7 +349,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           }
           // Check if the class name and file name match
           let clsname = "";
-          const match = content.toString().match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+          const match = content.toString().match(classNameRegex);
           if (match) {
             [, clsname] = match;
           }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -148,6 +148,12 @@ export function isImportableLocalFile(file: vscode.TextDocument): boolean {
   }
 }
 
+/** A regex for extracting the name of a class from its content */
+export const classNameRegex = /^[ \t]*Class[ \t]+(%?[\p{L}\d\u{100}-\u{ffff}]+(?:\.[\p{L}\d\u{100}-\u{ffff}]+)+)/imu;
+
+/** A regex for extracting the name and type of a routine from its content */
+export const routineNameTypeRegex = /^ROUTINE ([^\s]+)(?:\s*\[\s*Type\s*=\s*\b([a-z]{3})\b)?/i;
+
 export function currentFileFromContent(uri: vscode.Uri, content: string | Buffer): CurrentTextFile | CurrentBinaryFile {
   const fileName = uri.fsPath;
   const workspaceFolder = workspaceFolderOfUri(uri);
@@ -160,12 +166,12 @@ export function currentFileFromContent(uri: vscode.Uri, content: string | Buffer
   let ext = "";
   if (fileExt === "cls" && typeof content === "string") {
     // Allow Unicode letters
-    const match = content.match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+    const match = content.match(classNameRegex);
     if (match) {
       [, name, ext = "cls"] = match;
     }
   } else if (fileExt.match(/(mac|int|inc)/i) && typeof content === "string") {
-    const match = content.match(/^ROUTINE ([^\s]+)(?:\s*\[\s*Type\s*=\s*\b([a-z]{3})\b)?/i);
+    const match = content.match(routineNameTypeRegex);
     if (match) {
       [, name, ext = "mac"] = match;
     } else {
@@ -244,12 +250,12 @@ export function currentFile(document?: vscode.TextDocument): CurrentTextFile {
     name = uri.path;
   } else if (fileExt === "cls") {
     // Allow Unicode letters
-    const match = content.match(/^[ \t]*Class[ \t]+(%?[\p{L}\d]+(?:\.[\p{L}\d]+)+)/imu);
+    const match = content.match(classNameRegex);
     if (match) {
       [, name, ext = "cls"] = match;
     }
   } else if (fileExt.match(/(mac|int|inc)/i)) {
-    const match = content.match(/^ROUTINE ([^\s]+)(?:\s*\[\s*Type\s*=\s*\b([a-z]{3})\b)?/i);
+    const match = content.match(routineNameTypeRegex);
     if (match) {
       [, name, ext = "mac"] = match;
     } else {


### PR DESCRIPTION
Starting with IRIS 2023.3, any Unicode character above 255 will be allowed in identifiers. This PR modifies our class name regex to match those characters.