### PR TITLE
Improve language configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "2.12.0-SNAPSHOT",
+  "version": "2.12.2-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "2.12.0-SNAPSHOT",
+      "version": "2.12.2-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -143,7 +143,7 @@ async function importFile(
         undefined,
         true
       );
-      documentContentProvider.update(serverUri.with({ scheme: "objectscript" }));
+      documentContentProvider.update(serverUri.with({ scheme: OBJECTSCRIPT_FILE_SCHEMA }));
     })
     .catch((error) => {
       if (error?.statusCode == 409) {

--- a/src/commands/documaticPreviewPanel.ts
+++ b/src/commands/documaticPreviewPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { classNameRegex } from "../utils";
+import { clsLangId } from "../extension";
 
 /**
  * The schema of the message that gets sent to the webview.
@@ -45,7 +46,7 @@ export class DocumaticPreviewPanel {
       return;
     }
     const openDoc = openEditor.document;
-    if (openDoc.languageId !== "objectscript-class") {
+    if (openDoc.languageId !== clsLangId) {
       // Documatic preview is for classes only
       return;
     }
@@ -278,7 +279,7 @@ export class DocumaticPreviewPanel {
 
     vscode.window.onDidChangeActiveTextEditor(
       async (editor: vscode.TextEditor) => {
-        if (editor !== undefined && editor.document.languageId === "objectscript-class") {
+        if (editor !== undefined && editor.document.languageId === clsLangId) {
           // The new active editor is a class, so switch our preview to it
 
           // Get the name of the current class

--- a/src/commands/studioMigration.ts
+++ b/src/commands/studioMigration.ts
@@ -4,7 +4,7 @@ import util = require("util");
 import { gte } from "semver";
 
 import { fileExists, outputChannel } from "../utils";
-import { clsLangId, cspLangId } from "../extension";
+import { clsLangId, cspLangId, incLangId, intLangId, macLangId } from "../extension";
 
 /** Run a command using `node-cmd` and return a Promise */
 const runCmd = util.promisify(cmd.run);
@@ -118,7 +118,7 @@ export async function loadStudioSnippets(): Promise<void> {
                         ? cspLangId
                         : parts[1] == "3"
                         ? clsLangId
-                        : "objectscript,objectscript-int,objectscript-macros,objectscript-class,objectscript-csp",
+                        : `${macLangId},${intLangId},${incLangId},${clsLangId},${cspLangId}`,
                   };
                 }
               });

--- a/src/commands/studioMigration.ts
+++ b/src/commands/studioMigration.ts
@@ -4,6 +4,7 @@ import util = require("util");
 import { gte } from "semver";
 
 import { fileExists, outputChannel } from "../utils";
+import { clsLangId, cspLangId } from "../extension";
 
 /** Run a command using `node-cmd` and return a Promise */
 const runCmd = util.promisify(cmd.run);
@@ -114,9 +115,9 @@ export async function loadStudioSnippets(): Promise<void> {
                     // Use Language to determine the scope
                     scope:
                       parts[1] == "5"
-                        ? "objectscript-csp"
+                        ? cspLangId
                         : parts[1] == "3"
-                        ? "objectscript-class"
+                        ? clsLangId
                         : "objectscript,objectscript-int,objectscript-macros,objectscript-class,objectscript-csp",
                   };
                 }

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as Atelier from "../api/atelier";
-import { extensionId, filesystemSchemas, lsExtensionId } from "../extension";
+import { clsLangId, extensionId, filesystemSchemas, lsExtensionId } from "../extension";
 import { getFileText, methodOffsetToLine, outputChannel, stripClassMemberNameQuotes, uriIsParentOf } from "../utils";
 import { fileSpecFromURI } from "../utils/FileProviderUtil";
 import { AtelierAPI } from "../api";
