### PR TITLE
Add `Compile` command to server-side file explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,10 +196,6 @@
           "when": "vscode-objectscript.connectActive"
         },
         {
-          "command": "vscode-objectscript.compileFolder",
-          "when": "false"
-        },
-        {
           "command": "vscode-objectscript.serverCommands.sourceControl",
           "when": "vscode-objectscript.connectActive && resourceScheme == isfs || (vscode-objectscript.connectActive && !editorIsOpen)"
         },
@@ -338,6 +334,10 @@
         {
           "command": "vscode-objectscript.extractXMLFileContents",
           "when": "vscode-objectscript.connectActive && workspaceFolderCount != 0"
+        },
+        {
+          "command": "vscode-objectscript.compileIsfs",
+          "when": "false"
         }
       ],
       "view/title": [
@@ -622,6 +622,11 @@
           "command": "vscode-objectscript.extractXMLFileContents",
           "when": "vscode-objectscript.connectActive && resourceExtname =~ /^\\.xml$/i && !(resourceScheme =~ /^isfs(-readonly)?$/)",
           "group": "objectscript_modify@4"
+        },
+        {
+          "command": "vscode-objectscript.compileIsfs",
+          "when": "vscode-objectscript.connectActive && resourceScheme == isfs && resourcePath && !(resourcePath =~ /^\\/?$/) && !listMultiSelection",
+          "group": "objectscript_modify@1"
         }
       ],
       "file/newFile": [
@@ -1174,6 +1179,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.extractXMLFileContents",
         "title": "Extract Documents from XML File..."
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.compileIsfs",
+        "title": "Compile"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -877,7 +877,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand("vscode-objectscript.compileWithFlags", () => importAndCompile(true)),
     vscode.commands.registerCommand("vscode-objectscript.compileAll", () => namespaceCompile(false)),
     vscode.commands.registerCommand("vscode-objectscript.compileAllWithFlags", () => namespaceCompile(true)),
-    vscode.commands.registerCommand("vscode-objectscript.refreshLocalFile", async (_file, files) => {
+    vscode.commands.registerCommand("vscode-objectscript.refreshLocalFile", async () => {
       const file = currentFile();
       if (!file) {
         return;
@@ -1404,6 +1404,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
       }
     ),
+    vscode.commands.registerCommand("vscode-objectscript.compileIsfs", (uri) => fileSystemProvider.compile(uri)),
     ...setUpTestController(),
 
     /* Anything we use from the VS Code proposed API */

--- a/src/utils/FileProviderUtil.ts
+++ b/src/utils/FileProviderUtil.ts
@@ -25,16 +25,16 @@ export async function projectContentsFromUri(uri: vscode.Uri, overrideFlat?: boo
       "SELECT CASE " +
       "WHEN Type = 'CLS' THEN Name||'.cls' " +
       "ELSE Name END Name, Type FROM %Studio.Project_ProjectItemsList(?) " +
-      "WHERE (Name %STARTSWITH ? OR Name %STARTSWITH ?) AND (" +
+      "WHERE (Name %STARTSWITH ? OR Name %STARTSWITH ?) AND ((" +
       "(Type = 'MAC' AND EXISTS (SELECT sod.Size FROM %Library.RoutineMgr_StudioOpenDialog('*.mac,*.int,*.inc,*.bas,*.mvi',1,1,1,1,0,1) AS sod WHERE Name = sod.Name)) OR " +
       "(Type = 'CSP' AND EXISTS (SELECT sod.Size FROM %Library.RoutineMgr_StudioOpenDialog('*.cspall',1,1,1,1,0,1) AS sod WHERE '/'||Name = sod.Name)) OR " +
       "(Type NOT IN ('CLS','PKG','MAC','CSP','DIR','GBL') AND EXISTS (SELECT sod.Size FROM %Library.RoutineMgr_StudioOpenDialog('*.other',1,1,1,1,0,1) AS sod WHERE Name = sod.Name))) OR " +
-      "(Type = 'CLS' AND (Package IS NOT NULL OR (Package IS NULL AND EXISTS (SELECT dcd.ID FROM %Dictionary.ClassDefinition AS dcd WHERE dcd.ID = Name)))) " +
+      "(Type = 'CLS' AND (Package IS NOT NULL OR (Package IS NULL AND EXISTS (SELECT dcd.ID FROM %Dictionary.ClassDefinition AS dcd WHERE dcd.ID = Name))))) " +
       "UNION " +
-      "SELECT SUBSTR(sod.Name,2) AS Name, pil.Type FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,1,1,0,1) AS sod " +
+      "SELECT SUBSTR(sod.Name,2) AS Name, pil.Type FROM %Library.RoutineMgr_StudioOpenDialog('*.cspall',1,1,1,1,0,1,?) AS sod " +
       "JOIN %Studio.Project_ProjectItemsList(?,1) AS pil ON " +
       "pil.Type = 'DIR' AND SUBSTR(sod.Name,2) %STARTSWITH ? AND SUBSTR(sod.Name,2) %STARTSWITH pil.Name||'/'";
-    parameters = [project, folderDots, folder, folder + "*.cspall", project, folder];
+    parameters = [project, folderDots, folder, `Name %STARTSWITH '/${folder}'`, project, folder];
   } else {
     if (folder.length) {
       const l = String(folder.length + 1); // Need the + 1 because SUBSTR is 1 indexed


### PR DESCRIPTION
* Fixes #1388 
* Fixes a bug in folder deletion in Project server-side workspace folders
* Improve performance of loading post-compile changes by reducing REST request volume
* Remove outdated code in `updateOthers()`