### PR TITLE
Client-side improvements

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,7 @@ import {
   cspApps,
   otherDocExts,
   getWsServerConnection,
+  isClassOrRtn,
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentLinkProvider } from "./providers/DocumentLinkProvider";
@@ -1162,7 +1163,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       return Promise.all(
         e.files
           .filter(notIsfs)
-          .filter((uri) => ["cls", "inc", "int", "mac"].includes(uri.path.split(".").pop().toLowerCase()))
+          .filter(isClassOrRtn)
           .map(async (uri) => {
             // Determine the file name
             const workspace = workspaceFolderOfUri(uri);

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -5,7 +5,7 @@ import { AtelierAPI } from "../api";
 
 import { getFileName } from "../commands/export";
 import { config, FILESYSTEM_SCHEMA, FILESYSTEM_READONLY_SCHEMA, OBJECTSCRIPT_FILE_SCHEMA } from "../extension";
-import { currentWorkspaceFolder, notIsfs, uriOfWorkspaceFolder } from "../utils";
+import { currentWorkspaceFolder, isClassOrRtn, notIsfs, uriOfWorkspaceFolder } from "../utils";
 import { getUrisForDocument } from "../utils/documentIndex";
 
 export function compareConns(
@@ -52,7 +52,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     if (!notIsfs(wsFolder.uri)) return;
     const conf = vscode.workspace.getConfiguration("objectscript.export", wsFolder);
     const confFolder = conf.get("folder", "");
-    if (["cls", "mac", "int", "inc"].includes(name.split(".").pop().toLowerCase())) {
+    if (isClassOrRtn(name)) {
       // Use the document index to find the local URI
       const uris = getUrisForDocument(name, wsFolder);
       switch (uris.length) {


### PR DESCRIPTION
This PR addresses [feedback from a DC beta tester](https://community.intersystems.com/post/do-you-use-client-side-editing-vs-code-if-so-we-want-your-feedback#comment-279173).

- Limit concurrent file system reads on initial folder indexing to 250 to avoid `EMFILE` errors.
- Limit concurrent file update REST requests to 50 to avoid overloading the server.
- Always get the text of a document from the file system, even if VS Code has it loaded, to avoid concurrency issues when the file system updates before VS Code has updated its version.
- Avoid unneeded file system reads after export by updating the document index using the already known text of the file that was exported.
- New rate limiting utility code that is better documented