### PR TITLE
Change some pickers from "workspace folders" to "server connections"

### DIFF
--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -247,7 +247,7 @@ export async function newFile(type: NewFileType): Promise<void> {
       wsFolder = vscode.workspace.workspaceFolders[0];
     } else {
       wsFolder = await vscode.window.showWorkspaceFolderPick({
-        placeHolder: "Pick the workspace folder to create the file in.",
+        placeHolder: "Pick the workspace folder where you want to create the file",
       });
     }
     if (!wsFolder) {

--- a/src/commands/webSocketTerminal.ts
+++ b/src/commands/webSocketTerminal.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import WebSocket = require("ws");
 
 import { AtelierAPI } from "../api";
-import { connectionTarget, currentFile, handleError, notIsfs, outputChannel } from "../utils";
+import { connectionTarget, currentFile, getWsServerConnection, handleError, notIsfs, outputChannel } from "../utils";
 import { config, iscIcon, resolveConnectionSpec } from "../extension";
 
 const keys = {
@@ -755,26 +755,6 @@ function terminalConfigForUri(
   };
 }
 
-async function workspaceUriForTerminal(throwErrors = false) {
-  let uri: vscode.Uri;
-  const workspaceFolders = vscode.workspace.workspaceFolders || [];
-  if (workspaceFolders.length == 0) {
-    reportError("Lite Terminal requires an open workspace.", throwErrors);
-  } else if (workspaceFolders.length == 1) {
-    // Use the current connection
-    uri = workspaceFolders[0].uri;
-  } else {
-    // Pick from the workspace folders
-    uri = (
-      await vscode.window.showWorkspaceFolderPick({
-        ignoreFocusOut: true,
-        placeHolder: "Pick the workspace folder to get server connection information from",
-      })
-    )?.uri;
-  }
-  return uri;
-}
-
 export async function launchWebSocketTerminal(targetUri?: vscode.Uri): Promise<void> {
   // Determine the server to connect to
   if (targetUri) {
@@ -784,10 +764,9 @@ export async function launchWebSocketTerminal(targetUri?: vscode.Uri): Promise<v
     const serverName = notIsfs(targetUri) ? config("conn", configName).server : configName;
     await resolveConnectionSpec(serverName);
   } else {
-    targetUri = currentFile()?.uri;
-    if (!targetUri) {
-      targetUri = await workspaceUriForTerminal();
-    }
+    // Determine the server connection to use
+    targetUri = currentFile()?.uri ?? (await getWsServerConnection("2023.2.0"));
+    if (!targetUri) return;
   }
   const api = new AtelierAPI(targetUri);
 
@@ -806,14 +785,16 @@ export async function launchWebSocketTerminal(targetUri?: vscode.Uri): Promise<v
 export class WebSocketTerminalProfileProvider implements vscode.TerminalProfileProvider {
   async provideTerminalProfile(): Promise<vscode.TerminalProfile> {
     // Determine the server connection to use
-    const uri: vscode.Uri = await workspaceUriForTerminal(true);
+    const uri: vscode.Uri = await getWsServerConnection("2023.2.0");
 
     if (uri) {
       // Get the terminal configuration. Will throw if there's an error.
       const terminalOpts = terminalConfigForUri(new AtelierAPI(uri), uri, true);
       return new vscode.TerminalProfile(terminalOpts);
     } else {
-      throw new Error("Lite Terminal requires a selected workspace folder.");
+      throw new Error(
+        "Lite Terminal requires an active server connection to InterSystems IRIS version 2023.2 or above."
+      );
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,6 +100,7 @@ import {
   handleError,
   cspApps,
   otherDocExts,
+  getWsServerConnection,
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentLinkProvider } from "./providers/DocumentLinkProvider";
@@ -996,31 +997,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       }
       if (!connectionUri) {
         // May need to ask the user
-        const workspaceFolders = vscode.workspace.workspaceFolders || [];
-        if (workspaceFolders.length == 0) {
-          vscode.window.showErrorMessage(`Attaching to a server process requires a workspace to be open.`, {
-            modal: true,
-          });
-          return;
-        }
-        if (workspaceFolders.length == 1) {
-          connectionUri = workspaceFolders[0].uri;
-        } else {
-          // Pick from the workspace folders
-          connectionUri = (
-            await vscode.window.showWorkspaceFolderPick({
-              ignoreFocusOut: true,
-              placeHolder: "Pick the workspace folder to get server connection information from",
-            })
-          )?.uri;
-        }
+        connectionUri = await getWsServerConnection();
       }
       if (!connectionUri) {
         return;
       }
       const api = new AtelierAPI(connectionUri);
       if (!api.active) {
-        vscode.window.showErrorMessage(`No active server connection.`, {
+        vscode.window.showErrorMessage(`Server connection is inactive.`, {
           modal: true,
         });
         return;
@@ -1489,7 +1473,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         wsFolder = workspaceFolders[0];
       } else if (workspaceFolders.length > 1) {
         // Pick from the workspace folders
-        wsFolder = await vscode.window.showWorkspaceFolderPick();
+        wsFolder = await vscode.window.showWorkspaceFolderPick({
+          placeHolder: "Pick the workspace folder where you want to open a document",
+        });
       }
       if (!wsFolder) return;
       const api = new AtelierAPI(wsFolder.uri);


### PR DESCRIPTION
This PR fixes #1461. I added a new utility method for picking a server connection from the current workspace. It de-duplicates connections and has optional minimum server version checking. I used it for Lite Terminal and picking a process to attach to for debugging.

<img width="616" alt="Screenshot 2025-01-23 at 9 12 22 AM" src="https://github.com/user-attachments/assets/26ae7a78-e8f8-4a09-a7c2-cd0fc9e18803" />
