### PR TITLE
Fire source control hooks when creating/opening/editing/deleting projects

### DIFF
--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -737,9 +737,9 @@ export async function modifyProject(
   }
 
   // Technically a project is a "document", so tell the server that we're opening it
-  await new StudioActions()
-    .fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument)
-    .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+  await new StudioActions().fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument).catch(() => {
+    // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+  });
 
   let items: ProjectItem[] = await api
     .actionQuery("SELECT Name, Type FROM %Studio.Project_ProjectItemsList(?,?) WHERE Type != 'GBL'", [project, "1"])

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -79,7 +79,7 @@ export class StudioActions {
       this.name = getServerName(uriOrNode);
       this.api = new AtelierAPI(uriOrNode);
     } else if (uriOrNode) {
-      this.api = new AtelierAPI(uriOrNode.workspaceFolder);
+      this.api = new AtelierAPI(uriOrNode.workspaceFolderUri || uriOrNode.workspaceFolder);
       this.api.setNamespace(uriOrNode.namespace);
       this.name = uriOrNode instanceof PackageNode ? uriOrNode.fullName + ".PKG" : uriOrNode.fullName;
     } else {

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -354,8 +354,8 @@ export class StudioActions {
                     await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
                   }
                   if (this.name.toUpperCase().endsWith(".PRJ")) {
-                    // Store the answer
-                    this.projectEditAnswer = answer;
+                    // Store the answer. No answer means "allow the edit".
+                    this.projectEditAnswer = answer ?? "1";
                   }
                 }
                 if (answer) {

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -279,7 +279,9 @@ async function childrenForServerSideFolderItem(
     // Technically a project is a "document", so tell the server that we're opening it
     await new StudioActions()
       .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
-      .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+      .catch(() => {
+        // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+      });
     query =
       "SELECT DISTINCT CASE " +
       "WHEN $LENGTH(SUBSTR(Name,?),'.') > 1 THEN $PIECE(SUBSTR(Name,?),'.') " +

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -5,6 +5,7 @@ import { getFileText, methodOffsetToLine, outputChannel, stripClassMemberNameQuo
 import { fileSpecFromURI } from "../utils/FileProviderUtil";
 import { AtelierAPI } from "../api";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
+import { StudioActions, OtherStudioAction } from "./studio";
 
 enum TestStatus {
   Failed = 0,
@@ -259,7 +260,7 @@ function replaceRootTestItems(testController: vscode.TestController): void {
 }
 
 /** Create a `Promise` that resolves to a query result containing an array of children for `item`. */
-function childrenForServerSideFolderItem(
+async function childrenForServerSideFolderItem(
   item: vscode.TestItem
 ): Promise<Atelier.Response<Atelier.Content<{ Name: string }[]>>> {
   let query: string;
@@ -275,6 +276,10 @@ function childrenForServerSideFolderItem(
   const params = new URLSearchParams(item.uri.query);
   const api = new AtelierAPI(item.uri);
   if (params.has("project")) {
+    // Technically a project is a "document", so tell the server that we're opening it
+    await new StudioActions()
+      .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
+      .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
     query =
       "SELECT DISTINCT CASE " +
       "WHEN $LENGTH(SUBSTR(Name,?),'.') > 1 THEN $PIECE(SUBSTR(Name,?),'.') " +

--- a/src/explorer/models/projectNode.ts
+++ b/src/explorer/models/projectNode.ts
@@ -18,9 +18,9 @@ export class ProjectNode extends NodeBase {
     // Technically a project is a "document", so tell the server that we're opening it
     const api = new AtelierAPI(this.workspaceFolderUri);
     api.setNamespace(this.namespace);
-    await new StudioActions()
-      .fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument)
-      .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+    await new StudioActions().fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument).catch(() => {
+      // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+    });
 
     node = new ProjectRootNode(
       "Classes",

--- a/src/explorer/models/projectNode.ts
+++ b/src/explorer/models/projectNode.ts
@@ -1,6 +1,8 @@
 import * as vscode from "vscode";
 import { NodeBase, NodeOptions } from "./nodeBase";
 import { ProjectRootNode } from "./projectRootNode";
+import { OtherStudioAction, StudioActions } from "../../commands/studio";
+import { AtelierAPI } from "../../api";
 
 export class ProjectNode extends NodeBase {
   private description: string;
@@ -12,6 +14,11 @@ export class ProjectNode extends NodeBase {
   public async getChildren(_element: NodeBase): Promise<NodeBase[]> {
     const children = [];
     let node: ProjectRootNode;
+
+    // Technically a project is a "document", so tell the server that we're opening it
+    const api = new AtelierAPI(this.workspaceFolderUri);
+    api.setNamespace(this.namespace);
+    await new StudioActions().fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument);
 
     node = new ProjectRootNode(
       "Classes",

--- a/src/explorer/models/projectNode.ts
+++ b/src/explorer/models/projectNode.ts
@@ -18,7 +18,9 @@ export class ProjectNode extends NodeBase {
     // Technically a project is a "document", so tell the server that we're opening it
     const api = new AtelierAPI(this.workspaceFolderUri);
     api.setNamespace(this.namespace);
-    await new StudioActions().fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument);
+    await new StudioActions()
+      .fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument)
+      .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
 
     node = new ProjectRootNode(
       "Classes",

--- a/src/providers/FileSystemProvider/FileSearchProvider.ts
+++ b/src/providers/FileSystemProvider/FileSearchProvider.ts
@@ -26,7 +26,9 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
       // Technically a project is a "document", so tell the server that we're opening it
       await new StudioActions()
         .fireProjectUserAction(new AtelierAPI(options.folder), params.get("project"), OtherStudioAction.OpenedDocument)
-        .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+        .catch(() => {
+          // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+        });
       if (token.isCancellationRequested) {
         return;
       }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -206,7 +206,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         // Technically a project is a "document", so tell the server that we're opening it
         await new StudioActions()
           .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
-          .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+          .catch(() => {
+            // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+          });
       }
 
       // Get all items in the project

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -3,7 +3,7 @@ import * as vscode from "vscode";
 import { AtelierAPI } from "../../api";
 import { Directory } from "./Directory";
 import { File } from "./File";
-import { fireOtherStudioAction, OtherStudioAction } from "../../commands/studio";
+import { fireOtherStudioAction, OtherStudioAction, StudioActions } from "../../commands/studio";
 import { projectContentsFromUri, studioOpenDialogFromURI } from "../../utils/FileProviderUtil";
 import {
   classNameRegex,
@@ -202,6 +202,17 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     }
     const params = new URLSearchParams(uri.query);
     if (params.has("project") && params.get("project").length) {
+      if (["", "/"].includes(uri.path)) {
+        // Technically a project is a "document", so tell the server that we're opening it
+        try {
+          await new StudioActions().fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument);
+        } catch {
+          throw vscode.FileSystemError.Unavailable(
+            `'OpenedDocument' source control action failed for '${params.get("project")}.PRJ'`
+          );
+        }
+      }
+
       // Get all items in the project
       return projectContentsFromUri(uri).then((entries) =>
         entries.map((entry) => {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -204,13 +204,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     if (params.has("project") && params.get("project").length) {
       if (["", "/"].includes(uri.path)) {
         // Technically a project is a "document", so tell the server that we're opening it
-        try {
-          await new StudioActions().fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument);
-        } catch {
-          throw vscode.FileSystemError.Unavailable(
-            `'OpenedDocument' source control action failed for '${params.get("project")}.PRJ'`
-          );
-        }
+        await new StudioActions()
+          .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
+          .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
       }
 
       // Get all items in the project

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -400,7 +400,9 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
       // Technically a project is a "document", so tell the server that we're opening it
       await new StudioActions()
         .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
-        .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+        .catch(() => {
+          // Swallow error because showing it is more disruptive than using a potentially outdated project definition
+        });
     }
     if (token.isCancellationRequested) {
       return;

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -6,6 +6,7 @@ import { DocumentContentProvider } from "../DocumentContentProvider";
 import { notNull, outputChannel, throttleRequests } from "../../utils";
 import { config } from "../../extension";
 import { fileSpecFromURI } from "../../utils/FileProviderUtil";
+import { OtherStudioAction, StudioActions } from "../../commands/studio";
 
 /**
  * Convert an `attrline` in a description to a line number in document `content`.
@@ -394,6 +395,16 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
     // Generate the query pattern that gets sent to the server
     // Needed because the server matches the full line against the regex and ignores the case parameter when in regex mode
     const pattern = query.isRegExp ? `${!query.isCaseSensitive ? "(?i)" : ""}.*${query.pattern}.*` : query.pattern;
+
+    if (params.has("project") && params.get("project").length) {
+      // Technically a project is a "document", so tell the server that we're opening it
+      await new StudioActions()
+        .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
+        .catch(/* Swallow error because showing it is more disruptive than using a potentially outdated project definition */);
+    }
+    if (token.isCancellationRequested) {
+      return;
+    }
 
     if (api.config.apiVersion >= 6) {
       // Build the request object


### PR DESCRIPTION
This PR fixes #1312

I think this is the best I can do with "other" actions to approximate what happens when a file is opened via the Atelier GET /doc/ API. @gjsjohnmurray I'd really appreciate your review on this since since you're a server-side source control expert. 