### PR TITLE
Remove `objectscript.ignoreInstallServerManager` setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1477,11 +1477,6 @@
           "default": false,
           "description": "Output in JSON format the action that VS Code should perform as requested by the server."
         },
-        "objectscript.ignoreInstallServerManager": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Do not offer to install the [intersystems-community.servermanager](https://marketplace.visualstudio.com/items?itemName=intersystems-community.servermanager) extension."
-        },
         "objectscript.autoShowTerminal": {
           "description": "Automatically show terminal when connected to docker-compose.",
           "type": "boolean",


### PR DESCRIPTION
This setting is no longer required because this extension depends on the Server Manager in its package.json