### PR TITLE
Improvements to attach-type debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1719,7 +1719,12 @@
             "type": "objectscript",
             "request": "launch",
             "name": "XDebug"
-          }
+          },
+          {
+            "type": "objectscript",
+            "request": "attach",
+            "name": "Attach to running process"
+          }    
         ],
         "configurationSnippets": [
           {

--- a/src/debug/debugAdapterFactory.ts
+++ b/src/debug/debugAdapterFactory.ts
@@ -5,33 +5,41 @@ import { ObjectScriptDebugSession } from "./debugSession";
 export class ObjectScriptDebugAdapterDescriptorFactory
   implements vscode.DebugAdapterDescriptorFactory, vscode.Disposable
 {
-  private server?: net.Server;
+  private serverMap = new Map<string, net.Server>();
 
   public createDebugAdapterDescriptor(
     session: vscode.DebugSession,
     executable: vscode.DebugAdapterExecutable | undefined
   ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
-    if (!this.server) {
-      // start listening on a random port
-      const debugSession = new ObjectScriptDebugSession();
+    const debugSession = new ObjectScriptDebugSession();
 
-      this.server = net
+    // pickProcess may have added a suffix to inform us which folder's connection it used
+    const workspaceFolderIndex = (session.configuration.processId as string)?.split("@")[1];
+    const workspaceFolderUri = workspaceFolderIndex
+      ? vscode.workspace.workspaceFolders[parseInt(workspaceFolderIndex)]?.uri
+      : undefined;
+    debugSession.setupAPI(workspaceFolderUri);
+
+    const serverId = debugSession.serverId;
+    let server = this.serverMap.get(serverId);
+    if (!server) {
+      // start listening on a random port
+      server = net
         .createServer((socket) => {
           debugSession.setRunAsServer(true);
           debugSession.start(socket as NodeJS.ReadableStream, socket);
         })
         .listen(0);
+      this.serverMap.set(serverId, server);
     }
 
-    // make VS Code connect to debug server
-    const address = this.server.address();
+    // make VS Code connect to this debug server
+    const address = server.address();
     const port = typeof address !== "string" ? address.port : 9000;
     return new vscode.DebugAdapterServer(port);
   }
 
   public dispose(): void {
-    if (this.server) {
-      this.server.close();
-    }
+    this.serverMap.forEach((server) => server.close());
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1015,7 +1015,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           matchOnDescription: true,
         })
         .then((value) => {
-          if (value) return value.label;
+          if (value) {
+            const workspaceFolderIndex = vscode.workspace.workspaceFolders.findIndex(
+              (folder) => folder.uri.toString() === connectionUri.toString()
+            );
+            return workspaceFolderIndex < 0 ? value.label : `${value.label}@${workspaceFolderIndex}`;
+          }
         });
     }),
     vscode.commands.registerCommand("vscode-objectscript.jumpToTagAndOffset", jumpToTagAndOffset),


### PR DESCRIPTION
This PR implements some improvements to the type of debugging in which you attach to a running process on a server.

It adds an entry to "initialConfigurations" in package.json so users setting up debugging in a workspace or folder for the first time won't have to add an attach-type configuration manually.

It also makes attach-type debugging usable when no documents are open from the server. In this case, if the workspace is multi-root the user must select a folder before being offered the process picker.

In conjunction with the new "always pause the attached process" behaviour (#1415) this means it is no longer necessary to open a document from the target namespace before being able to attach and debug a running process.