### PR TITLE
Pass namespace differently to Studio add-in (fix #1249)

### DIFF
--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -251,7 +251,7 @@ export async function serverActions(): Promise<void> {
             if (addin) {
               const token = await getCSPToken(api, addin.id);
               vscode.env.openExternal(
-                vscode.Uri.parse(`${serverUrl}${addin.id}?$NAMESPACE=${nsEncoded}&CSPCHD=${token}`)
+                vscode.Uri.parse(`${serverUrl}${addin.id}?Namespace=${nsEncoded}&CSPCHD=${token}`)
               );
             }
           }


### PR DESCRIPTION
Previously passed as $NAMESPACE but this only works for first page of a multi-page add-in such as the SOAP wizard.

This PR fixes #1249