### PR TITLE
Make Explorer Find widget work in 1.94 as long as proposed APIs are enabled (fix #1443)

### DIFF
--- a/src/providers/FileSystemProvider/FileSearchProvider.ts
+++ b/src/providers/FileSystemProvider/FileSearchProvider.ts
@@ -49,17 +49,13 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     // When this is called without a query.pattern, every file is supposed to be returned, so do not provide a filter
     let filter = "";
     if (pattern.length) {
-      let escapeClause = "";
       pattern = !csp ? pattern.replace(/\//g, ".") : pattern;
-      if (pattern.includes("_") || pattern.includes("%")) {
-        // Need to escape any % or _ characters
-        pattern = pattern.replace(/(_|%|\\)/g, "\\$1");
-        escapeClause = " ESCAPE '\\'";
-      }
-      // Change glob syntax to SQL LIKE syntax
-      pattern = pattern.replace(/\*/g, "%");
-      pattern = pattern.replace(/\?/g, "_");
-      filter = `Name LIKE '%${pattern}%'${escapeClause}`;
+      filter = `Name LIKE '%${pattern
+        // Escape % or _ characters
+        .replace(/(_|%|\\)/g, "\\$1")
+        // Change glob syntax to SQL LIKE syntax
+        .replace(/\*/g, "%")
+        .replace(/\?/g, "_")}%' ESCAPE '\\'`;
     }
     if (token.isCancellationRequested) {
       return;


### PR DESCRIPTION
This PR fixes #1443 which occurs on VS Code 1.94+

A separate issue is that the Explorer Find widget now depends on FileSearchProvider. I will raise this with the VS Code project.