### PR TITLE
Allow prompt for username if unauthenticated access fails

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -221,12 +221,12 @@ export async function resolveConnectionSpec(serverName: string): Promise<void> {
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export async function resolvePassword(serverSpec, ignoreUnauthentiated = false): Promise<void> {
+export async function resolvePassword(serverSpec, ignoreUnauthenticated = false): Promise<void> {
   const AUTHENTICATION_PROVIDER = "intersystems-server-credentials";
   // This arises if setting says to use authentication provider
   if (
     // Connection isn't unauthenticated
-    (!isUnauthenticated(serverSpec.username) || ignoreUnauthentiated) &&
+    (!isUnauthenticated(serverSpec.username) || ignoreUnauthenticated) &&
     // A password is missing
     typeof serverSpec.password == "undefined"
   ) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -699,6 +699,11 @@ export function methodOffsetToLine(
   return line;
 }
 
+/** Return `true` if this username signals unauthenticated access  */
+export function isUnauthenticated(username: string): boolean {
+  return username == undefined || username == "" || username.toLowerCase() == "unknownuser";
+}
+
 // ---------------------------------------------------------------------
 // Source: https://github.com/amsterdamharu/lib/blob/master/src/index.js
 


### PR DESCRIPTION
This PR fixes #1371 and fixes #1364

This change will make the extension fall back to the pre-#1351 behavior if the unauthenticated access fails.