### PR TITLE
Support opening links from Studio extension pages

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -155,7 +155,9 @@ export class StudioActions {
               answer = "1";
               panel.dispose();
             } else if (typeof message.href == "string") {
-              vscode.env.openExternal(vscode.Uri.parse(message.href));
+              const linkUri = vscode.Uri.parse(message.href);
+              // Only open http(s) links
+              if (/^https?$/.test(linkUri.scheme)) vscode.env.openExternal(linkUri);
             }
           });
           panel.onDidDispose(() => resolve(answer));

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -154,6 +154,8 @@ export class StudioActions {
             if (message.result && message.result === "done") {
               answer = "1";
               panel.dispose();
+            } else if (typeof message.href == "string") {
+              vscode.env.openExternal(vscode.Uri.parse(message.href));
             }
           });
           panel.onDidDispose(() => resolve(answer));


### PR DESCRIPTION
This PR fixes #1328 

@gjsjohnmurray @isc-rsingh Should I do any input validation on the VS Code side before attempting the `openExternal()`? That failing should be harmless since it's a Thenable and we aren't awaiting it. I doubt a Studio extension page is going to have links to spam web pages.