### PR TITLE
Add `Modify Project Metadata...` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -459,6 +459,11 @@
           "group": "5_objectscript_prj@7"
         },
         {
+          "command": "vscode-objectscript.modifyProjectMetadata",
+          "when": "view == ObjectScriptProjectsExplorer && viewItem == dataNode:projectNode",
+          "group": "5_objectscript_prj@8"
+        },
+        {
           "command": "vscode-objectscript.explorer.project.closeOtherServerNs",
           "when": "view == ObjectScriptProjectsExplorer && viewItem == projectsServerNsNode:extra",
           "group": "inline@10"
@@ -597,6 +602,11 @@
           "command": "vscode-objectscript.removeItemsFromProject",
           "when": "vscode-objectscript.connectActive && resourceScheme =~ /^isfs(-readonly)?$/ && resource =~ /project%3D/ && explorerResourceIsRoot",
           "group": "objectscript_prj@2"
+        },
+        {
+          "command": "vscode-objectscript.modifyProjectMetadata",
+          "when": "vscode-objectscript.connectActive && resourceScheme =~ /^isfs(-readonly)?$/ && resource =~ /project%3D/ && explorerResourceIsRoot",
+          "group": "objectscript_prj@3"
         },
         {
           "command": "vscode-objectscript.importLocalFilesServerSide",
@@ -1031,6 +1041,11 @@
       {
         "command": "vscode-objectscript.removeItemsFromProject",
         "title": "Remove Items from Project...",
+        "category": "ObjectScript"
+      },
+      {
+        "command": "vscode-objectscript.modifyProjectMetadata",
+        "title": "Modify Project Metadata...",
         "category": "ObjectScript"
       },
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,6 +126,7 @@ import {
   deleteProject,
   exportProjectContents,
   modifyProject,
+  modifyProjectMetadata,
 } from "./commands/project";
 import { NodeBase } from "./explorer/models/nodeBase";
 import { loadStudioColors, loadStudioSnippets } from "./commands/studioMigration";
@@ -1094,25 +1095,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       }
     }),
     vscode.commands.registerCommand("vscode-objectscript.addItemsToProject", (item) => {
-      if (item instanceof NodeBase || item instanceof vscode.Uri) {
-        return modifyProject(item, "add");
-      } else {
-        return modifyProject(undefined, "add");
-      }
+      return modifyProject(item instanceof NodeBase || item instanceof vscode.Uri ? item : undefined, "add");
     }),
     vscode.commands.registerCommand("vscode-objectscript.removeFromProject", (item) => {
-      if (item instanceof NodeBase || item instanceof vscode.Uri) {
-        return modifyProject(item, "remove");
-      } else {
-        return modifyProject(undefined, "remove");
-      }
+      return modifyProject(item instanceof NodeBase || item instanceof vscode.Uri ? item : undefined, "remove");
     }),
     vscode.commands.registerCommand("vscode-objectscript.removeItemsFromProject", (item) => {
-      if (item instanceof NodeBase || item instanceof vscode.Uri) {
-        return modifyProject(item, "remove");
-      } else {
-        return modifyProject(undefined, "remove");
-      }
+      return modifyProject(item instanceof NodeBase || item instanceof vscode.Uri ? item : undefined, "remove");
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.modifyProjectMetadata", (item) => {
+      return modifyProjectMetadata(item instanceof NodeBase || item instanceof vscode.Uri ? item : undefined);
     }),
     vscode.commands.registerCommand("vscode-objectscript.createProject", (node) => createProject(node)),
     vscode.commands.registerCommand("vscode-objectscript.deleteProject", (node) => deleteProject(node)),


### PR DESCRIPTION
This PR fixes #1324

I added a command called `Modify Project Metadata...`. It can be accessed from: 

* Projects Explorer (right-click on a project node)
* file explorer (right-click on server-side root folder with a `project` query parameter)
* command palette.

Right now the command only lets you change the Description of a project, but I chose a generic name in case we eventually want it to edit other properties (which I consider very unlikely).