@@ -998,7 +998,7 @@ export function setUpTestController(): vscode.Disposable[] {
   // Create the initial root items
   replaceRootTestItems(testController);
 
-  const openClass = vscode.workspace.textDocuments.find((d) => d.languageId == "objectscript-class");
+  const openClass = vscode.workspace.textDocuments.find((d) => d.languageId == clsLangId);
   if (openClass) {
     // Create TestItems for any test classes that are open at activation.
     // Must be done after this extension activates because the resolve
@@ -1085,7 +1085,7 @@ export function setUpTestController(): vscode.Disposable[] {
     vscode.workspace.onDidOpenTextDocument((document) => addItemForClassUri(testController, document.uri)),
     vscode.workspace.onDidChangeTextDocument(async (e) => {
       // If this is a test class, re-compute its TestItems
-      if (e.document.languageId == "objectscript-class") {
+      if (e.document.languageId == clsLangId) {
         // Don't pass create flag because if it existed it would
         // have been created already by the onDidOpen handler
         const item = await getTestItemForClass(testController, e.document.uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -723,23 +723,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
       }),
       vscode.languages.registerHoverProvider(
-        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
+        documentSelector(clsLangId, macLangId, intLangId, incLangId),
         new ObjectScriptHoverProvider()
       ),
       vscode.languages.registerDocumentFormattingEditProvider(
-        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
+        documentSelector(clsLangId, macLangId, intLangId, incLangId),
         new DocumentFormattingEditProvider()
       ),
       vscode.languages.registerDocumentRangeFormattingEditProvider(
-        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
+        documentSelector(clsLangId, macLangId, intLangId, incLangId),
         new DocumentRangeFormattingEditProvider()
       ),
       vscode.languages.registerDefinitionProvider(
-        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
+        documentSelector(clsLangId, macLangId, intLangId, incLangId),
         new ObjectScriptDefinitionProvider()
       ),
       vscode.languages.registerCompletionItemProvider(
-        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
+        documentSelector(clsLangId, macLangId, intLangId, incLangId),
         new ObjectScriptCompletionItemProvider(),
         "$",
         "^",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,12 @@ export const schemas = [
 ];
 export const filesystemSchemas = [FILESYSTEM_SCHEMA, FILESYSTEM_READONLY_SCHEMA];
 
+export const clsLangId = "objectscript-class";
+export const macLangId = "objectscript";
+export const intLangId = "objectscript-int";
+export const incLangId = "objectscript-macros";
+export const cspLangId = "objectscript-csp";
+
 import * as url from "url";
 import path = require("path");
 import {
@@ -717,23 +723,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
       }),
       vscode.languages.registerHoverProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
+        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
         new ObjectScriptHoverProvider()
       ),
       vscode.languages.registerDocumentFormattingEditProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
+        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
         new DocumentFormattingEditProvider()
       ),
       vscode.languages.registerDocumentRangeFormattingEditProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
+        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
         new DocumentRangeFormattingEditProvider()
       ),
       vscode.languages.registerDefinitionProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
+        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
         new ObjectScriptDefinitionProvider()
       ),
       vscode.languages.registerCompletionItemProvider(
-        documentSelector("objectscript-class", "objectscript", "objectscript-int", "objectscript-macros"),
+        documentSelector(clsLangId, macLangId, intLangId, cspLangId),
         new ObjectScriptCompletionItemProvider(),
         "$",
         "^",
@@ -741,11 +747,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         "#"
       ),
       vscode.languages.registerDocumentSymbolProvider(
-        documentSelector("objectscript-class"),
+        documentSelector(clsLangId),
         new ObjectScriptClassSymbolProvider()
       ),
       vscode.languages.registerDocumentSymbolProvider(
-        documentSelector("objectscript", "objectscript-int"),
+        documentSelector(macLangId, intLangId),
         new ObjectScriptRoutineSymbolProvider()
       )
     );
@@ -756,11 +762,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     if (semver.lt(lsVersion, "1.0.5")) {
       context.subscriptions.push(
         vscode.languages.registerFoldingRangeProvider(
-          documentSelector("objectscript-class"),
+          documentSelector(clsLangId),
           new ObjectScriptClassFoldingRangeProvider()
         ),
         vscode.languages.registerFoldingRangeProvider(
-          documentSelector("objectscript", "objectscript-int"),
+          documentSelector(macLangId, intLangId),
           new ObjectScriptFoldingRangeProvider()
         )
       );
@@ -1008,19 +1014,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       isCaseSensitive: true,
       isReadonly: true,
     }),
