### PR TITLE
Input UI normalization

### DIFF
--- a/src/commands/addServerNamespaceToWorkspace.ts
+++ b/src/commands/addServerNamespaceToWorkspace.ts
@@ -73,7 +73,7 @@ async function pickNamespaceOnServer(serverName: string): Promise<string> {
   }
   // Get user's choice of namespace
   const namespace = await vscode.window.showQuickPick(allNamespaces, {
-    placeHolder: `Namespace on server '${serverName}' (${connDisplayString})`,
+    title: `Pick a namespace on server '${serverName}' (${connDisplayString})`,
     ignoreFocusOut: true,
   });
   return namespace;
@@ -133,7 +133,7 @@ export async function addServerNamespaceToWorkspace(resource?: vscode.Uri): Prom
             detail: "Documents opened in this folder will be read-only.",
           },
         ],
-        { placeHolder: "Choose the type of access", ignoreFocusOut: true }
+        { title: "Pick the type of access", ignoreFocusOut: true }
       )
       .then((mode) => mode?.value);
   }
@@ -194,7 +194,7 @@ async function modifyWsFolderUri(uri: vscode.Uri): Promise<vscode.Uri | undefine
   const filterType = await new Promise<string | undefined>((resolve) => {
     let result: string;
     const quickPick = vscode.window.createQuickPick();
-    quickPick.placeholder = "Choose what to show in the workspace folder";
+    quickPick.title = "Pick what to show in the workspace folder";
     quickPick.ignoreFocusOut = true;
     quickPick.items = [
       {
@@ -203,11 +203,11 @@ async function modifyWsFolderUri(uri: vscode.Uri): Promise<vscode.Uri | undefine
       },
       {
         label: "$(file-code) Web Application Files",
-        detail: "Choose a specific web application, or show all.",
+        detail: "Pick a specific web application, or show all.",
       },
       {
         label: "$(files) Contents of a Server-side Project",
-        detail: "Choose an existing project, or create a new one.",
+        detail: "Pick an existing project, or create a new one.",
       },
     ];
     quickPick.activeItems = [project ? quickPick.items[2] : csp ? quickPick.items[1] : quickPick.items[0]];
@@ -263,7 +263,7 @@ async function modifyWsFolderUri(uri: vscode.Uri): Promise<vscode.Uri | undefine
       let result: string;
       const allItem: vscode.QuickPickItem = { label: "All" };
       const quickPick = vscode.window.createQuickPick();
-      quickPick.placeholder = "Pick a specific web application to show, or show all";
+      quickPick.title = "Pick a specific web application to show, or show all";
       quickPick.ignoreFocusOut = true;
       quickPick.items = [
         allItem,
@@ -331,7 +331,7 @@ async function modifyWsFolderUri(uri: vscode.Uri): Promise<vscode.Uri | undefine
     const otherParams = await vscode.window.showQuickPick(items, {
       ignoreFocusOut: true,
       canPickMany: true,
-      placeHolder: "Add optional filters",
+      title: "Pick optional filters",
     });
     if (!otherParams) {
       return;

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -748,21 +748,23 @@ export async function importXMLFiles(): Promise<any> {
   try {
     // Use the server connection from a workspace folder
     const wsFolder = await getWsFolder(
-      "Pick a workspace folder. Server-side folders import from the local file system."
+      "Pick a workspace folder. Server-side folders import from the local file system.",
+      false,
+      false,
+      false,
+      true
     );
     if (!wsFolder) {
       if (wsFolder === undefined) {
         // Strict equality needed because undefined == null
-        vscode.window.showErrorMessage("'Import XML Files...' command requires an open workspace.", "Dismiss");
+        vscode.window.showErrorMessage(
+          "'Import XML Files...' command requires a workspace folder with an active server connection.",
+          "Dismiss"
+        );
       }
       return;
     }
     const api = new AtelierAPI(wsFolder.uri);
-    // Make sure the server connection is active
-    if (!api.active || api.ns == "") {
-      vscode.window.showErrorMessage("'Import XML Files...' command requires an active server connection.", "Dismiss");
-      return;
-    }
     // Make sure the server has the xml endpoints
     if (api.config.apiVersion < 7) {
       vscode.window.showErrorMessage(

--- a/src/commands/connectFolderToServerNamespace.ts
+++ b/src/commands/connectFolderToServerNamespace.ts
@@ -37,7 +37,7 @@ export async function connectFolderToServerNamespace(): Promise<void> {
   const pick =
     items.length === 1 && !items[0].detail
       ? items[0]
-      : await vscode.window.showQuickPick(items, { placeHolder: "Choose folder" });
+      : await vscode.window.showQuickPick(items, { title: "Pick a folder" });
   const folder = allFolders.find((el) => el.name === pick.label);
   // Get user's choice of server
   const options: vscode.QuickPickOptions = {};
@@ -78,7 +78,7 @@ export async function connectFolderToServerNamespace(): Promise<void> {
   }
   // Get user's choice of namespace
   const namespace = await vscode.window.showQuickPick(allNamespaces, {
-    placeHolder: `Namespace on server '${serverName}' (${connDisplayString})`,
+    title: `Pick a namespace on server '${serverName}' (${connDisplayString})`,
   });
   if (!namespace) {
     return;

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -292,26 +292,24 @@ export async function exportCurrentFile(): Promise<any> {
 export async function exportDocumentsToXMLFile(): Promise<void> {
   try {
     // Use the server connection from a workspace folder
-    const wsFolder = await getWsFolder("Pick a workspace folder. Server-side folders export to the local file system.");
+    const wsFolder = await getWsFolder(
+      "Pick a workspace folder. Server-side folders export to the local file system.",
+      false,
+      false,
+      false,
+      true
+    );
     if (!wsFolder) {
       if (wsFolder === undefined) {
         // Strict equality needed because undefined == null
         vscode.window.showErrorMessage(
-          "'Export Documents to XML File...' command requires an open workspace.",
+          "'Export Documents to XML File...' command requires a workspace folder with an active server connection.",
           "Dismiss"
         );
       }
       return;
     }
     const api = new AtelierAPI(wsFolder.uri);
-    // Make sure the server connection is active
-    if (!api.active || api.ns == "") {
-      vscode.window.showErrorMessage(
-        "'Export Documents to XML File...' command requires an active server connection.",
-        "Dismiss"
-      );
-      return;
-    }
     // Make sure the server has the xml endpoints
     if (api.config.apiVersion < 7) {
       vscode.window.showErrorMessage(

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -165,7 +165,7 @@ export async function exportAll(): Promise<any> {
     .map((el) => el.name);
   if (workspaceList.length > 1) {
     const selection = await vscode.window.showQuickPick(workspaceList, {
-      placeHolder: "Select the workspace folder to export files to.",
+      title: "Pick the workspace folder to export files to.",
     });
     if (selection === undefined) {
       return;

--- a/src/commands/jumpToTagAndOffset.ts
+++ b/src/commands/jumpToTagAndOffset.ts
@@ -66,7 +66,6 @@ export async function openErrorLocation(): Promise<void> {
   const regex = /^(%?[\p{L}\d]+)?(?:\+(\d+))?\^(%?[\p{L}\d.]+)$/u;
   const location = await vscode.window.showInputBox({
     title: "Enter the location to open",
-    ignoreFocusOut: true,
     placeHolder: "label+offset^routine",
     validateInput: (v) => (regex.test(v.trim()) ? undefined : "Input is not in the format 'label+offset^routine'"),
   });

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -26,7 +26,7 @@ export async function pickProject(api: AtelierAPI): Promise<string | undefined> 
   if (projects.length === 0) {
     const create = await vscode.window.showQuickPick(["Yes", "No"], {
       ignoreFocusOut: true,
-      placeHolder: `Namespace ${ns} on server '${api.serverId}' contains no projects. Create one?`,
+      title: `Namespace ${ns} on server '${api.serverId}' contains no projects. Create one?`,
     });
     if (create == "Yes") {
       return createProject(undefined, api);
@@ -839,7 +839,7 @@ export async function modifyProject(
           {
             ignoreFocusOut: true,
             canPickMany: true,
-            placeHolder: `Select the items to remove from project '${project}'.`,
+            title: `Pick the items to remove from project '${project}'.`,
           }
         );
         if (removeQPIs !== undefined) {
@@ -942,7 +942,7 @@ export async function exportProjectContents(node: ProjectNode | undefined): Prom
       .map((el) => el.name);
     if (workspaceList.length > 1) {
       const selection = await vscode.window.showQuickPick(workspaceList, {
-        placeHolder: "Select the workspace folder to export files to.",
+        title: "Pick the workspace folder to export files to.",
       });
       if (selection === undefined) {
         return;

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -25,7 +25,6 @@ export async function pickProject(api: AtelierAPI): Promise<string | undefined> 
     );
   if (projects.length === 0) {
     const create = await vscode.window.showQuickPick(["Yes", "No"], {
-      ignoreFocusOut: true,
       title: `Namespace ${ns} on server '${api.serverId}' contains no projects. Create one?`,
     });
     if (create == "Yes") {
@@ -38,7 +37,6 @@ export async function pickProject(api: AtelierAPI): Promise<string | undefined> 
     let resolveOnHide = true;
     const quickPick = vscode.window.createQuickPick();
     quickPick.title = `Select a project in namespace ${ns} on server '${api.serverId}', or click '+' to add one.`;
-    quickPick.ignoreFocusOut = true;
     quickPick.items = projects;
     quickPick.buttons = [{ iconPath: new vscode.ThemeIcon("add"), tooltip: "Create new project" }];
 
@@ -837,7 +835,6 @@ export async function modifyProject(
             };
           }),
           {
-            ignoreFocusOut: true,
             canPickMany: true,
             title: `Pick the items to remove from project '${project}'.`,
           }

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -102,7 +102,7 @@ export async function serverActions(): Promise<void> {
         }
 
         const namespace = await vscode.window.showQuickPick(allNamespaces, {
-          placeHolder: `Choose the namespace to switch to`,
+          title: "Pick the namespace to switch to",
           ignoreFocusOut: true,
         });
 
@@ -215,7 +215,7 @@ export async function serverActions(): Promise<void> {
   }
   return vscode.window
     .showQuickPick(actions, {
-      placeHolder: `Pick action to perform for server ${connInfo}`,
+      title: `Pick action to perform for server ${connInfo}`,
     })
     .then(connectionActionsHandler)
     .then(async (action) => {
@@ -244,7 +244,7 @@ export async function serverActions(): Promise<void> {
             });
           if (addins != undefined) {
             const addin = await vscode.window.showQuickPick(addins, {
-              placeHolder: `Pick a Studio Add-In to open for server: ${connInfo}`,
+              title: `Pick a Studio Add-In to open for server: ${connInfo}`,
             });
             if (addin) {
               const token = await getCSPToken(api, addin.id);

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -103,7 +103,6 @@ export async function serverActions(): Promise<void> {
 
         const namespace = await vscode.window.showQuickPick(allNamespaces, {
           title: "Pick the namespace to switch to",
-          ignoreFocusOut: true,
         });
 
         if (namespace) {

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -438,7 +438,7 @@ export class StudioActions {
         }
         return vscode.window.showQuickPick<StudioAction>(menuItems, {
           canPickMany: false,
-          placeHolder: `Pick a server-side ${noun} to execute${suffix}`,
+          title: `Pick a server-side ${noun} to execute${suffix}`,
         });
       })
       .then((action) => this.userAction(action));

--- a/src/commands/subclass.ts
+++ b/src/commands/subclass.ts
@@ -30,7 +30,7 @@ export async function subclass(): Promise<void> {
       vscode.window
         .showQuickPick(
           list.map((el) => el.Name),
-          { placeHolder: "Pick a subclass" }
+          { title: "Pick a subclass" }
         )
         .then((item) => {
           open(item);

--- a/src/commands/superclass.ts
+++ b/src/commands/superclass.ts
@@ -23,7 +23,7 @@ export async function superclass(): Promise<void> {
       if (!list.length) {
         return;
       }
-      vscode.window.showQuickPick(list, { placeHolder: "Pick a superclass" }).then((item) => {
+      vscode.window.showQuickPick(list, { title: "Pick a superclass" }).then((item) => {
         open(item);
       });
     })

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -402,7 +402,6 @@ async function runHandler(
         }),
         {
           matchOnDetail: true,
-          ignoreFocusOut: true,
           title: `Cannot ${action} tests from multiple roots at once`,
           placeHolder: `Pick a root to ${action} tests from`,
         }

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -404,7 +404,7 @@ async function runHandler(
           matchOnDetail: true,
           ignoreFocusOut: true,
           title: `Cannot ${action} tests from multiple roots at once`,
-          placeHolder: `Please select a root to ${action} tests from`,
+          placeHolder: `Pick a root to ${action} tests from`,
         }
       );
       if (picked) {

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -115,7 +115,7 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
             }),
             {
               ignoreFocusOut: true,
-              placeHolder: "Pick the workspace folder to run the command in",
+              title: "Pick the workspace folder to run the command in",
             }
           )
         )?.wf;
@@ -170,7 +170,7 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
       {
         canPickMany: true,
         ignoreFocusOut: true,
-        title: "Select the documents to extract",
+        title: "Pick the documents to extract",
         placeHolder: "Files are created using your 'objectscript.export' settings",
       }
     );

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import path = require("path");
 import { config, OBJECTSCRIPTXML_FILE_SCHEMA, xmlContentProvider } from "../extension";
 import { AtelierAPI } from "../api";
-import { fileExists, handleError, notIsfs, outputChannel } from "../utils";
+import { fileExists, getWsFolder, handleError, notIsfs, outputChannel } from "../utils";
 import { getFileName } from "./export";
 
 const exportHeader = /^\s*<Export generator="(Cache|IRIS)" version="\d+"/;
@@ -33,7 +33,6 @@ export async function previewXMLAsUDL(textEditor: vscode.TextEditor, auto = fals
           }),
           {
             canPickMany: true,
-            ignoreFocusOut: true,
             title: "Select the documents to preview",
           }
         );
@@ -96,29 +95,17 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
     if (xmlUri) {
       wsFolder = vscode.workspace.getWorkspaceFolder(xmlUri);
     } else {
-      // Can only run this command on non-isfs folders with an active server connection
-      const options = vscode.workspace.workspaceFolders.filter((f) => notIsfs(f.uri) && new AtelierAPI(f.uri).active);
-      if (options.length == 0) {
-        vscode.window.showErrorMessage(
-          "'Extract Documents from XML File...' command requires a non-isfs workspace folder with an active server connection.",
-          "Dismiss"
-        );
+      // Use the server connection from a workspace folder
+      wsFolder = await getWsFolder("Pick the workspace folder to run the command in", false, false, true, true);
+      if (!wsFolder) {
+        if (wsFolder === undefined) {
+          // Strict equality needed because undefined == null
+          vscode.window.showErrorMessage(
+            "'Extract Documents from XML File...' command requires a non-isfs workspace folder with an active server connection.",
+            "Dismiss"
+          );
+        }
         return;
-      } else if (options.length == 1) {
-        wsFolder = options[0];
-      } else {
-        // Prompt the user to select a workspace folder
-        wsFolder = (
-          await vscode.window.showQuickPick(
-            options.map((f) => {
-              return { label: f.name, wf: f };
-            }),
-            {
-              ignoreFocusOut: true,
-              title: "Pick the workspace folder to run the command in",
-            }
-          )
-        )?.wf;
       }
     }
     if (!wsFolder) return;

--- a/src/explorer/explorer.ts
+++ b/src/explorer/explorer.ts
@@ -155,7 +155,7 @@ export class ObjectScriptExplorerProvider implements vscode.TreeDataProvider<Nod
       .then((data) => data.map((ns) => ({ label: ns })))
       .then((data) =>
         vscode.window.showQuickPick(data, {
-          placeHolder: `Choose a namespace on ${api.config.host}:${api.config.port} to add to the Explorer`,
+          title: `Pick a namespace on ${api.config.host}:${api.config.port} to add to the Explorer`,
         })
       )
       .then((ns) => this.showExtra4Workspace(workspaceFolder, ns.label))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -521,7 +521,7 @@ export async function checkConnection(
             vscode.window
               .showInputBox({
                 password: true,
-                placeHolder: `Not Authorized. Enter password to connect as user '${username}' to ${connInfo}`,
+                title: `Not Authorized. Enter password to connect as user '${username}' to ${connInfo}`,
                 prompt: !api.externalServer ? "If no password is entered the connection will be disabled." : "",
                 ignoreFocusOut: true,
               })
@@ -1052,7 +1052,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       }
       return vscode.window
         .showInputBox({
-          placeHolder: "Please enter comma delimited arguments list",
+          title: "Enter comma delimited arguments list",
         })
         .then((args) => {
           if (args != undefined && args != null) {
@@ -1122,7 +1122,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       }
       return vscode.window
         .showQuickPick<vscode.QuickPickItem>(list, {
-          placeHolder: `Pick the process to attach to in ${api.ns} on '${api.serverId}'`,
+          title: `Pick the process to attach to in ${api.ns} on '${api.serverId}'`,
           matchOnDescription: true,
         })
         .then((value) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1541,11 +1541,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     ),
     vscode.commands.registerCommand("vscode-objectscript.compileIsfs", (uri) => fileSystemProvider.compile(uri)),
     vscode.commands.registerCommand("vscode-objectscript.openISCDocument", async () => {
-      const wsFolder = await getWsFolder("Pick the workspace folder where you want to open a document");
+      const wsFolder = await getWsFolder(
+        "Pick the workspace folder where you want to open a document",
+        false,
+        false,
+        false,
+        true
+      );
       if (!wsFolder) {
         if (wsFolder === undefined) {
           // Strict equality needed because undefined == null
-          vscode.window.showErrorMessage("No workspace folders are open.", "Dismiss");
+          vscode.window.showErrorMessage("No workspace folders with an active server connection are open.", "Dismiss");
         }
         return;
       }


### PR DESCRIPTION
* Use `title` instead of `placeHolder` for inputs that only have one prompt
* Normalize language

I deliberately didn't do anything about `ignoreFocusOut` because I wanted to get your feedback first. Should we remove this from our extensions so there's always a mouse option to dismiss an input? Once this PR is merged I will make similar changes to the other two extensions.