### PR TITLE
Add CSPSHARE=1 to align add-in behaviour with Studio

### DIFF
--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -261,6 +261,7 @@ export async function serverActions(): Promise<void> {
                 params += `&Project=${encodeURIComponent(project)}`;
               }
               params += `&CSPCHD=${token}`;
+              params += "&CSPSHARE=1";
               vscode.env.openExternal(vscode.Uri.parse(`${serverUrl}${addin.id}?${params}`));
             }
           }


### PR DESCRIPTION
The Studio add-in that is integral to George James Software's Yuzinji tool misbehaves when invoked from VS Code.

This PR corrects the issue by adding CSPSHARE=1 to the URL with which an add-in is launched.

Based on commit https://github.com/intersystems-community/vscode-objectscript/pull/756/commits/f58416c6719b0f75bede71ed58240227bf8160f2 by @timleavitt which was part of PR #756 I think it's very likely Studio adds this parameter too, which would explain the problem which this PR fixes.