### PR TITLE
XML Import/Export commands shouldn't assume a server connection in a multi-root workspace

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -812,25 +812,22 @@ interface XMLQuickPickItem extends vscode.QuickPickItem {
 
 export async function importXMLFiles(): Promise<any> {
   try {
-    // Use the server connection from the active document if possible
-    let connectionUri = currentFile()?.uri;
-    if (!connectionUri) {
-      // Use the server connection from a workspace folder
-      const workspaceFolders = vscode.workspace.workspaceFolders || [];
-      if (workspaceFolders.length == 0) {
-        vscode.window.showErrorMessage("'Import XML Files...' command requires an open workspace.", "Dismiss");
-      } else if (workspaceFolders.length == 1) {
-        // Use the current connection
-        connectionUri = workspaceFolders[0].uri;
-      } else {
-        // Pick from the workspace folders
-        connectionUri = (
-          await vscode.window.showWorkspaceFolderPick({
-            ignoreFocusOut: true,
-            placeHolder: "Pick the workspace folder to get server connection information from",
-          })
-        )?.uri;
-      }
+    // Use the server connection from a workspace folder
+    let connectionUri: vscode.Uri;
+    const workspaceFolders = vscode.workspace.workspaceFolders || [];
+    if (workspaceFolders.length == 0) {
+      vscode.window.showErrorMessage("'Import XML Files...' command requires an open workspace.", "Dismiss");
+    } else if (workspaceFolders.length == 1) {
+      // Use the current connection
+      connectionUri = workspaceFolders[0].uri;
+    } else {
+      // Pick from the workspace folders
+      connectionUri = (
+        await vscode.window.showWorkspaceFolderPick({
+          ignoreFocusOut: true,
+          placeHolder: "Pick the workspace folder to get server connection information from",
+        })
+      )?.uri;
     }
     if (connectionUri) {
       const api = new AtelierAPI(connectionUri);

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -385,28 +385,25 @@ export async function exportCurrentFile(): Promise<any> {
 
 export async function exportDocumentsToXMLFile(): Promise<void> {
   try {
-    // Use the server connection from the active document if possible
-    let connectionUri = currentFile()?.uri;
-    if (!connectionUri) {
-      // Use the server connection from a workspace folder
-      const workspaceFolders = vscode.workspace.workspaceFolders || [];
-      if (workspaceFolders.length == 0) {
-        vscode.window.showErrorMessage(
-          "'Export Documents to XML File...' command requires an open workspace.",
-          "Dismiss"
-        );
-      } else if (workspaceFolders.length == 1) {
-        // Use the current connection
-        connectionUri = workspaceFolders[0].uri;
-      } else {
-        // Pick from the workspace folders
-        connectionUri = (
-          await vscode.window.showWorkspaceFolderPick({
-            ignoreFocusOut: true,
-            placeHolder: "Pick the workspace folder to get server connection information from",
-          })
-        )?.uri;
-      }
+    // Use the server connection from a workspace folder
+    let connectionUri: vscode.Uri;
+    const workspaceFolders = vscode.workspace.workspaceFolders || [];
+    if (workspaceFolders.length == 0) {
+      vscode.window.showErrorMessage(
+        "'Export Documents to XML File...' command requires an open workspace.",
+        "Dismiss"
+      );
+    } else if (workspaceFolders.length == 1) {
+      // Use the current connection
+      connectionUri = workspaceFolders[0].uri;
+    } else {
+      // Pick from the workspace folders
+      connectionUri = (
+        await vscode.window.showWorkspaceFolderPick({
+          ignoreFocusOut: true,
+          placeHolder: "Pick the workspace folder to get server connection information from",
+        })
+      )?.uri;
     }
     if (connectionUri) {
       const api = new AtelierAPI(connectionUri);


### PR DESCRIPTION
This PR addresses some confusing behavior reported by an internal dev. They had a multi-root workspace connected to %SYS and USER on the same server. They had a document from %SYS in the active editor tab, but wanted to import an XML file into USER. The command defaulted to use the %SYS connection, so the file got imported into the wrong namespace. I think it's a better user experience to always ask for the connection if you're in a multi-root workspace. 