-    vscode.languages.setLanguageConfiguration("objectscript-class", getLanguageConfiguration("class")),
-    vscode.languages.setLanguageConfiguration("objectscript", getLanguageConfiguration("routine")),
-    vscode.languages.setLanguageConfiguration("objectscript-macros", getLanguageConfiguration("routine")),
-    vscode.languages.registerCodeActionsProvider(
-      documentSelector("objectscript-class", "objectscript"),
-      new CodeActionProvider()
-    ),
+    vscode.languages.setLanguageConfiguration(clsLangId, getLanguageConfiguration(clsLangId)),
+    vscode.languages.setLanguageConfiguration(macLangId, getLanguageConfiguration(macLangId)),
+    vscode.languages.setLanguageConfiguration(incLangId, getLanguageConfiguration(incLangId)),
+    vscode.languages.setLanguageConfiguration(intLangId, getLanguageConfiguration(intLangId)),
+    vscode.languages.registerCodeActionsProvider(documentSelector(clsLangId, macLangId), new CodeActionProvider()),
     vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider()),
     vscode.debug.registerDebugConfigurationProvider("objectscript", new ObjectScriptConfigurationProvider()),
     vscode.debug.registerDebugAdapterDescriptorFactory("objectscript", debugAdapterFactory),
     debugAdapterFactory,
     vscode.languages.registerCodeLensProvider(
-      documentSelector("objectscript-class", "objectscript", "objectscript-int"),
+      documentSelector(clsLangId, macLangId, intLangId),
       new ObjectScriptCodeLensProvider()
     ),
     vscode.commands.registerCommand("vscode-objectscript.compileOnly", () => compileOnly(false)),
