### PR TITLE
Support trailing slash in `isfs` directory URIs

### DIFF
--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -218,7 +218,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
           if (!entry.Name.includes(".")) {
             if (!parent.entries.has(entry.Name)) {
               const folder = !csp
-                ? uri.path.replace(/\//g, ".")
+                ? uri.path.replace(/\/$/, "").replace(/\//g, ".")
                 : uri.path === "/"
                 ? ""
                 : uri.path.endsWith("/")
@@ -247,7 +247,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     }
     const csp = params.has("csp") && ["", "1"].includes(params.get("csp"));
     const folder = !csp
-      ? uri.path.replace(/\//g, ".")
+      ? uri.path.replace(/\/$/, "").replace(/\//g, ".")
       : uri.path === "/"
       ? ""
       : uri.path.endsWith("/")

--- a/src/utils/FileProviderUtil.ts
+++ b/src/utils/FileProviderUtil.ts
@@ -110,7 +110,7 @@ export function fileSpecFromURI(uri: vscode.Uri): string {
   const csp = params.has("csp") && ["", "1"].includes(params.get("csp"));
 
   const folder = !csp
-    ? uri.path.replace(/\//g, ".")
+    ? uri.path.replace(/\/$/, "").replace(/\//g, ".")
     : uri.path === "/"
     ? ""
     : uri.path.endsWith("/")


### PR DESCRIPTION
Our `FileSystemProvider` currently only supports directory URIs that don't end with a slash (for example, `isfs://iris:USER/User` works but `isfs://iris:USER/User/` always returns no contents). This PR fixes that bug by removing the trailing slash during processing if it's present. This bug is most clearly seen when trying to open a file using `Ctrl-O`. The Simple File dialog is shown, and when you try to see the contents of a directory that you haven't already expanded in the File Explorer, you get no results.