### PR TITLE
PR to fix my previous issues.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "2.10.5-SNAPSHOT",
+  "version": "2.10.6-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "2.10.5-SNAPSHOT",
+      "version": "2.10.6-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1458,8 +1458,8 @@
           "type": "boolean",
           "default": false
         },
-        "objectscript.disableImplictCodeChange": {
-          "description": "Disable all implict change to any of your code.",
+        "objectscript.disableImplicitCodeChange": {
+          "description": "Disable all implicit changes to your code.",
           "type": "boolean",
           "default": false
         },

--- a/package.json
+++ b/package.json
@@ -1458,10 +1458,10 @@
           "type": "boolean",
           "default": false
         },
-        "objectscript.disableImplicitCodeChange": {
-          "description": "Disable all code modifications that occur without the user's explicit awareness.",
+        "objectscript.autoAdjustName": {
+          "markdownDescription": "Automatically modify the class name or ROUTINE header to match the file's path when copying or creating a new file. Does not affect `isfs` files.",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "objectscript.compileOnSave": {
           "description": "Automatically compile an InterSystems file when saved in the editor.",

--- a/package.json
+++ b/package.json
@@ -1459,7 +1459,7 @@
           "default": false
         },
         "objectscript.disableImplicitCodeChange": {
-          "description": "Disable all implicit changes to your code.",
+          "description": "Disable all code modifications that occur without the user's explicit awareness.",
           "type": "boolean",
           "default": false
         },

--- a/package.json
+++ b/package.json
@@ -1458,6 +1458,11 @@
           "type": "boolean",
           "default": false
         },
+        "objectscript.disableImplictCodeChange": {
+          "description": "Disable all implict change to any of your code.",
+          "type": "boolean",
+          "default": false
+        },
         "objectscript.compileOnSave": {
           "description": "Automatically compile an InterSystems file when saved in the editor.",
           "type": "boolean",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1045,7 +1045,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       RESTDebugPanel.create(context.extensionUri)
     ),
     vscode.commands.registerCommand("vscode-objectscript.exportCurrentFile", exportCurrentFile),
-    vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) =>{
+    vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) => {
       if (!config("autoAdjustName")) return;
       return Promise.all(
         e.files
@@ -1079,9 +1079,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
             // Write the new content to the file
             return vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(newContent.content.join("\n")));
           })
