### PR TITLE
Put link to editor in class comment when creating new BPL/DTL

### DIFF
--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -535,20 +535,20 @@ Method OnProcessInput(pInput As %RegisteredObject, pOutput As %RegisteredObject)
 ${typeof desc == "string" ? "/// " + desc.replace(/\n/g, "\n/// ") : ""}
 Class ${cls} Extends Ens.BusinessProcessBPL [ ClassType = persistent, ProcedureBlock ]
 {
-
-/// BPL Definition
-XData BPL [ XMLNamespace = "http://www.intersystems.com/bpl" ]
-{${
-          api
-            ? `
-<!--
+${
+  api
+    ? `
+/*
 You can edit this class in the Business Process Editor by pasting the following URL into your web browser.
 You can also edit this XML block directly.
 ${api.config.https ? "https" : "http"}://${api.config.host}:${api.config.port}${
-                api.config.pathPrefix
-              }/csp/${api.config.ns.toLowerCase()}/EnsPortal.BPLEditor.zen?BP=${cls}.BPL\n-->`
-            : ""
-        }
+        api.config.pathPrefix
+      }/csp/${api.config.ns.toLowerCase()}/EnsPortal.BPLEditor.zen?BP=${cls}.BPL\n*/\n`
+    : ""
+}
+/// BPL Definition
+XData BPL [ XMLNamespace = "http://www.intersystems.com/bpl" ]
+{
 <process language='objectscript' request='Ens.Request' response='Ens.Response' height='2000' width='2000' >
 <sequence xend='300' yend='450' >
 </sequence>
@@ -632,7 +632,17 @@ Class ${cls} Extends Ens.DataTransformDTL [ DependsOn = ${
           sourceCls == targetCls ? sourceCls : `(${sourceCls}, ${targetCls})`
         } ]
 {
-
+${
+  api
+    ? `
+/*
+You can edit this class in the Data Transformation Editor by pasting the following URL into your web browser.
+You can also edit this XML block directly.
+${api.config.https ? "https" : "http"}://${api.config.host}:${api.config.port}${
+        api.config.pathPrefix
+      }/csp/${api.config.ns.toLowerCase()}/EnsPortal.DTLEditor.zen?DT=${cls}.DTL\n*/\n`
+    : ""
+}
 Parameter IGNOREMISSINGSOURCE = 1;
 
 Parameter REPORTERRORS = 1;
@@ -640,17 +650,7 @@ Parameter REPORTERRORS = 1;
 Parameter TREATEMPTYREPEATINGFIELDASNULL = 0;
 
 XData DTL [ XMLNamespace = "http://www.intersystems.com/dtl" ]
-{${
-          api
-            ? `
-<!--
-You can edit this class in the Data Transformation Editor by pasting the following URL into your web browser.
-You can also edit this XML block directly.
-${api.config.https ? "https" : "http"}://${api.config.host}:${api.config.port}${
-                api.config.pathPrefix
-              }/csp/${api.config.ns.toLowerCase()}/EnsPortal.DTLEditor.zen?DT=${cls}.DTL\n-->`
-            : ""
-        }
+{
 <transform sourceClass='${sourceCls}' targetClass='${targetCls}' create='new' language='objectscript' >
 </transform>
 }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -27,7 +27,7 @@ export function generateFileContent(
   fileName: string,
   sourceContent: Buffer
 ): { content: string[]; enc: boolean } {
-  const sourceLines = sourceContent.toString().split("\n");
+  const sourceLines = new TextDecoder().decode(sourceContent).split("\n");
   const fileExt = fileName.split(".").pop().toLowerCase();
   const csp = fileName.startsWith("/");
   if (fileExt === "cls" && !csp) {
@@ -349,7 +349,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           }
           // Check if the class name and file name match
           let clsname = "";
-          const match = content.toString().match(classNameRegex);
+          const match = new TextDecoder().decode(content).match(classNameRegex);
           if (match) {
             [, clsname] = match;
           }


### PR DESCRIPTION
This PR fixes #1230. It also fixes a bug where new file content was getting overridden due to bad buffer to string conversion. I switched from `Buffer.toString()` to `new TextDecoder().decode()`.