### PR TITLE
Support Server Manager being able to handle `objectscript.conn.docker-compose` type connections

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -488,21 +488,23 @@ async function composeCommand(cwd?: string): Promise<string> {
   });
 }
 
-export async function portFromDockerCompose(): Promise<{ port: number; docker: boolean; service?: string }> {
+export async function portFromDockerCompose(
+  workspaceFolderName?: string
+): Promise<{ port: number; docker: boolean; service?: string }> {
   // When running remotely, behave as if there is no docker-compose object within objectscript.conn
   if (extensionContext.extension.extensionKind === vscode.ExtensionKind.Workspace) {
     return { docker: false, port: null };
   }
 
   // Seek a valid docker-compose object within objectscript.conn
-  const { "docker-compose": dockerCompose = {} } = config("conn");
+  const { "docker-compose": dockerCompose = {} } = config("conn", workspaceFolderName);
   const { service, file = "docker-compose.yml", internalPort = 52773, envFile } = dockerCompose;
   if (!internalPort || !file || !service || service === "") {
     return { docker: false, port: null };
   }
 
   const result = { port: null, docker: true, service };
-  const workspaceFolder = uriOfWorkspaceFolder();
+  const workspaceFolder = uriOfWorkspaceFolder(workspaceFolderName);
   if (!workspaceFolder) {
     // No workspace folders are open
     return { docker: false, port: null };


### PR DESCRIPTION
This PR enables an incoming Server Manager enhancement to implement https://github.com/intersystems-community/intersystems-servermanager/issues/187

The VSIX built from this PR should work OK with Server Manager VSIXes that don't contain the relevant change, and vice versa. However the new features will only become available when both extensions have been updated.