### PR TITLE
Set file readonly if class is deployed or if server-side source control reports it not editable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1310,12 +1310,14 @@
         "objectscript.serverSourceControl.disableOtherActionTriggers": {
           "description": "Prevent server-side source control 'other action' triggers from firing.",
           "type": "boolean",
-          "scope": "resource"
+          "scope": "resource",
+          "default": false
         },
         "objectscript.serverSourceControl.respectEditableStatus": {
           "markdownDescription": "Set `isfs` document readonly if GetStatus method of server-side source control class returns Editable = 0.",
           "type": "boolean",
-          "scope": "resource"
+          "scope": "resource",
+          "default": false
         },
         "objectscript.export": {
           "type": "object",
@@ -1379,11 +1381,13 @@
             },
             "atelier": {
               "description": "Export source code as Atelier did it, with packages as subfolders. This setting only affects classes, routines, include files and DFI files.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "generated": {
               "description": "Export generated source code files, such as INTs generated from classes.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "filter": {
               "markdownDescription": "SQL filter to limit what to export. The filter is applied to document names using the [LIKE predicate](https://irisdocs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_like) (i.e. `Name LIKE '%filter%'`).",
@@ -1402,11 +1406,13 @@
             },
             "noStorage": {
               "description": "Strip the storage definition on export. Can be useful when working across multiple systems.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "dontExportIfNoChanges": {
               "description": "Do not rewrite the local file if the content is identical to what came from the server.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             },
             "maxConcurrentConnections": {
               "description": "Maximum number of concurrent export connections. (0 = unlimited)",
@@ -1414,7 +1420,8 @@
             },
             "mapped": {
               "description": "Export source code files mapped from a non-default database.",
-              "type": "boolean"
+              "type": "boolean",
+              "default": false
             }
           }
         },
@@ -1693,7 +1700,8 @@
               },
               "stopOnEntry": {
                 "type": "boolean",
-                "description": "Automatically stop target after attach. If not specified, target does not stop."
+                "description": "Automatically stop target after attach. If not specified, target does not stop.",
+                "default": false
               }
             }
           }

--- a/package.json
+++ b/package.json
@@ -1381,13 +1381,11 @@
             },
             "atelier": {
               "description": "Export source code as Atelier did it, with packages as subfolders. This setting only affects classes, routines, include files and DFI files.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "generated": {
               "description": "Export generated source code files, such as INTs generated from classes.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "filter": {
               "markdownDescription": "SQL filter to limit what to export. The filter is applied to document names using the [LIKE predicate](https://irisdocs.intersystems.com/irislatest/csp/docbook/DocBook.UI.Page.cls?KEY=RSQL_like) (i.e. `Name LIKE '%filter%'`).",
@@ -1406,13 +1404,11 @@
             },
             "noStorage": {
               "description": "Strip the storage definition on export. Can be useful when working across multiple systems.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "dontExportIfNoChanges": {
               "description": "Do not rewrite the local file if the content is identical to what came from the server.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             },
             "maxConcurrentConnections": {
               "description": "Maximum number of concurrent export connections. (0 = unlimited)",
@@ -1420,8 +1416,7 @@
             },
             "mapped": {
               "description": "Export source code files mapped from a non-default database.",
-              "type": "boolean",
-              "default": false
+              "type": "boolean"
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -1313,7 +1313,7 @@
           "scope": "resource"
         },
         "objectscript.serverSourceControl.respectEditableStatus": {
-          "description": "Set ISFS document readonly if GetStatus method of server-side source control class returns Editable=0",
+          "markdownDescription": "Set `isfs` document readonly if GetStatus method of server-side source control class returns Editable = 0.",
           "type": "boolean",
           "scope": "resource"
         },

--- a/package.json
+++ b/package.json
@@ -1312,6 +1312,11 @@
           "type": "boolean",
           "scope": "resource"
         },
+        "objectscript.serverSourceControl.respectEditableStatus": {
+          "description": "Set ISFS document readonly if GetStatus method of server-side source control class returns Editable=0",
+          "type": "boolean",
+          "scope": "resource"
+        },
         "objectscript.export": {
           "type": "object",
           "description": "Control what to export from the server into the local folder.",

--- a/src/providers/FileSystemProvider/File.ts
+++ b/src/providers/FileSystemProvider/File.ts
@@ -5,6 +5,7 @@ export class File implements vscode.FileStat {
   public ctime: number;
   public mtime: number;
   public size: number;
+  public permissions?: vscode.FilePermission;
   public fileName: string;
   public name: string;
   public data?: Uint8Array;

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -7,7 +7,6 @@ import { fireOtherStudioAction, OtherStudioAction, StudioActions } from "../../c
 import { projectContentsFromUri, studioOpenDialogFromURI } from "../../utils/FileProviderUtil";
 import {
   classNameRegex,
-  getServerName,
   isClassDeployed,
   notNull,
   outputChannel,
@@ -222,7 +221,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     //
     if (result instanceof File) {
       const api = new AtelierAPI(uri);
-      const serverName = getServerName(uri);
+      const serverName = isCSPFile(uri) ? uri.path : uri.path.slice(1).replace(/\//g, ".");
       if (serverName.slice(-4).toLowerCase() == ".cls") {
         if (await isClassDeployed(serverName, api)) {
           result.permissions |= vscode.FilePermission.Readonly;
@@ -234,7 +233,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       if (vscode.workspace.getConfiguration("objectscript.serverSourceControl", uri)?.get("respectEditableStatus")) {
         const query = "select * from %Atelier_v1_Utils.Extension_GetStatus(?)";
         const statusObj = await api.actionQuery(query, [serverName]);
-        const docStatus = statusObj.result.content.pop();
+        const docStatus = statusObj.result?.content?.pop();
         if (docStatus) {
           result.permissions = docStatus.editable ? undefined : result.permissions | vscode.FilePermission.Readonly;
         }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -231,11 +231,13 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       }
 
       // Does server-side source control report it as editable?
-      const query = "select * from %Atelier_v1_Utils.Extension_GetStatus(?)";
-      const statusObj = await api.actionQuery(query, [serverName]);
-      const docStatus = statusObj.result.content.pop();
-      if (docStatus) {
-        result.permissions = docStatus.editable ? undefined : result.permissions | vscode.FilePermission.Readonly;
+      if (vscode.workspace.getConfiguration("objectscript.serverSourceControl", uri)?.get("respectEditableStatus")) {
+        const query = "select * from %Atelier_v1_Utils.Extension_GetStatus(?)";
+        const statusObj = await api.actionQuery(query, [serverName]);
+        const docStatus = statusObj.result.content.pop();
+        if (docStatus) {
+          result.permissions = docStatus.editable ? undefined : result.permissions | vscode.FilePermission.Readonly;
+        }
       }
     }
     return result;


### PR DESCRIPTION
This PR closes #1397

In some circumstances the current VS Code (1.91.1) doesn't correctly switch an editor to be readonly. My PR https://github.com/microsoft/vscode/pull/221023 will resolve this. Meanwhile I am creating this PR as a Draft.