### PR TITLE
Improve auto-commenting of new lines following ObjectScript comments

### DIFF
--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -24,27 +24,27 @@ export function getLanguageConfiguration(lang: string): LanguageConfiguration {
           ]
         : [
             {
-              beforeText: /^\s\/\/\//,
+              beforeText: /^\s*\/\/\//,
               action: { indentAction: IndentAction.None, appendText: "/// " },
             },
             {
-              beforeText: /^\s\/\/[^/]?/,
+              beforeText: /^\s+\/\/[^/]?/,
               action: { indentAction: IndentAction.None, appendText: "// " },
             },
             {
-              beforeText: /^\s;;/,
+              beforeText: /^\s+;;/,
               action: { indentAction: IndentAction.None, appendText: ";; " },
             },
             {
-              beforeText: /^\s;[^;]?/,
+              beforeText: /^\s+;[^;]?/,
               action: { indentAction: IndentAction.None, appendText: "; " },
             },
             {
-              beforeText: /^\s#;/,
+              beforeText: /^\s*#;/,
               action: { indentAction: IndentAction.None, appendText: "#; " },
             },
             {
-              beforeText: /^\s##;/,
+              beforeText: /^\s*##;/,
               action: { indentAction: IndentAction.None, appendText: "##; " },
             },
           ],


### PR DESCRIPTION
This PR improves the behavior introduced by #761. The current implementation only works if there's a single space for indentation. See #1297 for motivation.