### PR TITLE
Don't log error when attempting a debug attach in a non-Interoperability namespace

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -941,12 +941,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           .actionQuery("SELECT Job, ConfigName FROM Ens.Job_Enumerate() WHERE State = 'Alive'", [])
           .then((data) => Object.fromEntries(data.result.content.map((x) => [x.Job, x.ConfigName])))
           .catch((error) => {
-            if (
-              error &&
-              error.errorText &&
-              !error.errorText.includes("'ENS.JOB_ENUMERATE'(...)") &&
-              error.errorText != ""
-            ) {
+            if (error?.errorText && error.errorText != "" && !error.errorText.includes("ENS.JOB_ENUMERATE")) {
               // Hide errors about Ens.Job_Enumerate procedure not existing because
               // the current namespace may not be Interoperability-enabled
               outputChannel.appendLine("\n" + error.errorText);


### PR DESCRIPTION
I think this was caused by a server-side change that HTML-encoded the quote characters in the error text.