### PR TITLE
Improve handling of debugging WebSocket messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.18.0",
         "@types/vscode": "1.75.0",
-        "@types/ws": "^8.5.8",
+        "@types/ws": "8.5.4",
         "@types/xmldom": "^0.1.29",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
         "@typescript-eslint/parser": "^4.32.0",
@@ -426,9 +426,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5618,9 +5618,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
-      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.4.tgz",
+      "integrity": "sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "2.10.2-SNAPSHOT",
+  "version": "2.10.4-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "2.10.2-SNAPSHOT",
+      "version": "2.10.4-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -21,7 +21,7 @@
         "node-fetch-cjs": "3.1.1",
         "vscode-cache": "^0.3.0",
         "vscode-extension-telemetry": "^0.1.6",
-        "ws": "^7.4.6"
+        "ws": "^8.14.2"
       },
       "devDependencies": {
         "@types/glob": "^7.1.2",
@@ -29,7 +29,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "^14.18.0",
         "@types/vscode": "1.75.0",
-        "@types/ws": "^7.2.5",
+        "@types/ws": "^8.5.8",
         "@types/xmldom": "^0.1.29",
         "@typescript-eslint/eslint-plugin": "^4.32.0",
         "@typescript-eslint/parser": "^4.32.0",
@@ -426,9 +426,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5214,15 +5214,15 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -5618,9 +5618,9 @@
       "dev": true
     },
     "@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+      "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -9146,9 +9146,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.5.6",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
-      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "version": "8.14.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
+      "integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -1685,7 +1685,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.18.0",
     "@types/vscode": "1.75.0",
-    "@types/ws": "^7.2.5",
+    "@types/ws": "^8.5.8",
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",
@@ -1720,6 +1720,6 @@
     "@vscode/debugadapter": "^1.61.0",
     "@vscode/debugprotocol": "^1.61.0",
     "vscode-extension-telemetry": "^0.1.6",
-    "ws": "^7.4.6"
+    "ws": "^8.14.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1685,7 +1685,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^14.18.0",
     "@types/vscode": "1.75.0",
-    "@types/ws": "^8.5.8",
+    "@types/ws": "8.5.4",
     "@types/xmldom": "^0.1.29",
     "@typescript-eslint/eslint-plugin": "^4.32.0",
     "@typescript-eslint/parser": "^4.32.0",


### PR DESCRIPTION
The server generally tries to send one "line" of console output per WebSocket "packet" when debugging. However, in cases where an extreme amount of output is written to the console in a short amount of time , the server may send a 32K chunk of many "lines". Currently our debug adapter chokes on that huge packet and throws an error, and the debugger becomes out of sync with the server. This PR fixes that.