### PR TITLE
Adjust activity bar icon to work correctly with upcoming 1.84 top-bar feature

### DIFF
--- a/images/InterSystems.svg
+++ b/images/InterSystems.svg
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   class="custom-logo "
-   version="1.1"
-   id="Layer_1"
-   width="128px"
-   height="128px"
-   viewBox="0 0 128 128"
-   xml:space="preserve"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
+  class="custom-logo "
+  version="1.1"
+  id="Layer_1"
+  x="0px"
+  y="0px"
+  viewBox="0 0 80 80"
+  xml:space="preserve"
+  xmlns="http://www.w3.org/2000/svg"
+  xmlns:svg="http://www.w3.org/2000/svg">
   <g
    id="Canvas"
    fill="none"
-   transform="matrix(1.6318908,0,0,1.1754735,-22.624497,-0.68381501)">
-   	  <polygon
-   fill="#ffffff"
-   points="32.6,9.1 32.6,95.7 60.2,109.4 60.2,94.1 46.4,87.2 46.4,15.8 "
-   id="polygon1" />
-   	  <polygon
-   fill="#ffffff"
-   points="73.8,101 73.8,14.4 46.4,0.6 46.4,15.8 60.2,22.9 60.2,94.1 "
-   id="polygon2" />
-    </g>
-  </svg>
+   transform="matrix(1.1764706,0,0,1.1764706,15.338235,-9.2941177)">
+    <polygon
+      fill="#ffffff"
+      points="25.1,75.9 25.1,66.3 16.5,62 16.5,17.4 7.9,13.2 7.9,67.3 "
+      id="polygon1" />
+    <polygon
+    fill="#ffffff"
+    points="16.5,7.9 16.5,17.4 25.1,21.8 25.1,66.3 33.6,70.6 33.6,16.5 "
+    id="polygon2" />
+  </g>
+</svg>

--- a/images/InterSystems.svg
+++ b/images/InterSystems.svg
@@ -1,7 +1,25 @@
-<?xml version="1.0" standalone="yes"?>
-<svg class="custom-logo " version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="110px" height="110px" viewBox="0 0 110 110" xml:space="preserve">
-  <g id="Canvas" fill="none">
-	  <polygon fill="#fff" points="46.4,15.8 32.6,9.1 32.6,95.7 60.2,109.4 60.2,94.1 46.4,87.2"></polygon>
-	  <polygon fill="#fff" points="60.2,94.1 73.8,101 73.8,14.4 46.4,.6 46.4,15.8 60.2,22.9"></polygon>
-  </g>
-</svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   class="custom-logo "
+   version="1.1"
+   id="Layer_1"
+   width="128px"
+   height="128px"
+   viewBox="0 0 128 128"
+   xml:space="preserve"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <g
+   id="Canvas"
+   fill="none"
+   transform="matrix(1.6318908,0,0,1.1754735,-22.624497,-0.68381501)">
+   	  <polygon
+   fill="#ffffff"
+   points="32.6,9.1 32.6,95.7 60.2,109.4 60.2,94.1 46.4,87.2 46.4,15.8 "
+   id="polygon1" />
+   	  <polygon
+   fill="#ffffff"
+   points="73.8,101 73.8,14.4 46.4,0.6 46.4,15.8 60.2,22.9 60.2,94.1 "
+   id="polygon2" />
+    </g>
+  </svg>

--- a/images/InterSystems.svg
+++ b/images/InterSystems.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="yes"?>
-<svg class="custom-logo " version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 40 80" xml:space="preserve">
+<svg class="custom-logo " version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="110px" height="110px" viewBox="0 0 110 110" xml:space="preserve">
   <g id="Canvas" fill="none">
-	  <polygon fill="#fff" points="16.5,17.4 7.9,13.2 7.9,67.3 25.1,75.9 25.1,66.3 16.5,62 "></polygon>
-	  <polygon fill="#fff" points="25.1,66.3 33.6,70.6 33.6,16.5 16.5,7.9 16.5,17.4 25.1,21.8 "></polygon>
+	  <polygon fill="#fff" points="46.4,15.8 32.6,9.1 32.6,95.7 60.2,109.4 60.2,94.1 46.4,87.2"></polygon>
+	  <polygon fill="#fff" points="60.2,94.1 73.8,101 73.8,14.4 46.4,.6 46.4,15.8 60.2,22.9"></polygon>
   </g>
 </svg>


### PR DESCRIPTION
Already in 1.84 Insiders the Activity Bar position can be changed from Side to Top. The SVG of the InterSystems logo that the ObjectScript Explorer contributes wasn't displaying properly because its ratio wasn't 1:1

This PR corrects that.

Before:

![image](https://github.com/intersystems-community/vscode-objectscript/assets/6726799/27284301-4d95-411f-8e0d-d18ebf879a45)

After:

![image](https://github.com/intersystems-community/vscode-objectscript/assets/6726799/fb3651a7-68c6-4de7-8759-f78b7736e29e)

