### PR TITLE
Remove dependency on Server Manager extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "onLanguage:objectscript-class",
     "onLanguage:objectscript-macros",
     "onLanguage:xml",
-    "onView:intersystems-community_servermanager",
+    "onView:intersystems-community",
     "onFileSystem:isfs",
     "onFileSystem:isfs-readonly",
     "onFileSystem:objectscript",
@@ -1614,7 +1614,7 @@
       }
     },
     "views": {
-      "intersystems-community_servermanager": [
+      "intersystems-community": [
         {
           "id": "ObjectScriptExplorer",
           "name": "Explorer",
@@ -1822,6 +1822,6 @@
     "ws": "^8.18.0"
   },
   "extensionDependencies": [
-    "intersystems-community.servermanager"
+    "intersystems-community.viewcontainer"
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -752,10 +752,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   extensionContext = context;
   workspaceState.update("workspaceFolder", undefined);
 
-  // Get api for servermanager extension
+  // Get api for servermanager extension if it is installed
   const smExt = vscode.extensions.getExtension(smExtensionId);
-  if (!smExt.isActive) await smExt.activate();
-  serverManagerApi = smExt.exports;
+  if (smExt && !smExt.isActive) {
+    await smExt.activate();
+    serverManagerApi = smExt.exports;
+  }
 
   documentContentProvider = new DocumentContentProvider();
   fileSystemProvider = new FileSystemProvider();


### PR DESCRIPTION
This PR fixes #1491 by relocating the InterSystems view container out of Server Manager (see https://github.com/intersystems-community/intersystems-servermanager/pull/257)  into a standalone stub extension (see https://github.com/intersystems-community/vscode-intersystems-viewcontainer). That extension becomes a dependency of this one, so it must be published before this PR is merged.

