### PR TITLE
Add command for opening InterSystems documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -359,6 +359,10 @@
           "command": "vscode-objectscript.explorer.project.openOtherServerNs",
           "when": "view == ObjectScriptProjectsExplorer && vscode-objectscript.projectsExplorerRootCount > 0",
           "group": "navigation"
+        },
+        {
+          "command": "vscode-objectscript.openISCDocument",
+          "when": "view == workbench.explorer.fileView && vscode-objectscript.connectActive && workspaceFolderCount != 0"
         }
       ],
       "view/item/context": [

--- a/package.json
+++ b/package.json
@@ -338,6 +338,10 @@
         {
           "command": "vscode-objectscript.compileIsfs",
           "when": "false"
+        },
+        {
+          "command": "vscode-objectscript.openISCDocument",
+          "when": "vscode-objectscript.connectActive && workspaceFolderCount != 0"
         }
       ],
       "view/title": [
@@ -1179,6 +1183,11 @@
         "category": "ObjectScript",
         "command": "vscode-objectscript.compileIsfs",
         "title": "Compile"
+      },
+      {
+        "category": "ObjectScript",
+        "command": "vscode-objectscript.openISCDocument",
+        "title": "Open InterSystems Document..."
       }
     ],
     "keybindings": [

--- a/package.json
+++ b/package.json
@@ -362,7 +362,8 @@
         },
         {
           "command": "vscode-objectscript.openISCDocument",
-          "when": "view == workbench.explorer.fileView && vscode-objectscript.connectActive && workspaceFolderCount != 0"
+          "when": "view == workbench.explorer.fileView && vscode-objectscript.connectActive && workspaceFolderCount != 0",
+          "group": "navigation"
         }
       ],
       "view/item/context": [
@@ -1191,7 +1192,8 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.openISCDocument",
-        "title": "Open InterSystems Document..."
+        "title": "Open InterSystems Document...",
+        "icon": "$(go-to-file)"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1425,7 +1425,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         );
         return;
       }
