### PR TITLE
Make it easier to add namespace from same server to workspace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -990,8 +990,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.previewXml", () => {
       xml2doc(context, vscode.window.activeTextEditor);
     }),
-    vscode.commands.registerCommand("vscode-objectscript.addServerNamespaceToWorkspace", () => {
-      addServerNamespaceToWorkspace();
+    vscode.commands.registerCommand("vscode-objectscript.addServerNamespaceToWorkspace", (resource?: vscode.Uri) => {
+      addServerNamespaceToWorkspace(resource);
     }),
     vscode.commands.registerCommand("vscode-objectscript.connectFolderToServerNamespace", () => {
       connectFolderToServerNamespace();


### PR DESCRIPTION
When using the Explorer context menu on a folder in an isfs workspace to add another root, make it easier to pick another namespace on the same server as the current root.

![image](https://github.com/intersystems-community/vscode-objectscript/assets/6726799/1010d03e-29e3-402d-a83a-f0e63306f8dc)
