### PR TITLE
Harden `TextSearchProvider`

### DIFF
--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -316,7 +316,9 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
         // The file name is malformed
         (file.doc.includes("/") && !/\/(?:[^/]+\/)+[^/.]*(?:\.[^/.]+)+/.test(file.doc)) ||
         (!file.doc.includes("/") && !/(%?[\p{L}\d\u{100}-\u{ffff}]+(?:\.[\p{L}\d\u{100}-\u{ffff}]+)+)/u.test(file.doc))
-      ) return;
+      ) {
+        return;
+      }
 
       const uri = DocumentContentProvider.getUri(file.doc, "", "", true, options.folder);
       const content = decoder.decode(await vscode.workspace.fs.readFile(uri)).split("\n");

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -149,8 +149,8 @@ function searchMatchToLine(
             // This is in the class description
             line = descLineToDocLine(content, match.attrline, i);
             break;
-          } else if (match.attr == "Super") {
-            // This is a superclass
+          } else if (match.attr == "Super" || match.attr == "Name") {
+            // This is in the class definition line
             if (content[i].includes(match.text)) {
               line = i;
             }
@@ -306,9 +306,17 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
 
     /** Report matches in `file` to the user */
     const reportMatchesForFile = async (file: SearchResult): Promise<void> => {
-      if (token.isCancellationRequested) {
-        return;
-      }
+      // The last three checks are needed to protect against
+      // bad output from the server due to a bug.
+      if (
+        // The user cancelled the search
+        token.isCancellationRequested ||
+        // The server reported no matches in this file
+        !file.matches.length ||
+        // The file name is malformed
+        (file.doc.includes("/") && !/\/(?:[^/]+\/)+[^/.]*(?:\.[^/.]+)+/.test(file.doc)) ||
+        (!file.doc.includes("/") && !/(%?[\p{L}\d\u{100}-\u{ffff}]+(?:\.[\p{L}\d\u{100}-\u{ffff}]+)+)/u.test(file.doc))
+      ) return;
 
       const uri = DocumentContentProvider.getUri(file.doc, "", "", true, options.folder);
       const content = decoder.decode(await vscode.workspace.fs.readFile(uri)).split("\n");


### PR DESCRIPTION
Our `TextSearchProvider` assumes that the server won't send back junk results. This leads to it choking if it tries to process an invalid document name. This problem can arise due to a server-side bug described [here](https://github.com/intersystems-community/vscode-objectscript/issues/1273#issuecomment-1816587381). This PR hardens the code to ignore clearly invalid document names.