-      const doc = await pickDocument(api, "to open");
+      const doc = await pickDocument(api, "Open a document");
       if (!doc) return;
       vscode.window.showTextDocument(
         DocumentContentProvider.getUri(doc, undefined, undefined, undefined, wsFolder.uri)

--- a/src/utils/documentPicker.ts
+++ b/src/utils/documentPicker.ts
@@ -351,9 +351,7 @@ export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<st
 
   return new Promise<string>((resolve) => {
     const quickPick = vscode.window.createQuickPick<DocumentPickerItem>();
-    quickPick.title = `Select a document in namespace '${api.ns}' on server '${api.serverId}'${
-      prompt ? " " + prompt : ""
-    }`;
+    quickPick.title = `${prompt ? prompt : "Select a document"} in namespace '${api.ns}' on server '${api.serverId}'`;
     quickPick.ignoreFocusOut = true;
     quickPick.buttons = [
       { iconPath: sysBtn, tooltip: "Show system documents" },

--- a/src/utils/documentPicker.ts
+++ b/src/utils/documentPicker.ts
@@ -1,13 +1,13 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
-import { outputChannel } from ".";
+import { cspAppsForApi, outputChannel } from ".";
 
 interface DocumentPickerItem extends vscode.QuickPickItem {
   /** The full name of this item, including its parent(s). */
   fullName: string;
 }
 
-function sodItemToDocumentPickerItem(
+function createMultiSelectItem(
   item: { Name: string; Type: number },
   parent?: string,
   parentPad?: number
@@ -53,6 +53,33 @@ function sodItemToDocumentPickerItem(
   return result;
 }
 
+function createSingleSelectItem(
+  item: { Name: string; Type: number },
+  parent?: string,
+  delimiter?: string
+): DocumentPickerItem {
+  const result: DocumentPickerItem = { label: item.Name, fullName: item.Name };
+  // Add the icon
+  if (item.Type == 0) {
+    if (item.Name.endsWith(".inc")) {
+      result.label = "$(file-symlink-file) " + result.label;
+    } else if (item.Name.endsWith(".int") || item.Name.endsWith(".mac")) {
+      result.label = "$(note) " + result.label;
+    } else {
+      result.label = "$(symbol-misc) " + result.label;
+    }
+  } else if (item.Type == 4) {
+    result.label = "$(symbol-class) " + result.label;
+  } else if (![9, 10].includes(item.Type)) {
+    result.label = "$(symbol-file) " + result.label;
+  }
+  if (parent) {
+    // Update the full name if this is a nested item
+    result.fullName = parent + delimiter + item.Name;
+  }
+  return result;
+}
+
 /**
  * Prompts the user to select documents in server-namespace `api`
  * using a custom multi-select QuickPick. An optional prompt will customize the title.
@@ -60,17 +87,29 @@ function sodItemToDocumentPickerItem(
 export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<string[]> {
   let sys: "0" | "1" = "0";
   let gen: "0" | "1" = "0";
-  let map: "0" | "1" = "0";
+  let map: "0" | "1" = "1";
   const query = "SELECT Name, Type FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,?,0,0,?,,0,?)";
-  const parameters = ["*", sys, gen, map];
   const sysBtn = new vscode.ThemeIcon("library");
   const genBtn = new vscode.ThemeIcon("server-process");
   const mapBtn = new vscode.ThemeIcon("references");
+  const webApps = cspAppsForApi(api);
+  const webAppRootItems = webApps.map((app: string) => {
+    return {
+      label: "$(folder) " + app,
+      fullName: app,
+      buttons: [
+        {
+          iconPath: new vscode.ThemeIcon("chevron-right"),
+          tooltip: "Expand",
+        },
+      ],
+    };
+  });
 
   return new Promise<string[]>((resolve) => {
     let result: string[] = [];
     const quickPick = vscode.window.createQuickPick<DocumentPickerItem>();
-    quickPick.title = `Select documents in namespace '${api.ns.toUpperCase()}' on server '${api.serverId}'${
+    quickPick.title = `Select documents in namespace '${api.ns}' on server '${api.serverId}'${
       prompt ? " " + prompt : ""
     }`;
     quickPick.ignoreFocusOut = true;
@@ -80,42 +119,23 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
     quickPick.buttons = [
       { iconPath: sysBtn, tooltip: "Show system documents" },
       { iconPath: genBtn, tooltip: "Show generated documents" },
-      { iconPath: mapBtn, tooltip: "Show mapped documents" },
+      { iconPath: mapBtn, tooltip: "Hide mapped documents" },
     ];
 
-    const getCSPRootItems = (): Promise<DocumentPickerItem[]> => {
-      return api.getCSPApps().then((data) =>
-        data.result.content.map((app: string) => {
-          return {
-            label: "$(folder) " + app,
-            fullName: app,
-            buttons: [
-              {
-                iconPath: new vscode.ThemeIcon("chevron-right"),
-                tooltip: "Expand",
-              },
-            ],
-          };
-        })
-      );
-    };
     const getRootItems = (): Promise<void> => {
       return api
-        .actionQuery(`${query} WHERE Type != 5 AND Type != 10`, parameters)
+        .actionQuery(`${query} WHERE Type != 5 AND Type != 10`, ["*", sys, gen, map])
         .then((data) => {
-          const rootitems: DocumentPickerItem[] = data.result.content.map((i) => sodItemToDocumentPickerItem(i));
-          return getCSPRootItems().then((csprootitems) => {
-            const findLastIndex = (): number => {
-              let l = rootitems.length;
-              while (l--) {
-                if (rootitems[l].buttons) return l;
-              }
-              return -1;
-            };
-
-            rootitems.splice(findLastIndex() + 1, 0, ...csprootitems);
-            return rootitems;
-          });
+          const rootitems: DocumentPickerItem[] = data.result.content.map((i) => createMultiSelectItem(i));
+          const findLastIndex = (): number => {
+            let l = rootitems.length;
+            while (l--) {
+              if (rootitems[l].buttons) return l;
+            }
+            return -1;
+          };
+          rootitems.splice(findLastIndex() + 1, 0, ...webAppRootItems);
+          return rootitems;
         })
         .then((items) => {
           quickPick.items = items;
@@ -143,10 +163,10 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
         },
       ];
       return api
-        .actionQuery(query, [item.fullName + "/*", sys, gen, map])
+        .actionQuery(query, [`${item.fullName}/*`, sys, gen, map])
         .then((data) => {
           const insertItems: DocumentPickerItem[] = data.result.content.map((i) =>
-            sodItemToDocumentPickerItem(i, item.fullName, item.label.search(/\S/))
+            createMultiSelectItem(i, item.fullName, item.label.search(/\S/))
           );
           const newItems = [...quickPick.items];
           newItems.splice(itemIdx + 1, 0, ...insertItems);
@@ -181,15 +201,12 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
       quickPick.enabled = false;
       if (button.tooltip.charAt(0) == "S") {
         if (button.tooltip.includes("system")) {
-          // Update the button
           quickPick.buttons = [
             { iconPath: sysBtn, tooltip: "Hide system documents" },
             quickPick.buttons[1],
             quickPick.buttons[2],
           ];
-          // Change value of correct parameter in array
           sys = "1";
-          parameters[1] = sys;
         } else if (button.tooltip.includes("generated")) {
           quickPick.buttons = [
             quickPick.buttons[0],
@@ -197,7 +214,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
             quickPick.buttons[2],
           ];
           gen = "1";
-          parameters[2] = gen;
         } else {
           quickPick.buttons = [
             quickPick.buttons[0],
@@ -205,7 +221,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
             { iconPath: mapBtn, tooltip: "Hide mapped documents" },
           ];
           map = "1";
-          parameters[3] = map;
         }
       } else {
         if (button.tooltip.includes("system")) {
@@ -215,7 +230,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
             quickPick.buttons[2],
           ];
           sys = "0";
-          parameters[1] = sys;
         } else if (button.tooltip.includes("generated")) {
           quickPick.buttons = [
             quickPick.buttons[0],
@@ -223,7 +237,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
             quickPick.buttons[2],
           ];
           gen = "0";
-          parameters[2] = gen;
         } else {
           quickPick.buttons = [
             quickPick.buttons[0],
@@ -231,7 +244,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
             { iconPath: mapBtn, tooltip: "Show mapped documents" },
           ];
           map = "0";
-          parameters[3] = map;
         }
       }
       // Refresh the items list
@@ -308,6 +320,200 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
     });
     quickPick.onDidHide(() => {
       resolve([]);
+      quickPick.dispose();
+    });
+    quickPick.busy = true;
+    quickPick.enabled = false;
+    quickPick.show();
+    getRootItems();
+  });
+}
+
+/**
+ * Prompts the user to select a single document in server-namespace `api`
+ * using a custom QuickPick. An optional prompt will customize the title.
+ */
+export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<string> {
+  let sys: "0" | "1" = "0";
+  let gen: "0" | "1" = "0";
+  let map: "0" | "1" = "1";
+  const query = "SELECT Name, Type FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,?,0,0,?,,0,?)";
+  const sysBtn = new vscode.ThemeIcon("library");
+  const genBtn = new vscode.ThemeIcon("server-process");
+  const mapBtn = new vscode.ThemeIcon("references");
+  const webApps = cspAppsForApi(api);
+  const webAppRootItems = webApps.map((app: string) => {
+    return {
+      label: app,
+      fullName: app,
+    };
+  });
+
+  return new Promise<string>((resolve) => {
+    const quickPick = vscode.window.createQuickPick<DocumentPickerItem>();
+    quickPick.title = `Select a document in namespace '${api.ns}' on server '${api.serverId}'${
+      prompt ? " " + prompt : ""
+    }`;
+    quickPick.ignoreFocusOut = true;
+    quickPick.buttons = [
+      { iconPath: sysBtn, tooltip: "Show system documents" },
+      { iconPath: genBtn, tooltip: "Show generated documents" },
+      { iconPath: mapBtn, tooltip: "Hide mapped documents" },
+    ];
+
+    const getRootItems = (): Promise<void> => {
+      return api
+        .actionQuery(`${query} WHERE Type != 5 AND Type != 10`, ["*,'*.prj", sys, gen, map])
+        .then((data) => {
+          const rootitems: DocumentPickerItem[] = data.result.content.map((i) => createSingleSelectItem(i));
+          const findLastIndex = (): number => {
+            let l = rootitems.length;
+            while (l--) {
+              if (!rootitems[l].label.startsWith("$(")) return l;
+            }
+            return -1;
+          };
+          rootitems.splice(findLastIndex() + 1, 0, ...webAppRootItems);
+          return rootitems;
+        })
+        .then((items) => {
+          quickPick.items = items;
+          quickPick.selectedItems = [];
+          quickPick.value = "";
+          quickPick.busy = false;
+          quickPick.enabled = true;
+        })
+        .catch((error) => {
+          quickPick.hide();
+          let message = `Failed to get namespace contents.`;
+          if (error && error.errorText && error.errorText !== "") {
+            outputChannel.appendLine("\n" + error.errorText);
+            outputChannel.show(true);
+            message += " Check 'ObjectScript' output channel for details.";
+          }
+          vscode.window.showErrorMessage(message, "Dismiss");
+        });
+    };
+
+    quickPick.onDidTriggerButton((button) => {
+      quickPick.busy = true;
+      quickPick.enabled = false;
+      if (button.tooltip.charAt(0) == "S") {
+        if (button.tooltip.includes("system")) {
+          quickPick.buttons = [
+            { iconPath: sysBtn, tooltip: "Hide system documents" },
+            quickPick.buttons[1],
+            quickPick.buttons[2],
+          ];
+          sys = "1";
+        } else if (button.tooltip.includes("generated")) {
+          quickPick.buttons = [
+            quickPick.buttons[0],
+            { iconPath: genBtn, tooltip: "Hide generated documents" },
+            quickPick.buttons[2],
+          ];
+          gen = "1";
+        } else {
+          quickPick.buttons = [
+            quickPick.buttons[0],
+            quickPick.buttons[1],
+            { iconPath: mapBtn, tooltip: "Hide mapped documents" },
+          ];
+          map = "1";
+        }
+      } else {
+        if (button.tooltip.includes("system")) {
+          quickPick.buttons = [
+            { iconPath: sysBtn, tooltip: "Show system documents" },
+            quickPick.buttons[1],
+            quickPick.buttons[2],
+          ];
+          sys = "0";
+        } else if (button.tooltip.includes("generated")) {
+          quickPick.buttons = [
+            quickPick.buttons[0],
+            { iconPath: genBtn, tooltip: "Show generated documents" },
+            quickPick.buttons[2],
+          ];
+          gen = "0";
+        } else {
+          quickPick.buttons = [
+            quickPick.buttons[0],
+            quickPick.buttons[1],
+            { iconPath: mapBtn, tooltip: "Show mapped documents" },
+          ];
+          map = "0";
+        }
+      }
+      // Refresh the items list
+      getRootItems();
+    });
+    quickPick.onDidAccept(() => {
+      quickPick.busy = true;
+      quickPick.enabled = false;
+      const item = quickPick.selectedItems[0];
+      if (!item || item.label.startsWith("$(")) {
+        const doc = item?.fullName ?? quickPick.value.trim();
+        if (!item) {
+          // The document name came from the value text, so validate it first
+          api
+            .headDoc(doc)
+            .then(() => resolve(doc))
+            .catch((error) => {
+              vscode.window.showErrorMessage(
+                error?.statusCode == 400
+                  ? `'${doc}' is an invalid document name.`
+                  : error?.statusCode == 404
+                  ? `Document '${doc}' does not exist.`
+                  : `Internal Server Error encountered trying to validate document '${doc}'.`,
+                "Dismiss"
+              );
+              resolve(undefined);
+            })
+            .finally(() => quickPick.hide());
+        } else {
+          // The document name came from an item so no validation is required
+          resolve(doc);
+          quickPick.hide();
+        }
+      } else {
+        // Replace the items with the folder's contents
+        if (item.fullName == "") {
+          getRootItems();
+        } else {
+          api
+            .actionQuery(query, [`${item.fullName}/*`, sys, gen, map])
+            .then((data) => {
+              const delim = item.fullName.includes("/") ? "/" : ".";
+              const newItems: DocumentPickerItem[] = data.result.content.map((i) =>
+                createSingleSelectItem(i, item.fullName, delim)
+              );
+              let parentFullName =
+                delim == "/" && webApps.includes(item.fullName)
+                  ? ""
+                  : item.fullName.split(delim).slice(0, -1).join(delim);
+              if (parentFullName == "/") parentFullName = "";
+              quickPick.items = [{ label: "..", fullName: parentFullName }].concat(newItems);
+              quickPick.value = "";
+              quickPick.selectedItems = [];
+              quickPick.busy = false;
+              quickPick.enabled = true;
+            })
+            .catch((error) => {
+              quickPick.hide();
+              let message = `Failed to get namespace contents.`;
+              if (error && error.errorText && error.errorText !== "") {
+                outputChannel.appendLine("\n" + error.errorText);
+                outputChannel.show(true);
+                message += " Check 'ObjectScript' output channel for details.";
+              }
+              vscode.window.showErrorMessage(message, "Dismiss");
+            });
+        }
+      }
+    });
+    quickPick.onDidHide(() => {
+      resolve(undefined);
       quickPick.dispose();
     });
     quickPick.busy = true;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -70,17 +70,21 @@ export interface ConnectionTarget {
   configName: string;
 }
 
-/**
- * Get a list of all CSP web apps in the server-namespace that `uri` is connected to.
- */
+/** Get a list of all CSP web apps in the server-namespace that `uri` is connected to. */
 export function cspAppsForUri(uri: vscode.Uri): string[] {
-  const api = new AtelierAPI(uri);
-  const key = (
-    api.config.serverName && api.config.serverName != ""
-      ? `${api.config.serverName}:${api.config.ns}`
-      : `${api.config.host}:${api.config.port}${api.config.pathPrefix}:${api.config.ns}`
-  ).toLowerCase();
-  return cspApps.get(key) ?? [];
+  return cspAppsForApi(new AtelierAPI(uri));
+}
+
+/** Get a list of all CSP web apps in the server-namespace that `api` is connected to. */
+export function cspAppsForApi(api: AtelierAPI): string[] {
+  return (
+    cspApps.get(
+      (api.config.serverName && api.config.serverName != ""
+        ? `${api.config.serverName}:${api.config.ns}`
+        : `${api.config.host}:${api.config.port}${api.config.pathPrefix}:${api.config.ns}`
+      ).toLowerCase()
+    ) ?? []
+  );
 }
 
 /**


### PR DESCRIPTION
This PR fixes #1379. The new `Open InterSystems Document...` command can be opened from the command palette and it provides a UI for browsing all files in the connected server-namespace. The user can either pick an item in the list, or type text into the filter box and press "Enter" to submit that. The UI should function very similarity to the built-in simple file dialog. I would like to assign a keybinding to this command, but I couldn't find a good one so I'm open to suggestions. 

![output](https://github.com/intersystems-community/vscode-objectscript/assets/44776135/358dc533-f6e6-4416-985b-e5493341a98f)
