### PR TITLE
Add `Launch Lite Terminal` action to Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,6 +325,10 @@
           "when": "false"
         },
         {
+          "command": "vscode-objectscript.ObjectScriptExplorer.webterminal",
+          "when": "false"
+        },
+        {
           "command": "vscode-objectscript.importXMLFiles",
           "when": "vscode-objectscript.connectActive && workspaceFolderCount != 0"
         },
@@ -402,6 +406,11 @@
           "command": "vscode-objectscript.explorer.otherNamespaceClose",
           "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode.*:extra:/",
           "group": "inline@30"
+        },
+        {
+          "command": "vscode-objectscript.ObjectScriptExplorer.webterminal",
+          "when": "view == ObjectScriptExplorer && viewItem =~ /^serverNode/",
+          "group": "inline@25"
         },
         {
           "command": "vscode-objectscript.explorer.showGenerated",
@@ -1167,6 +1176,11 @@
       },
       {
         "command": "vscode-objectscript.intersystems-servermanager.webterminal",
+        "title": "Launch Lite Terminal",
+        "icon": "$(terminal)"
+      },
+      {
+        "command": "vscode-objectscript.ObjectScriptExplorer.webterminal",
         "title": "Launch Lite Terminal",
         "icon": "$(terminal)"
       },

--- a/src/commands/webSocketTerminal.ts
+++ b/src/commands/webSocketTerminal.ts
@@ -624,7 +624,10 @@ function terminalConfigForUri(
   }
 
   return {
-    name: api.config.serverName && api.config.serverName != "" ? api.config.serverName : "iris",
+    name:
+      api.config.serverName && api.config.serverName != ""
+        ? api.config.serverName
+        : `${api.config.host}:${api.config.port}${api.config.pathPrefix}`,
     location:
       // Mimic what a built-in profile does. When it is the default and the Terminal tab is selected while empty,
       // a terminal is always created in the Panel.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1422,6 +1422,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         launchWebSocketTerminal(targetUri);
       }
     ),
+    vscode.commands.registerCommand("vscode-objectscript.ObjectScriptExplorer.webterminal", (node: NodeBase) => {
+      const targetUri = DocumentContentProvider.getUri(
+        node.fullName,
+        node.workspaceFolder,
+        node.namespace,
+        undefined,
+        undefined,
+        true
+      );
+      launchWebSocketTerminal(targetUri);
+    }),
     vscode.window.registerTerminalProfileProvider(
       "vscode-objectscript.webSocketTerminal",
       new WebSocketTerminalProfileProvider()


### PR DESCRIPTION
This PR gives users of the client-side editing paradigm another way of launching a Lite Terminal.