### PR TITLE
Add new method stub to KPI classes created via command

### DIFF
--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -835,6 +835,17 @@ Method %OnLoadKPI() As %Status
   Return $$$OK
 }
 
+${
+  kpiType == "sql"
+    ? `/// Return a SQL statement to execute.\nMethod %OnGetSQL(ByRef pSQL As %String)`
+    : kpiType == "mdx"
+    ? `/// Return an MDX statement to execute.\nMethod %OnGetMDX(ByRef pMDX As %String)`
+    : `/// Get the data for this KPI manually.\nMethod %OnExecute()`
+} As %Status
+{
+  Return $$$OK
+}
+
 /// This callback is invoked from a dashboard when an action defined by this dashboard is invoked.
 ClassMethod %OnDashboardAction(pAction As %String, pContext As %ZEN.proxyObject) As %Status
 {


### PR DESCRIPTION
The new KPI command added by #1237 wasn't generating a method stub that the Studio KPI wizard generated. This PR adds that stub to the generated content.