### PR TITLE
Better message when WebSocket Terminal can't be started

### DIFF
--- a/src/commands/webSocketTerminal.ts
+++ b/src/commands/webSocketTerminal.ts
@@ -170,6 +170,7 @@ class WebSocketTerminal implements vscode.Pseudoterminal {
       outputChannel.appendLine(
         typeof error == "string" ? error : error instanceof Error ? error.message : JSON.stringify(error)
       );
+      outputChannel.appendLine("Check that the InterSystems server's web server supports WebSockets.");
       outputChannel.show(true);
       vscode.window.showErrorMessage(
         "Failed to initialize WebSocket Terminal. Check 'ObjectScript' Output channel for details.",


### PR DESCRIPTION
The debugger prompts users to check their web server's settings if the debug session can't be started. We should do the same for the WebSocket Terminal.