### PR TITLE
Use more granular symbols for class members

### DIFF
--- a/src/providers/WorkspaceSymbolProvider.ts
+++ b/src/providers/WorkspaceSymbolProvider.ts
@@ -38,19 +38,27 @@ export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
     for (const element of data.result.content) {
       const kind: vscode.SymbolKind = (() => {
         switch (element.Type) {
-          case "Query":
           case "Method":
             return vscode.SymbolKind.Method;
+          case "Query":
+            return vscode.SymbolKind.Function;
+          case "Trigger":
+            return vscode.SymbolKind.Event;
           case "Parameter":
             return vscode.SymbolKind.Constant;
           case "Index":
+            return vscode.SymbolKind.Array;
+          case "ForeignKey":
             return vscode.SymbolKind.Key;
           case "XData":
-          case "Storage":
             return vscode.SymbolKind.Struct;
+          case "Storage":
+            return vscode.SymbolKind.Object;
+          case "Projection":
+            return vscode.SymbolKind.Interface;
           case "Class":
             return vscode.SymbolKind.Class;
-          default:
+          default: // Property and Relationship
             return vscode.SymbolKind.Property;
         }
       })();


### PR DESCRIPTION
This PR fixes #1441. When this PR is approved, I will make a corresponding Language Server commit.

Here's what the old symbols looked like:
<img width="255" alt="before" src="https://github.com/user-attachments/assets/9b89d707-5031-4c39-98b4-22915e9d2d38">

And here's the new ones:
<img width="254" alt="after" src="https://github.com/user-attachments/assets/a6114d37-6012-4d02-93e1-f9ddb2cdc8cf">