@@ -1074,7 +1078,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       );
     }),
     vscode.window.onDidChangeActiveTextEditor((editor: vscode.TextEditor) => {
-      if (config("openClassContracted") && editor && editor.document.languageId === "objectscript-class") {
+      if (config("openClassContracted") && editor && editor.document.languageId === clsLangId) {
         const uri: string = editor.document.uri.toString();
         if (!openedClasses.includes(uri)) {
           vscode.commands.executeCommand("editor.foldLevel1");
@@ -1237,7 +1241,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.window.onDidChangeTextEditorSelection((event: vscode.TextEditorSelectionChangeEvent) => {
       posPanel.text = "";
       const document = event.textEditor.document;
-      if (!["objectscript", "objectscript-int"].includes(document.languageId)) {
+      if (![macLangId, intLangId].includes(document.languageId)) {
         return;
       }
       if (event.selections.length > 1 || !event.selections[0].isEmpty) {

--- a/src/languageConfiguration.ts
+++ b/src/languageConfiguration.ts
@@ -1,52 +1,32 @@
-import { IndentAction, LanguageConfiguration } from "vscode";
+import * as vscode from "vscode";
 
-export const WORD_PATTERN =
-  /((?<=(class|extends|as|of) )(%?\b[a-z0-9]+(\.[a-z0-9]+)*\b))|(\^[a-z0-9]+(\.[a-z0-9]+)*)|((\${1,3}|[irm]?%|\^|#)?[a-z0-9]+)/i;
-
-export function getLanguageConfiguration(lang: string): LanguageConfiguration {
+export function getLanguageConfiguration(lang: string): vscode.LanguageConfiguration {
   return {
-    wordPattern: WORD_PATTERN,
+    wordPattern:
+      /((?<=(class|extends|as|of) )(%?\b[a-z0-9]+(\.[a-z0-9]+)*\b))|(\^[a-z0-9]+(\.[a-z0-9]+)*)|((\${1,3}|[irm]?%|\^|#)?[a-z0-9]+)/i,
     brackets: [
       ["{", "}"],
       ["(", ")"],
     ],
     comments: {
-      lineComment: lang === "class" ? "//" : "#;",
+      lineComment: ["objectscript-class", "objectscript-int"].includes(lang) ? "//" : "#;",
       blockComment: ["/*", "*/"],
     },
+    autoClosingPairs: [
+      {
+        open: "/*",
+        close: "*/",
+        notIn: [vscode.SyntaxTokenType.Comment, vscode.SyntaxTokenType.String, vscode.SyntaxTokenType.RegEx],
+      },
+    ],
     onEnterRules:
-      lang === "class"
+      lang == "objectscript-class"
         ? [
             {
               beforeText: /^\/\/\//,
-              action: { indentAction: IndentAction.None, appendText: "/// " },
+              action: { indentAction: vscode.IndentAction.None, appendText: "/// " },
             },
           ]
-        : [
-            {
-              beforeText: /^\s*\/\/\//,
-              action: { indentAction: IndentAction.None, appendText: "/// " },
-            },
-            {
-              beforeText: /^\s+\/\/[^/]?/,
-              action: { indentAction: IndentAction.None, appendText: "// " },
-            },
-            {
-              beforeText: /^\s+;;/,
-              action: { indentAction: IndentAction.None, appendText: ";; " },
-            },
-            {
-              beforeText: /^\s+;[^;]?/,
-              action: { indentAction: IndentAction.None, appendText: "; " },
-            },
-            {
-              beforeText: /^\s*#;/,
-              action: { indentAction: IndentAction.None, appendText: "#; " },
-            },
-            {
-              beforeText: /^\s*##;/,
-              action: { indentAction: IndentAction.None, appendText: "##; " },
-            },
-          ],
+        : undefined,
   };
 }

--- a/src/providers/FileDecorationProvider.ts
+++ b/src/providers/FileDecorationProvider.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import { currentFile } from "../utils";
+import { macLangId, clsLangId, intLangId, cspLangId } from "../extension";
 
 export class FileDecorationProvider implements vscode.FileDecorationProvider {
   private _genBadge = String.fromCharCode(9965); // Gear
@@ -20,13 +21,13 @@ export class FileDecorationProvider implements vscode.FileDecorationProvider {
     if (
       doc != undefined &&
       !doc.isUntitled &&
-      ["objectscript", "objectscript-class", "objectscript-int", "objectscript-macros"].includes(doc.languageId) &&
+      [macLangId, clsLangId, intLangId, cspLangId].includes(doc.languageId) &&
       vscode.workspace
         .getConfiguration("objectscript", vscode.workspace.getWorkspaceFolder(uri))
         .get<boolean>("showGeneratedFileDecorations")
     ) {
       // Use the file's contents to check if it's generated
-      if (doc.languageId == "objectscript-class") {
+      if (doc.languageId == clsLangId) {
         for (let line = 0; line < doc.lineCount; line++) {
           const lineText = doc.lineAt(line).text;
           if (lineText.startsWith("Class ")) {
@@ -51,7 +52,7 @@ export class FileDecorationProvider implements vscode.FileDecorationProvider {
               tooltip += ` by ${macMatch[1]}.cls`;
             } else if (intMatch) {
               tooltip += ` by ${intMatch[1]}.cls`;
-            } else if (doc.languageId == "objectscript-int") {
+            } else if (doc.languageId == intLangId) {
               tooltip += ` by ${file.slice(0, -3)}mac`;
             }
           }

--- a/src/providers/FileDecorationProvider.ts
+++ b/src/providers/FileDecorationProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import { currentFile } from "../utils";
-import { macLangId, clsLangId, intLangId, cspLangId } from "../extension";
+import { clsLangId, cspLangId, intLangId, macLangId } from "../extension";
 
 export class FileDecorationProvider implements vscode.FileDecorationProvider {
   private _genBadge = String.fromCharCode(9965); // Gear
@@ -21,7 +21,7 @@ export class FileDecorationProvider implements vscode.FileDecorationProvider {
     if (
       doc != undefined &&
       !doc.isUntitled &&
-      [macLangId, clsLangId, intLangId, cspLangId].includes(doc.languageId) &&
+      [clsLangId, macLangId, intLangId, cspLangId].includes(doc.languageId) &&
       vscode.workspace
         .getConfiguration("objectscript", vscode.workspace.getWorkspaceFolder(uri))
         .get<boolean>("showGeneratedFileDecorations")

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -13,7 +13,7 @@ import {
   redirectDotvscodeRoot,
   workspaceFolderOfUri,
 } from "../../utils/index";
-import { config, workspaceState } from "../../extension";
+import { config, intLangId, macLangId, workspaceState } from "../../extension";
 import { addIsfsFileToProject, modifyProject } from "../../commands/project";
 import { DocumentContentProvider } from "../DocumentContentProvider";
 import { Document } from "../../api/atelier";
@@ -80,7 +80,7 @@ export function generateFileContent(
       const routineName = fileName.split(".").slice(0, -1).join(".");
       const routineType = fileExt != "mac" ? `[Type=${fileExt.toUpperCase()}]` : "";
       if (sourceLines.length === 0 && fileExt !== "inc") {
-        const languageId = fileExt === "mac" ? "objectscript" : "objectscript-int";
+        const languageId = fileExt === "mac" ? macLangId : intLangId;
 
         // Labels cannot contain dots
         const firstLabel = routineName.replaceAll(".", "");

--- a/src/providers/ObjectScriptCodeLensProvider.ts
+++ b/src/providers/ObjectScriptCodeLensProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import { config } from "../extension";
+import { clsLangId, config, intLangId, macLangId } from "../extension";
 import { currentFile } from "../utils";
 import { AtelierAPI } from "../api";
 
@@ -8,10 +8,10 @@ export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
     document: vscode.TextDocument,
     token: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.CodeLens[]> {
-    if (document.languageId == "objectscript-class") {
+    if (document.languageId == clsLangId) {
       return this.classMembers(document);
     }
-    if (["objectscript", "objectscript-int"].includes(document.languageId)) {
+    if ([macLangId, intLangId].includes(document.languageId)) {
       return this.routineLabels(document);
     }
     return [];

--- a/src/providers/RuleEditorProvider.ts
+++ b/src/providers/RuleEditorProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { loadChanges } from "../commands/compile";
 import { StudioActions } from "../commands/studio";
-import { cspApps } from "../extension";
+import { clsLangId, cspApps } from "../extension";
 import { currentFile, outputChannel } from "../utils";
 
 /**
@@ -28,7 +28,7 @@ export class RuleEditorProvider implements vscode.CustomTextEditorProvider {
     token: vscode.CancellationToken
   ): Promise<void> {
     // Check that document is a clean, well-formed class
-    if (document.languageId != "objectscript-class") {
+    if (document.languageId != clsLangId) {
       return RuleEditorProvider._errorMessage(`${document.fileName} is not a class.`);
     }
     if (document.isUntitled) {

--- a/src/web-extension.ts
+++ b/src/web-extension.ts
@@ -23,10 +23,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       documentSelector("objectscript"),
       new ObjectScriptRoutineSymbolProvider()
     ),
-    vscode.languages.setLanguageConfiguration("objectscript-class", getLanguageConfiguration("class")),
-    vscode.languages.setLanguageConfiguration("objectscript", getLanguageConfiguration("routine")),
-    vscode.languages.setLanguageConfiguration("objectscript-int", getLanguageConfiguration("routine")),
-    vscode.languages.setLanguageConfiguration("objectscript-macros", getLanguageConfiguration("routine"))
+    vscode.languages.setLanguageConfiguration("objectscript-class", getLanguageConfiguration("objectscript-class")),
+    vscode.languages.setLanguageConfiguration("objectscript", getLanguageConfiguration("objectscript")),
+    vscode.languages.setLanguageConfiguration("objectscript-int", getLanguageConfiguration("objectscript-int")),
+    vscode.languages.setLanguageConfiguration("objectscript-macros", getLanguageConfiguration("objectscript-macros"))
   );
 }
 


### PR DESCRIPTION
* Rolls back #1298
* Adds auto-closing of C-style block comments (e.g. typing `/*` automatically adds `*/`)
* Adds new `const`s for language ID's to improve code readability and maintainability