### PR TITLE
Fix new class creation, broken in 2.10.4

### DIFF
--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -27,7 +27,7 @@ export function generateFileContent(
   fileName: string,
   sourceContent: Buffer
 ): { content: string[]; enc: boolean } {
-  const sourceLines = new TextDecoder().decode(sourceContent).split("\n");
+  const sourceLines = sourceContent.length ? new TextDecoder().decode(sourceContent).split("\n") : [];
   const fileExt = fileName.split(".").pop().toLowerCase();
   const csp = fileName.startsWith("/");
   if (fileExt === "cls" && !csp) {


### PR DESCRIPTION
This PR fixes #1265

Breakage was caused by #1253.

To verify, make sure you can create a new .cls file in an ISFS folder in VS Code Explorer view.