-      )
-      }
-    ),
+      );
+    }),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
       if (config("openClassContracted") && editor && editor.document.languageId === "objectscript-class") {
         const uri: string = editor.document.uri.toString();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1050,6 +1050,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         e.files
           .filter((uri) => !filesystemSchemas.includes(uri.scheme))
           .filter((uri) => ["cls", "inc", "int", "mac"].includes(uri.path.split(".").pop().toLowerCase()))
+          // If disableImplicitCodeChange is true, disable all changes
+          // Be aware that if you drag and drop a file for windows expolorer into vscode,
+          // it will trigger create event, but the file is not actually blank.
+          // read file content as text and write it back to the file will corrupt it's binary structure.
+          // so I use filter to skip file instead of 'verbatim output'.
+          .filter((_) => config("disableImplicitCodeChange") !== true)
           .map(async (uri) => {
             // Determine the file name
             const workspace = workspaceFolderOfUri(uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1050,12 +1050,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         e.files
           .filter((uri) => !filesystemSchemas.includes(uri.scheme))
           .filter((uri) => ["cls", "inc", "int", "mac"].includes(uri.path.split(".").pop().toLowerCase()))
-          // If disableImplicitCodeChange is true, disable all changes
-          // Be aware that if you drag and drop a file for windows expolorer into vscode,
-          // it will trigger create event, but the file is not actually blank.
-          // read file content as text and write it back to the file will corrupt it's binary structure.
-          // so I use filter to skip file instead of 'verbatim output'.
-          .filter((_) => config("disableImplicitCodeChange") !== true)
           .map(async (uri) => {
             // Determine the file name
             const workspace = workspaceFolderOfUri(uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1045,8 +1045,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       RESTDebugPanel.create(context.extensionUri)
     ),
     vscode.commands.registerCommand("vscode-objectscript.exportCurrentFile", exportCurrentFile),
-    vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) =>
-      Promise.all(
+    vscode.workspace.onDidCreateFiles((e: vscode.FileCreateEvent) =>{
+      if (!config("autoAdjustName")) return;
+      return Promise.all(
         e.files
           .filter((uri) => !filesystemSchemas.includes(uri.scheme))
           .filter((uri) => ["cls", "inc", "int", "mac"].includes(uri.path.split(".").pop().toLowerCase()))
@@ -1079,6 +1080,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
             return vscode.workspace.fs.writeFile(uri, new TextEncoder().encode(newContent.content.join("\n")));
           })
       )
+      }
     ),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
       if (config("openClassContracted") && editor && editor.document.languageId === "objectscript-class") {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -29,10 +29,11 @@ export function generateFileContent(
 ): { content: string[]; enc: boolean } {
   const sourceLines = sourceContent.length ? new TextDecoder().decode(sourceContent).split("\n") : [];
 
-  // since this function only changes class package line, disableImplictCodeChange completely skip this function
-  const disableImplictChange = config("disableImplictCodeChange");
-  console.log("generateFileContent called with " + disableImplictChange);
-  if (disableImplictChange === true) {
+  // Since this function only changes the class package line, disableImplicitCodeChange should completely skip this function.
+  // If, in the future, this function introduces some validation or caching, the below compare-and-return logic should be re-located to a proper position.
+  const disableImplicitCodeChange = config("disableImplicitCodeChange");
+  console.log("generateFileContent called with " + disableImplicitCodeChange);
+  if (disableImplicitCodeChange === true) {
     return { content: sourceLines, enc: false };
   }
 

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -28,15 +28,6 @@ export function generateFileContent(
   sourceContent: Buffer
 ): { content: string[]; enc: boolean } {
   const sourceLines = sourceContent.length ? new TextDecoder().decode(sourceContent).split("\n") : [];
-
-  // Since this function only changes the class package line, disableImplicitCodeChange should completely skip this function.
-  // If, in the future, this function introduces some validation or caching, the below compare-and-return logic should be re-located to a proper position.
-  const disableImplicitCodeChange = config("disableImplicitCodeChange");
-  console.log("generateFileContent called with " + disableImplicitCodeChange);
-  if (disableImplicitCodeChange === true) {
-    return { content: sourceLines, enc: false };
-  }
-
   const fileExt = fileName.split(".").pop().toLowerCase();
   const csp = fileName.startsWith("/");
   if (fileExt === "cls" && !csp) {
@@ -55,7 +46,6 @@ export function generateFileContent(
         while (sourceLines.length > 0) {
           const nextLine = sourceLines.shift();
           if (nextLine.toLowerCase().startsWith("class ")) {
-            console.log("class matched on line:" + nextLine);
             const classLine = nextLine.split(" ");
             classLine[0] = "Class";
             classLine[1] = className;

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -28,6 +28,14 @@ export function generateFileContent(
   sourceContent: Buffer
 ): { content: string[]; enc: boolean } {
   const sourceLines = sourceContent.length ? new TextDecoder().decode(sourceContent).split("\n") : [];
+
+  // since this function only changes class package line, disableImplictCodeChange completely skip this function
+  const disableImplictChange = config("disableImplictCodeChange");
+  console.log("generateFileContent called with " + disableImplictChange);
+  if (disableImplictChange === true) {
+    return { content: sourceLines, enc: false };
+  }
+
   const fileExt = fileName.split(".").pop().toLowerCase();
   const csp = fileName.startsWith("/");
   if (fileExt === "cls" && !csp) {
@@ -46,6 +54,7 @@ export function generateFileContent(
         while (sourceLines.length > 0) {
           const nextLine = sourceLines.shift();
           if (nextLine.toLowerCase().startsWith("class ")) {
+            console.log("class matched on line:" + nextLine);
             const classLine = nextLine.split(" ");
             classLine[0] = "Class";
             classLine[1] = className;


### PR DESCRIPTION
The current version of the plugin still has several unresolved issues that I have encountered, detailed as follows:

1. When openning server-side Classes using ObjectScript Explorer, pressing Ctrl+S and select a folder from the current workspace invariably prompts a question about overwriting. This happens because, upon file creation, the plugin automatically inserts a stub class code which often has a) an incorrect Package, and b) invariably triggers an overwrite prompt.
2. The issue of the Class file's Package being altered during movement persists in the latest version of the plugin. Every scenario I reported in my previous case still occurs.
3. When a file is a binary file but has a .cls extension, dragging it between folders in VSCode can corrupt its binary structure.

To thoroughly address these issues, I have submitted this PR. The PR introduces a new VSCode option designed to prevent any automated Code Formatter actions without explicit user permission. Any write operations to code files not executed through the user's ContextMenu will be disabled.

Currently, it only acts on onDidCreateFiles to prevent the automatic addition of PackageNames to code. If further similar behaviors are identified in the future, I plan to extend its control scope. For instance, if an ObjectScript Lint is introduced later, the option would block the automatic application of Lint when saving files with Ctrl+S. Users would need to explicitly apply Lint by right-clicking in the file and selecting FormatCurrentFile.