### PR TITLE
Extend `objectscript.conn.docker-compose` settings object to handle superserver port identification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1289,7 +1289,11 @@
                   "type": "string"
                 },
                 "internalPort": {
-                  "description": "Target port inside the service in docker-compose.",
+                  "description": "Target webserver port inside the service in docker-compose.",
+                  "type": "number"
+                },
+                "internalSuperserverPort": {
+                  "description": "Target superserver port inside the service in docker-compose.",
                   "type": "number"
                 },
                 "file": {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -30,6 +30,7 @@ interface ConnectionSettings {
   https: boolean;
   host: string;
   port: number;
+  superserverPort?: number;
   pathPrefix: string;
   ns: string;
   username: string;
@@ -67,6 +68,9 @@ export class AtelierAPI {
     const wsKey = this.configName.toLowerCase();
     const host = this.externalServer ? this._config.host : workspaceState.get(wsKey + ":host", this._config.host);
     const port = this.externalServer ? this._config.port : workspaceState.get(wsKey + ":port", this._config.port);
+    const superserverPort = this.externalServer
+      ? this._config.superserverPort
+      : workspaceState.get(wsKey + ":superserverPort", this._config.superserverPort);
     const password = workspaceState.get(wsKey + ":password", this._config.password);
     const apiVersion = workspaceState.get(wsKey + ":apiVersion", DEFAULT_API_VERSION);
     const serverVersion = workspaceState.get(wsKey + ":serverVersion", DEFAULT_SERVER_VERSION);
@@ -80,6 +84,7 @@ export class AtelierAPI {
       https,
       host,
       port,
+      superserverPort,
       pathPrefix,
       ns,
       username,
@@ -211,6 +216,7 @@ export class AtelierAPI {
         webServer: { scheme, host, port, pathPrefix = "" },
         username,
         password,
+        superServer,
       } = getResolvedConnectionSpec(serverName, config("intersystems.servers", workspaceFolderName).get(serverName));
       this._config = {
         serverName,
@@ -221,6 +227,7 @@ export class AtelierAPI {
         ns,
         host,
         port,
+        superserverPort: superServer.port,
         username,
         password,
         pathPrefix,
@@ -241,6 +248,7 @@ export class AtelierAPI {
           webServer: { scheme, host, port, pathPrefix = "" },
           username,
           password,
+          superServer,
         } = resolvedSpec;
         this._config = {
           serverName: "",
@@ -251,6 +259,7 @@ export class AtelierAPI {
           ns,
           host,
           port,
+          superserverPort: superServer.port,
           username,
           password,
           pathPrefix,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -340,7 +340,7 @@ export async function checkConnection(
     _onDidChangeConnection.fire();
   }
   let api = new AtelierAPI(apiTarget, false);
-  const { active, host = "", port = 0, username, ns = "" } = api.config;
+  const { active, host = "", port = 0, superserverPort = 0, username, ns = "" } = api.config;
   vscode.commands.executeCommand("setContext", "vscode-objectscript.connectActive", active);
   if (!panel.text) {
     panel.text = `${PANEL_LABEL}`;
@@ -384,6 +384,8 @@ export async function checkConnection(
         if (dockerPort !== port) {
           workspaceState.update(wsKey + ":host", "localhost");
           workspaceState.update(wsKey + ":port", dockerPort);
+        }
+        if (dockerSuperserverPort !== superserverPort) {
           workspaceState.update(wsKey + ":superserverPort", dockerSuperserverPort);
         }
         connInfo = `localhost:${dockerPort}[${ns}]`;


### PR DESCRIPTION
This PR closes #1243

It will make the recently added `asyncServerForUri` API function resolve a Docker container connection's local superserver port into `server.superserverPort`, allowing future development in other extensions such as Server Manager to identify the superserver port of container-type connections as well as for ordinary ones.