### PR TITLE
Reduce firing of `OpenedDocument` action for projects

### DIFF
--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -5,7 +5,6 @@ import { getFileText, methodOffsetToLine, outputChannel, stripClassMemberNameQuo
 import { fileSpecFromURI } from "../utils/FileProviderUtil";
 import { AtelierAPI } from "../api";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
-import { StudioActions, OtherStudioAction } from "./studio";
 
 enum TestStatus {
   Failed = 0,
@@ -276,12 +275,6 @@ async function childrenForServerSideFolderItem(
   const params = new URLSearchParams(item.uri.query);
   const api = new AtelierAPI(item.uri);
   if (params.has("project")) {
-    // Technically a project is a "document", so tell the server that we're opening it
-    await new StudioActions()
-      .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
-      .catch(() => {
-        // Swallow error because showing it is more disruptive than using a potentially outdated project definition
-      });
     query =
       "SELECT DISTINCT CASE " +
       "WHEN $LENGTH(SUBSTR(Name,?),'.') > 1 THEN $PIECE(SUBSTR(Name,?),'.') " +

--- a/src/providers/FileSystemProvider/FileSearchProvider.ts
+++ b/src/providers/FileSystemProvider/FileSearchProvider.ts
@@ -3,8 +3,6 @@ import { projectContentsFromUri, studioOpenDialogFromURI } from "../../utils/Fil
 import { notNull } from "../../utils";
 import { DocumentContentProvider } from "../DocumentContentProvider";
 import { ProjectItem } from "../../commands/project";
-import { StudioActions, OtherStudioAction } from "../../commands/studio";
-import { AtelierAPI } from "../../api";
 
 export class FileSearchProvider implements vscode.FileSearchProvider {
   /**
@@ -23,16 +21,6 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     const params = new URLSearchParams(options.folder.query);
     const csp = params.has("csp") && ["", "1"].includes(params.get("csp"));
     if (params.has("project") && params.get("project").length) {
-      // Technically a project is a "document", so tell the server that we're opening it
-      await new StudioActions()
-        .fireProjectUserAction(new AtelierAPI(options.folder), params.get("project"), OtherStudioAction.OpenedDocument)
-        .catch(() => {
-          // Swallow error because showing it is more disruptive than using a potentially outdated project definition
-        });
-      if (token.isCancellationRequested) {
-        return;
-      }
-
       const patternRegex = new RegExp(`.*${pattern}.*`.replace(/\.|\//g, "[./]"), "i");
       return projectContentsFromUri(options.folder, true).then((docs) =>
         docs

--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -6,7 +6,6 @@ import { DocumentContentProvider } from "../DocumentContentProvider";
 import { notNull, outputChannel, throttleRequests } from "../../utils";
 import { config } from "../../extension";
 import { fileSpecFromURI } from "../../utils/FileProviderUtil";
-import { OtherStudioAction, StudioActions } from "../../commands/studio";
 
 /**
  * Convert an `attrline` in a description to a line number in document `content`.
@@ -395,18 +394,6 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
     // Generate the query pattern that gets sent to the server
     // Needed because the server matches the full line against the regex and ignores the case parameter when in regex mode
     const pattern = query.isRegExp ? `${!query.isCaseSensitive ? "(?i)" : ""}.*${query.pattern}.*` : query.pattern;
-
-    if (params.has("project") && params.get("project").length) {
-      // Technically a project is a "document", so tell the server that we're opening it
-      await new StudioActions()
-        .fireProjectUserAction(api, params.get("project"), OtherStudioAction.OpenedDocument)
-        .catch(() => {
-          // Swallow error because showing it is more disruptive than using a potentially outdated project definition
-        });
-    }
-    if (token.isCancellationRequested) {
-      return;
-    }
 
     if (api.config.apiVersion >= 6) {
       // Build the request object


### PR DESCRIPTION
I've reduced the `OpenedDocument` calls to what I consider the bare minimum (when expanding the root of a project ISFS folder, expanding a root of the Projects Explorer, or modifying a project). See https://github.com/intersystems-community/vscode-objectscript/issues/1312#issuecomment-1954709482 for motivation.