### PR TITLE
Solve 1.93 performance issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "istextorbinary": "^6.0.0",
         "minimatch": "^9.0.3",
         "node-cmd": "^5.0.0",
-        "node-fetch-cjs": "3.1.1",
+        "node-fetch-cjs": "^3.3.2",
         "vscode-cache": "^0.3.0",
         "vscode-extension-telemetry": "^0.1.6",
         "ws": "^8.14.2"
@@ -3746,9 +3746,10 @@
       }
     },
     "node_modules/node-fetch-cjs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.1.1.tgz",
-      "integrity": "sha512-YOMqQ94r/1o95JS3yFye1czAVY6i3xreA6tsNnloLCKJKbfFMxgkhsLH0yYI0vWXBZmEQ80l66ue6UqFAgVv2g==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.3.2.tgz",
+      "integrity": "sha512-JvvyTiDcLnHvPmbxj6uxj4LaamCfZLlzlRNBZp+H82ECMLz4OQjI9Jc6YjjjycipeMk1Aq4xo90ejEUMKJeTjw==",
+      "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -8134,9 +8135,9 @@
       "integrity": "sha512-4sQTJmsS5uZKAPz/Df9fnIbmvOySfGdW+UreH4X5NcAOOpKjaE+K5wf4ehNBbZVPo0vQ36RkRnhhsXXJAT+Syw=="
     },
     "node-fetch-cjs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.1.1.tgz",
-      "integrity": "sha512-YOMqQ94r/1o95JS3yFye1czAVY6i3xreA6tsNnloLCKJKbfFMxgkhsLH0yYI0vWXBZmEQ80l66ue6UqFAgVv2g=="
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch-cjs/-/node-fetch-cjs-3.3.2.tgz",
+      "integrity": "sha512-JvvyTiDcLnHvPmbxj6uxj4LaamCfZLlzlRNBZp+H82ECMLz4OQjI9Jc6YjjjycipeMk1Aq4xo90ejEUMKJeTjw=="
     },
     "node-releases": {
       "version": "2.0.18",

--- a/package.json
+++ b/package.json
@@ -1842,7 +1842,7 @@
     "istextorbinary": "^6.0.0",
     "minimatch": "^9.0.3",
     "node-cmd": "^5.0.0",
-    "node-fetch-cjs": "3.1.1",
+    "node-fetch-cjs": "^3.3.2",
     "vscode-cache": "^0.3.0",
     "@vscode/debugadapter": "^1.61.0",
     "@vscode/debugprotocol": "^1.61.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -306,6 +306,11 @@ export class AtelierAPI {
     const http = this._config.https ? httpsModule : httpModule;
     if (!this._agent) {
       this._agent = new http.Agent({
+        /* VS Code 1.93 adopted a version of vscode-proxy-agent that fixed a failure to pass-through the keepAlive option (see https://github.com/microsoft/vscode/issues/173861 and https://github.com/microsoft/vscode-proxy-agent/commit/4eddc930d4fbc6b88ca5557ea7af07d623d390d6)
+         * This caused poor performance on some operations by our extension (see https://github.com/intersystems-community/vscode-objectscript/issues/1428)
+         * Short term solution adopted by PR https://github.com/intersystems-community/vscode-objectscript/pull/1432 is not to enable keepAlive
+         * We should revisit this in the future - TODO
+         */
         //keepAlive: true,
         //maxSockets: 10,
         rejectUnauthorized: https && vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -306,8 +306,8 @@ export class AtelierAPI {
     const http = this._config.https ? httpsModule : httpModule;
     if (!this._agent) {
       this._agent = new http.Agent({
-        keepAlive: true,
-        maxSockets: 10,
+        //keepAlive: true,
+        //maxSockets: 10,
         rejectUnauthorized: https && vscode.workspace.getConfiguration("http").get("proxyStrictSSL"),
       });
     }


### PR DESCRIPTION
This PR fixes #1428

VS Code 1.93 adopted a version of vscode-proxy-agent that fixed a failure to pass-through the keepAlive option (see https://github.com/microsoft/vscode/issues/173861 and https://github.com/microsoft/vscode-proxy-agent/commit/4eddc930d4fbc6b88ca5557ea7af07d623d390d6).

This caused poor performance on some operations by our extension (see #1428 and others linked there).

Short term solution adopted by this PR is not to enable keepAlive. We should revisit this in the future.
