### PR TITLE
Try to fix CI failure caused by non-unique name (meta) passed to download-artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
           path: ${{ steps.set-version.outputs.name }}.vsix
       - uses: actions/upload-artifact@v4
         with:
-          name: meta
+          name: meta-build
           path: |
             .name
             .version
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: meta
+          name: meta-beta
           path: .
       - name: Set an output
         id: set-version
@@ -118,7 +118,7 @@ jobs:
           token: ${{ secrets.TOKEN }}
       - uses: actions/download-artifact@v4
         with:
-          name: meta
+          name: meta-publish
           path: .
       - name: Use Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -72,7 +72,7 @@ jobs:
           path: ${{ steps.set-version.outputs.name }}.vsix
       - uses: actions/upload-artifact@v4
         with:
-          name: meta
+          name: meta-build
           path: |
             .name
             .version
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: meta
+          name: meta-beta
           path: .
       - name: Set an output
         id: set-version
@@ -113,7 +113,7 @@ jobs:
           token: ${{ secrets.TOKEN }}
       - uses: actions/download-artifact@v4
         with:
-          name: meta
+          name: meta-publish
           path: .
       - name: Use Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
```
Unable to download artifact(s): Artifact not found for name: meta
        Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
        For more information, visit the GitHub Artifacts FAQ: https://github.com/actions/toolkit/blob/main/packages/artifact/docs/faq.md
```
See also https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact
