### PR TITLE
Fix fuzzy match in Explorer tree Find on an ISFS folder in 1.94 (fix #1445)

### DIFF
--- a/src/providers/FileSystemProvider/FileSearchProvider.ts
+++ b/src/providers/FileSystemProvider/FileSearchProvider.ts
@@ -22,8 +22,8 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     // Drop a leading **/ from the glob pattern if it exists. This gets added by Find widget of Explorer tree (non-fuzzy mode), which since 1.94 uses FileSearchProvider
     if (pattern.startsWith("**/")) {
       pattern = pattern.slice(3);
-    } else if (pattern.length && !pattern.includes("*") && options.useGlobalIgnoreFiles) {
-      // Heuristic to detect a fuzzy search from Explorer's Find widget (see https://github.com/microsoft/vscode/issues/230483#issuecomment-2393928617)
+    } else if (pattern.length) {
+      // Do a fuzzy search
       pattern = "*" + pattern.split("").join("*") + "*";
     }
     const params = new URLSearchParams(options.folder.query);

--- a/src/providers/FileSystemProvider/FileSearchProvider.ts
+++ b/src/providers/FileSystemProvider/FileSearchProvider.ts
@@ -19,9 +19,12 @@ export class FileSearchProvider implements vscode.FileSearchProvider {
     let counter = 0;
     let pattern = query.pattern.charAt(0) == "/" ? query.pattern.slice(1) : query.pattern;
 
-    // Drop a leading **/ from the glob pattern if it exists (added by Find widget of Explorer tree, which since 1.94 uses FileSearchProvider)
+    // Drop a leading **/ from the glob pattern if it exists. This gets added by Find widget of Explorer tree (non-fuzzy mode), which since 1.94 uses FileSearchProvider
     if (pattern.startsWith("**/")) {
       pattern = pattern.slice(3);
+    } else if (pattern.length && !pattern.includes("*") && options.useGlobalIgnoreFiles) {
+      // Heuristic to detect a fuzzy search from Explorer's Find widget (see https://github.com/microsoft/vscode/issues/230483#issuecomment-2393928617)
+      pattern = "*" + pattern.split("").join("*") + "*";
     }
     const params = new URLSearchParams(options.folder.query);
     const csp = params.has("csp") && ["", "1"].includes(params.get("csp"));


### PR DESCRIPTION
This PR fixes #1445.

Still investigating some match failures, which may be caused by a VS Code bug. Hence PR is initially Draft.