### PR TITLE
Improve `Jump to Tag + Offset` UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
         },
         {
           "command": "vscode-objectscript.jumpToTagAndOffset",
-          "when": "editorLangId == objectscript"
+          "when": "editorLangId =~ /^objectscript(-int)?$/"
         },
         {
           "command": "vscode-objectscript.compileOnly",


### PR DESCRIPTION
This PR fixes #1323

I modified the `QuickPick` to update the text box if the user presses "Enter" and the text doesn't correspond to the currently selected `QuickPickItem`. This allows the user to use the text box to filter the options, then use the up and down arrows to select a label and gives them the opportunity to type an offset if they want. The downside is that two presses of "Enter" are required to select an option of you don't want to provide an offset (one to update the text, one more to confirm "no offset"). Here's a gif:

![output](https://github.com/intersystems-community/vscode-objectscript/assets/44776135/88b8ab6a-bff7-4df4-ad40-6ae7248f7ce6)
