### PR TITLE
Allow users to select no resource in new KPI command

### DIFF
--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -789,7 +789,7 @@ XData RuleDefinition [ XMLNamespace = "http://www.intersystems.com/rule" ]
           ? {
               type: "quickPick",
               title: "Resource",
-              items: serverResources,
+              items: [{ label: "No Resource" }].concat(serverResources),
             }
           : {
               type: "inputBox",
@@ -819,7 +819,7 @@ Class ${cls} Extends %DeepSee.KPI
 
 Parameter DOMAIN = "${kpiDomain}";
 
-Parameter RESOURCE = "${kpiResource}";
+Parameter RESOURCE = "${kpiResource == "No Resource" ? "" : kpiResource}";
 
 /// This XData definition defines the KPI.
 XData KPI [ XMLNamespace = "http://www.intersystems.com/deepsee/kpi" ]


### PR DESCRIPTION
In the KPI command in the `New File...` menu, there's a QuickPick of server resources that can be used to secure the KPI. There was no option to select "no resource", so I added one as the first option.