### PR TITLE
Output message with SystemMode upon connection to server

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -564,6 +564,7 @@ async function systemModeWarning(wsFolders: readonly vscode.WorkspaceFolder[]): 
       serverStr = ![undefined, ""].includes(api.config.serverName)
         ? `'${api.config.serverName}' (${serverUrl})`
         : serverUrl;
+    if (!api.active) continue; // Skip inactive connections
     let systemMode = systemModes.get(mapKey);
     if (systemMode == undefined) {
       systemMode = await api

--- a/syntaxes/vscode-objectscript-output.tmLanguage.json
+++ b/syntaxes/vscode-objectscript-output.tmLanguage.json
@@ -78,6 +78,14 @@
     {
       "match": "\\b(?i:(0?x)?[0-9a-f][0-9a-f]+)\\b",
       "name": "constant.numeric"
+    },
+    {
+      "match": "^WARNING:",
+      "name": "invalid"
+    },
+    {
+      "match": "^NOTE:",
+      "name": "string.quoted"
     }
   ]
 }


### PR DESCRIPTION
This PR fixes #1359 

If a connected server has a [`SystemMode`](https://docs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RACS_SystemMode) value of `LIVE`, `TEST`, or `FAILOVER`, a message will be written to the Output channel. This ahppens upon extension activation, or if a new workspace folder is added. 

<img width="856" alt="Screenshot 2024-05-13 at 9 15 39 AM" src="https://github.com/intersystems-community/vscode-objectscript/assets/44776135/17ab46d1-898a-47c4-87c8-5f163e4cc51f">
