### PR TITLE
Improve triggering of `AttemptedEdit` source control action

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -849,9 +849,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     }),
     vscode.workspace.onDidChangeTextDocument((event) => {
       if (
-        event.contentChanges.length !== 0 &&
-        event.document.uri.scheme === FILESYSTEM_SCHEMA &&
-        !event.document.isDirty
+        event.document.uri.scheme == FILESYSTEM_SCHEMA &&
+        // These two expressions will both be true only for
+        // the edit that makes a document go from clean to dirty
+        event.contentChanges.length == 0 &&
+        event.document.isDirty
       ) {
         fireOtherStudioAction(OtherStudioAction.AttemptedEdit, event.document.uri);
       }


### PR DESCRIPTION
This PR fixes a bug reported by an internal developer related to the firing of the `AttemptedEdit` source control action. The developer reported that after reverting a file in the source control UI (not VS Code) when VS Code refreshed its copy of the file the `AttemptedEdit` action was incorrectly fired, and then upon the next edit to the file the action was not fired. I determined that this was due to the `suppressEditListenerMap` that was added to avoid firing the action when the file was reverted by the the source control hook. I fixed this issue by changing the criteria that were checked before firing the action so the map was no longer needed.