### PR TITLE
Implement `Show Plan` CodeLens

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,10 +3,11 @@
 **
 !dist/*.js
 !dist/*.txt
-!snippets/
-!images/
-!syntaxes/
-!webview/
+!snippets/*.json
+!images/*.svg
+!images/*.png
+!syntaxes/*.json
+!webview/*.js
 !CHANGELOG.md
 !LICENSE
 !README.md

--- a/src/commands/restDebugPanel.ts
+++ b/src/commands/restDebugPanel.ts
@@ -346,7 +346,7 @@ export class RESTDebugPanel {
                   headers["content-type"] = "text/plain; charset=utf-8";
                   break;
                 case "HTML":
-                  headers["content-yype"] = "text/html; charset=utf-8";
+                  headers["content-type"] = "text/html; charset=utf-8";
                   break;
               }
             }

--- a/src/commands/showPlanPanel.ts
+++ b/src/commands/showPlanPanel.ts
@@ -27,12 +27,12 @@ function formatTextBlock(text: string): string {
     // for those sections to help users visually draw the link between them
     if (lineTrim.includes(" module ") || lineTrim.includes("subquery ") || lineTrim.includes("subqueries ")) {
       lineTrim = lineTrim
-        .replace(/(Call|in) (module [A-Z]|\d+)/g, '$1 <span class="module">$2</span>')
-        .replace(/subquery [A-Z]|\d+/g, '<span class="subquery">$&</span>')
-        .replace(/subqueries (?:[A-Z]|\d+)(?:, [A-Z]|\d+)*,? and [A-Z]|\d+/g, (match: string): string =>
+        .replace(/(Call|in) (module [A-Z]|\d{1,5})/g, '$1 <span class="module">$2</span>')
+        .replace(/subquery [A-Z]|\d{1,5}/g, '<span class="subquery">$&</span>')
+        .replace(/subqueries (?:[A-Z]|\d{1,5})(?:, [A-Z]|\d{1,5})*,? and [A-Z]|\d{1,5}/g, (match: string): string =>
           match
-            .replace(/subqueries [A-Z]|\d+/, '<span class="subquery">$&</span>')
-            .replace(/(,|and) ([A-Z]|\d+)/g, '$1 <span class="subquery">$2</span>')
+            .replace(/subqueries [A-Z]|\d{1,5}/, '<span class="subquery">$&</span>')
+            .replace(/(,|and) ([A-Z]|\d{1,5})/g, '$1 <span class="subquery">$2</span>')
         );
     }
     const indent = line.search(/\S/) - 1;

--- a/src/commands/showPlanPanel.ts
+++ b/src/commands/showPlanPanel.ts
@@ -1,0 +1,261 @@
+import * as vscode from "vscode";
+import { DOMParser } from "@xmldom/xmldom";
+import { lt } from "semver";
+import { AtelierAPI } from "../api";
+import { handleError } from "../utils";
+import { iscIcon } from "../extension";
+
+const viewType = "isc-show-plan";
+const viewTitle = "Show Plan";
+
+let panel: vscode.WebviewPanel;
+
+/** Escape any HTML characters so they are rendered literally */
+function htmlEncode(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+/** Convert a block of text (for example, the plan) to HTML */
+function formatTextBlock(text: string): string {
+  let newText = "<p>\n";
+  let prevIndent = 0;
+  let ulLevel = 0;
+  for (const line of text.split(/\r?\n/)) {
+    let lineTrim = htmlEncode(line.trim());
+    if (!lineTrim.length) continue; // Line is only whitespace
+    // Render references to modules or subqueries in the same color as the headers
+    // for those sections to help users visually draw the link between them
+    if (lineTrim.includes(" module ") || lineTrim.includes("subquery ") || lineTrim.includes("subqueries ")) {
+      lineTrim = lineTrim
+        .replace(/(Call|in) (module [A-Z]|\d+)/g, '$1 <span class="module">$2</span>')
+        .replace(/subquery [A-Z]|\d+/g, '<span class="subquery">$&</span>')
+        .replace(/subqueries (?:[A-Z]|\d+)(?:, [A-Z]|\d+)*,? and [A-Z]|\d+/g, (match: string): string =>
+          match
+            .replace(/subqueries [A-Z]|\d+/, '<span class="subquery">$&</span>')
+            .replace(/(,|and) ([A-Z]|\d+)/g, '$1 <span class="subquery">$2</span>')
+        );
+    }
+    const indent = line.search(/\S/) - 1;
+    if (indent == 0) {
+      const oldUlLevel = ulLevel;
+      while (ulLevel) {
+        newText += "</ul>\n";
+        if (ulLevel > 1) newText += "</li>\n";
+        ulLevel--;
+      }
+      if (oldUlLevel) newText += "</p>\n<p>\n";
+      newText += `${lineTrim}<br/>\n`;
+    } else {
+      if (indent > prevIndent) {
+        if (ulLevel) {
+          newText = `${newText.slice(0, -6)}\n<ul>\n`;
+        } else {
+          newText += "<ul>\n";
+        }
+        ulLevel++;
+      } else if (indent < prevIndent) {
+        newText += `</ul>\n</li>\n`;
+      }
+      newText += `<li>${lineTrim}</li>\n`;
+    }
+    prevIndent = indent;
+  }
+  while (ulLevel) {
+    newText += "</ul>\n";
+    if (ulLevel > 1) newText += "</li>\n";
+    ulLevel--;
+  }
+  return `${newText}</p>\n`;
+}
+
+/** Create a `Show Plan` Webview, or replace the contents of the one that already exists */
+export async function showPlanWebview(args: {
+  uri: vscode.Uri;
+  sqlQuery: string;
+  selectMode: string;
+  includes: string[];
+  imports: string[];
+  className?: string;
+}): Promise<void> {
+  const api = new AtelierAPI(args.uri);
+  if (!api.active) {
+    vscode.window.showErrorMessage("Show Plan requires an active server connection.", "Dismiss");
+    return;
+  }
+  if (lt(api.config.serverVersion, "2024.1.0")) {
+    vscode.window.showErrorMessage("Show Plan requires InterSystems IRIS version 2024.1 or above.", "Dismiss");
+    return;
+  }
+  if (args.className) {
+    // Query %Dictionary.CompiledClass for a list of all Includes and Imports
+    await api
+      .actionQuery(
+        "SELECT $LISTTOSTRING(Importall) AS Imports, $LISTTOSTRING(IncludeCodeall) AS Includes FROM %Dictionary.CompiledClass WHERE Name = ?",
+        [args.className]
+      )
+      .then((data) => {
+        if (!data?.result?.content?.length) return;
+        const row = data.result.content.pop();
+        if (row.Imports) {
+          args.imports.push(...row.Imports.replace(/[^\x20-\x7E]/g, "").split(","));
+        }
+        if (row.Includes) {
+          args.includes.push(...row.Includes.replace(/[^\x20-\x7E]/g, "").split(","));
+        }
+      })
+      .catch(() => {
+        // Swallow errors and try with the info that was in the document
+      });
+  }
+  // Get the plan in XML format
+  const planXML: string = await api
+    .actionQuery("SELECT %SYSTEM.QUERY_PLAN(?,,,,,?) XML", [
+      args.sqlQuery.trimEnd(),
+      `{"selectmode":"${args.selectMode}"${args.imports.length ? `,"packages":"$LFS(\\"${[...new Set(args.imports)].join(",")}\\")"` : ""}${args.includes.length ? `,"includeFiles":"$LFS(\\"${[...new Set(args.includes)].join(",")}\\")"` : ""}}`,
+    ])
+    .then((data) => data?.result?.content[0]?.XML)
+    .catch((error) => {
+      handleError(error, "Failed to fetch query plan.");
+    });
+  if (!planXML) return;
+  // Convert the XML into HTML
+  let planHTML = "";
+  try {
+    // Parse the XML into a Document object
+    const xmlDoc = new DOMParser().parseFromString(planXML, "text/xml");
+    // Get the single <plan> Element, which contains everything else
+    const planElem = xmlDoc.getElementsByTagName("plan").item(0);
+
+    // Loop through the child elements of the plan
+    let capturePlan = false;
+    let planText = "";
+    let planChild = <Element>planElem.firstChild;
+    while (planChild) {
+      switch (planChild.nodeName) {
+        case "sql":
+          planHTML += '<h3>Statement Text</h3>\n<div class="code-block">\n';
+          for (const line of planChild.textContent.trim().split(/\r?\n/)) {
+            planHTML += `${htmlEncode(line.trim())}\n`;
+          }
+          planHTML += `</div>\n<hr class="vscode-divider">\n`;
+          break;
+        case "warning":
+          planHTML += `<h3 class="warning-h">Warning</h3>\n<p>\n${formatTextBlock(planChild.textContent)}</p>\n<hr class="vscode-divider">\n`;
+          break;
+        case "info":
+          planHTML += `<h3 class="info-h">Information</h3>\n${formatTextBlock(planChild.textContent)}<hr class="vscode-divider">\n`;
+          break;
+        case "cost":
+          planHTML += `<h4>Relative Cost `;
+          // The plan might not have a cost
+          planHTML +=
+            planChild.attributes.length &&
+            planChild.attributes.item(0).nodeName == "value" &&
+            +planChild.attributes.item(0).value
+              ? `= ${planChild.attributes.item(0).value}`
+              : "Unavailable";
+          planHTML += "</h4>\n";
+          capturePlan = true;
+          break;
+        case "#text":
+          if (capturePlan) {
+            planText += planChild.textContent;
+            if (!planChild.nextSibling || planChild.nextSibling.nodeName != "#text") {
+              // This is the end of the plan text, so convert the text to HTML
+              planHTML += `${formatTextBlock(planText)}<hr class="vscode-divider">\n`;
+              capturePlan = false;
+            }
+          }
+          break;
+        case "module": {
+          let moduleText = "";
+          let moduleChild = planChild.firstChild;
+          while (moduleChild) {
+            moduleText += moduleChild.textContent;
+            moduleChild = moduleChild.nextSibling;
+          }
+          planHTML += `<h3 class="module">Module ${planChild.attributes.item(0).value}</h3>\n${formatTextBlock(moduleText)}<hr class="vscode-divider">\n`;
+          break;
+        }
+        case "subquery": {
+          let subqueryText = "";
+          let subqueryChild = planChild.firstChild;
+          while (subqueryChild) {
+            subqueryText += subqueryChild.textContent;
+            subqueryChild = subqueryChild.nextSibling;
+          }
+          planHTML += `<h3 class="subquery">Subquery ${planChild.attributes.item(0).value}</h3>\n${formatTextBlock(subqueryText)}<hr class="vscode-divider">\n`;
+          break;
+        }
+      }
+      planChild = <Element>planChild.nextSibling;
+    }
+    // Remove the last divider
+    planHTML = planHTML.slice(0, -28);
+  } catch (error) {
+    handleError(error, "Failed to convert query plan to HTML.");
+    return;
+  }
+
+  // If a ShowPlan panel exists, replace the content instead of the panel
+  if (!panel) {
+    // Create the webview panel
+    panel = vscode.window.createWebviewPanel(
+      viewType,
+      viewTitle,
+      { preserveFocus: false, viewColumn: vscode.ViewColumn.Beside },
+      {
+        localResourceRoots: [],
+      }
+    );
+    panel.onDidDispose(() => (panel = undefined));
+    panel.iconPath = iscIcon;
+  } else if (!panel.visible) {
+    // Make the panel visible
+    panel.reveal(vscode.ViewColumn.Beside, false);
+  }
+  // Set the HTML content
+  panel.webview.html = `
+      <!DOCTYPE html>
+      <html lang="en-us">
+      <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>${viewTitle}</title>
+        <style>
+          .vscode-divider {
+            background-color: var(--vscode-widget-border);
+            border: 0;
+            display: block;
+            height: 1px;
+            margin-bottom: 10px;
+            margin-top: 10px;
+          }
+          .warning-h {
+            color: var(--vscode-terminal-ansiYellow);
+          }
+          .info-h {
+            color: var(--vscode-terminal-ansiBlue);
+          }
+          .module {
+            color: var(--vscode-terminal-ansiMagenta);
+          }
+          .subquery {
+            color: var(--vscode-terminal-ansiGreen);
+          }
+          div.code-block {
+            background-color: var(--vscode-textCodeBlock-background);
+            border-radius: 5px;
+            font-family: monospace;
+            white-space: pre;
+            padding: 10px;
+            padding-top: initial;
+            overflow-x: scroll;
+          }
+        </style>
+      </head>
+      <body>
+        ${planHTML}
+      </body>
+      </html>`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,6 +151,7 @@ import {
   updateIndexForDocument,
 } from "./utils/documentIndex";
 import { WorkspaceNode, NodeBase } from "./explorer/nodes";
+import { showPlanWebview } from "./commands/showPlanPanel";
 
 const packageJson = vscode.extensions.getExtension(extensionId).packageJSON;
 const extensionVersion = packageJson.version;
@@ -1224,7 +1225,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     ),
     vscode.commands.registerCommand("vscode-objectscript.editOthers", () => viewOthers(true)),
     vscode.commands.registerCommand("vscode-objectscript.showClassDocumentationPreview", () =>
-      DocumaticPreviewPanel.create(context.extensionUri)
+      DocumaticPreviewPanel.create()
     ),
     vscode.commands.registerCommand("vscode-objectscript.showRESTDebugWebview", () =>
       RESTDebugPanel.create(context.extensionUri)
@@ -1593,6 +1594,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
           .executeCommand("workbench.action.closeActiveEditor")
           .then(() => vscode.commands.executeCommand("vscode.openWith", uri, lowCodeEditorViewType));
       }
+    }),
+    vscode.commands.registerCommand("vscode-objectscript.showPlanWebview", (args) => {
+      if (typeof args != "object") return;
+      showPlanWebview(args);
     }),
 
     /* Anything we use from the VS Code proposed API */

--- a/src/providers/ObjectScriptCodeLensProvider.ts
+++ b/src/providers/ObjectScriptCodeLensProvider.ts
@@ -1,56 +1,218 @@
 import * as vscode from "vscode";
 import { gte } from "semver";
-import { clsLangId, config, intLangId, macLangId } from "../extension";
-import { currentFile } from "../utils";
+import { clsLangId, intLangId, lsExtensionId, macLangId } from "../extension";
+import { currentFile, parseClassMemberDefinition, quoteClassMemberName } from "../utils";
 import { AtelierAPI } from "../api";
 
-export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
-  public provideCodeLenses(
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken
-  ): vscode.ProviderResult<vscode.CodeLens[]> {
-    if (document.languageId == clsLangId) {
-      return this.classMembers(document);
-    }
-    if ([macLangId, intLangId].includes(document.languageId)) {
-      return this.routineLabels(document);
-    }
-    return [];
-  }
+const includeRegex = /^Include\s+\(?([^(]+)\)?\s*$/i;
+const importRegex = /^Import\s+\(?([^(]+)\)?\s*$/i;
+const sqlQueryRegex = /\)\s+(?:As|as|AS|aS)\s+%(?:Library\.)?SQLQuery(?:\([^)]*SELECTMODE\s*=\s*"([^"]+)"[^)]*\))?/;
+const eSqlStartRegex = /(?:^|(?:[^"]*"[^"]*")*)(?:##sql|&sql([^(+-/\\|*\s)]*))\(/i;
+const poundImportRegex = /^\s*#import\s+(.+)$/i;
+const poundIncludeRegex = /^\s*#include\s+(\S+)\s*$/i;
+const sqlSelectRegex = /^\s*#sqlcompile\s+select\s*=\s*(\S+)\s*$/i;
+const commentRegex = /(?:^|(?:[^"]*"[^"]*")*)(\/\/|;|\/\*)/;
+const rtnProcedureRegex = /^\(([^)]*)\)\s*(?:\[[^\]]*\])?\s*public/i;
 
-  private classMembers(document: vscode.TextDocument): vscode.CodeLens[] {
-    const file = currentFile(document);
-    const result = new Array<vscode.CodeLens>();
-    const className = file.name.slice(0, -4);
-    const { debugThisMethod, copyToClipboard } = config("debug");
-    const methodPattern = /(?:^(ClassMethod|Query)\s)([^(]+)\((.*)/i;
-    const xdataPattern = /^XData\s([^[{\s]+)/i;
-    const superPattern = new RegExp(
-      `^\\s*Class\\s+${className.replace(/\./g, "\\.")}\\s+Extends\\s+(?:(?:\\(([^)]+)\\))|(?:([^\\s]+)))`,
-      "i"
-    );
-    const api = new AtelierAPI(document.uri);
-
-    let superclasses: string[] = [];
-    let inComment = false;
-    for (let i = 0; i < document.lineCount; i++) {
-      const line = document.lineAt(i);
-      const text = this.stripLineComments(line.text);
-
-      if (text.match(/\/\*/)) {
-        inComment = true;
-      }
-
-      if (inComment) {
-        if (text.match(/\*\//)) {
-          inComment = false;
-        }
+/**
+ * Extract the text of the Embedded SQL query starting at `[startLine,StartChar]`.
+ * `end` is the string that terminates the embedding. Returns the empty string if the
+ * query couldn't be extratced, or if it's not a query that supports execution plans.
+ */
+function getSqlQuery(document: vscode.TextDocument, startLine: number, startChar: number, end: string): string {
+  const isMarker = end.length > 1,
+    isBrace = end == "}",
+    isParen = end == ")";
+  let result = "",
+    brk = false,
+    inSingleQ = false,
+    inDoubleQ = false,
+    inComment = false,
+    braceCount = 1;
+  for (let l = startLine; l < document.lineCount; l++) {
+    inSingleQ = inDoubleQ = false; // Neither of these can span multiple lines
+    const lineText = document.lineAt(l).text;
+    if (isMarker) {
+      if (lineText.includes(end)) {
+        result = document.getText(new vscode.Range(startLine, startChar, l, lineText.indexOf(end)));
+        break;
+      } else {
+        // Only the reverse marker can terminate the query
         continue;
       }
+    }
+    for (let c = l == startLine ? startChar : 0; c < lineText.length; c++) {
+      if (inComment && lineText[c] == "*" && c < lineText.length - 1 && lineText[c + 1] == "/") {
+        // This is the end of a C-style comment
+        inComment = false;
+        continue;
+      }
+      if (!inSingleQ && lineText[c] == '"') {
+        inDoubleQ = !inDoubleQ;
+      } else if (!inDoubleQ && lineText[c] == "'") {
+        inSingleQ = !inSingleQ;
+      } else if (!inSingleQ && !inComment && !inDoubleQ) {
+        if (lineText[c] == "-" && c < lineText.length - 1 && lineText[c + 1] == "-") {
+          // This is a single-line -- comment, so move on to the next line
+          break;
+        }
+        if (lineText[c] == "/" && c < lineText.length - 1 && lineText[c + 1] == "*") {
+          // This is the start of a C-style comment
+          inComment = true;
+          continue;
+        }
+        if ((isParen && lineText[c] == "(") || (isBrace && lineText[c] == "{")) {
+          braceCount++;
+        } else if ((isParen && lineText[c] == ")") || (isBrace && lineText[c] == "}")) {
+          braceCount--;
+        }
+      }
 
-      const methodMatch = text.match(methodPattern);
-      const xdataMatch = text.match(xdataPattern);
-      const superMatch = text.match(superPattern);
+      if (braceCount == 0) {
+        // We've passed the end of the query
+        result = document.getText(new vscode.Range(startLine, startChar, l, c));
+        brk = true;
+        break;
+      }
+    }
+    if (brk) break;
+  }
+  if (
+    result.length &&
+    !["SELECT", "DECLARE", "UPDATE", "DELETE", "TRUNCATE", "INSERT"].includes(
+      result.trimStart().split(/\s+/).shift().toUpperCase()
+    )
+  ) {
+    // Can only generate plans for certain SQL statements
+    result = "";
+  }
+  return result;
+}
+
+/**
+ * Scan the block of ObjectScript code in `document` starting at line `start` (inclusive) and ending
+ * at line `end` (exclusive) looking for Embedded SQL queries that we can show the execution plan for.
+ */
+function scanCodeBlock(
+  document: vscode.TextDocument,
+  start: number,
+  end: number,
+  className?: string,
+  classIncludes?: string[],
+  classImports?: string[]
+): vscode.CodeLens[] {
+  const result: vscode.CodeLens[] = [];
+  const includes: string[] = classIncludes ? [...classIncludes] : [];
+  const imports: string[] = classImports ? [...classImports] : [];
+  let selectMode: string = "LOGICAL";
+  let inCStyleComment = false;
+  for (let i = start; i < end; i++) {
+    const line = document.lineAt(i).text;
+    let commentStart: number;
+    let commentEnd: number;
+    if (!inCStyleComment) {
+      const commentMatch = line.match(commentRegex);
+      if (commentMatch) {
+        commentStart = commentMatch[0].length - commentMatch[1].length;
+        if (commentMatch[1] == "/*") inCStyleComment = true;
+      }
+    }
+    if (inCStyleComment) {
+      // The multi-line comment ends on this line
+      const endMatch = line.indexOf("*/");
+      if (endMatch != -1) {
+        commentStart = 0;
+        commentEnd = endMatch + 2;
+        inCStyleComment = false;
+      } else {
+        commentStart = 0;
+      }
+    }
+    if (commentStart == 0 && commentEnd == undefined) {
+      // The whole line is a comment
+      continue;
+    }
+    const eSqlMatch = line.match(eSqlStartRegex);
+    if (eSqlMatch) {
+      // Check if the match is commented out
+      if (
+        (commentStart == undefined && commentEnd == undefined) ||
+        (commentStart != undefined && eSqlMatch.index < commentStart) ||
+        (commentEnd != undefined && eSqlMatch.index > commentEnd)
+      ) {
+        const sqlQuery = getSqlQuery(
+          document,
+          i,
+          eSqlMatch.index + eSqlMatch[0].length,
+          `)${(eSqlMatch[1] ?? "").split("").reverse().join("")}`
+        );
+        if (sqlQuery) {
+          result.push(
+            new vscode.CodeLens(new vscode.Range(i, eSqlMatch.index, i, eSqlMatch.index + eSqlMatch[0].length), {
+              title: "Show Plan",
+              tooltip: "Show the plan for this query",
+              command: "vscode-objectscript.showPlanWebview",
+              arguments: [{ uri: document.uri, sqlQuery, selectMode, includes, imports, className }],
+            })
+          );
+          // Skip ahead to the end of the SQL text
+          i += sqlQuery.split(/\r?\n/).length - 1;
+        }
+      }
+      continue;
+    }
+    const includeMatch = line.match(poundIncludeRegex);
+    if (includeMatch) {
+      includes.push(includeMatch[1]);
+      continue;
+    }
+    const importMatch = line.match(poundImportRegex);
+    if (importMatch) {
+      imports.push(...importMatch[1].replace(/\s+/g, "").split(","));
+      continue;
+    }
+    const sqlSelectMatch = line.match(sqlSelectRegex);
+    if (sqlSelectMatch) {
+      selectMode = sqlSelectMatch[1].toUpperCase();
+      continue;
+    }
+  }
+  return result;
+}
+
+export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
+  public async provideCodeLenses(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ): Promise<vscode.CodeLens[]> {
+    if (![clsLangId, macLangId, intLangId].includes(document.languageId)) return;
+    const file = currentFile(document);
+    if (!file) return; // Document is malformed
+    const symbols: vscode.DocumentSymbol[] = await vscode.commands.executeCommand(
+      "vscode.executeDocumentSymbolProvider",
+      document.uri
+    );
+    if (!symbols?.length || token.isCancellationRequested) return;
+    const api = new AtelierAPI(document.uri);
+    const conf = vscode.workspace.getConfiguration("objectscript.debug");
+    const debugThisMethod: boolean = conf.get("debugThisMethod") && api.active;
+    const copyToClipboard: boolean = conf.get("copyToClipboard");
+    const showPlan = api.active && gte(api.config.serverVersion, "2024.1.0");
+    const result: vscode.CodeLens[] = [];
+    if (document.languageId == clsLangId) {
+      if (!symbols[0].children.length) return;
+      const className = file.name.slice(0, -4);
+      const superRegex = new RegExp(
+        `^\\s*Class\\s+${className.replace(/\./g, "\\.")}\\s+Extends\\s+(?:(?:\\(([^)]+)\\))|(?:([^\\s]+)))`,
+        "i"
+      );
+      const languageServer: boolean = vscode.extensions.getExtension(lsExtensionId)?.isActive ?? false;
+      let superclasses: string[] = [];
+      const includes: string[] = ["%systemInclude"];
+      const imports: string[] = [className.slice(0, className.lastIndexOf("."))];
+
+      // Capture any superclasses
+      const superMatch = document.lineAt(symbols[0].selectionRange.start.line).text.match(superRegex);
       if (superMatch) {
         const [, superclassesList, superclass] = superMatch;
         if (superclass) {
@@ -58,127 +220,204 @@ export class ObjectScriptCodeLensProvider implements vscode.CodeLensProvider {
         } else {
           superclasses = superclassesList.replace(/\s+/g, "").split(",");
         }
-      } else if (xdataMatch && api.active) {
-        let [, xdataName] = xdataMatch;
-        xdataName = xdataName.trim();
-        let cmd: vscode.Command = undefined;
-        if (xdataName == "BPL" && superclasses.includes("Ens.BusinessProcessBPL")) {
-          cmd = {
-            title: "Open Low-Code Editor in Browser",
-            command: "vscode-objectscript.openPathInBrowser",
-            tooltip: "Open low-code editor in an external browser",
-            arguments: [`/EnsPortal.BPLEditor.zen?BP=${className}.BPL`, document.uri],
-          };
-        } else if (
-          (xdataName == "RuleDefinition" &&
-            superclasses.includes("Ens.Rule.Definition") &&
-            gte(api.config.serverVersion, "2023.1.0")) ||
-          (xdataName == "DTL" &&
-            superclasses.includes("Ens.DataTransformDTL") &&
-            gte(api.config.serverVersion, "2025.1.0"))
-        ) {
-          cmd = {
-            title: "Reopen in Low-Code Editor",
-            command: "vscode-objectscript.reopenInLowCodeEditor",
-            arguments: [document.uri],
-            tooltip: "Replace text editor with low-code editor",
-          };
-        } else if (xdataName == "KPI" && superclasses.includes("%DeepSee.KPI")) {
-          cmd = {
-            title: "Test KPI in Browser",
-            command: "vscode-objectscript.openPathInBrowser",
-            tooltip: "Open testing page in an external browser",
-            arguments: [`/${className}.cls`, document.uri],
-          };
+      }
+
+      // Capture any Imports and Includes, if necessary
+      if (showPlan) {
+        for (let i = 0; i < symbols[0].selectionRange.start.line; i++) {
+          const line = document.lineAt(i).text;
+          const includeMatch = line.match(includeRegex);
+          if (includeMatch) {
+            includes.push(...includeMatch[1].replace(/\s+/g, "").split(","));
+            continue;
+          }
+          const importMatch = line.match(importRegex);
+          if (importMatch) {
+            imports.push(...importMatch[1].replace(/\s+/g, "").split(","));
+          }
         }
-        if (cmd) result.push(new vscode.CodeLens(new vscode.Range(i, 0, i, 80), cmd));
-      } else if (methodMatch && (debugThisMethod || copyToClipboard)) {
-        const [, kind, name, paramsRaw] = methodMatch;
-        let params = paramsRaw;
-        params = params.replace(/"[^"]*"/g, '""');
-        params = params.replace(/{[^{}]*}|{[^{}]*{[^{}]*}[^{}]*}/g, '""');
-        params = params.replace(/\([^()]*\)/g, "");
-        const args = params.split(")")[0];
-        const paramsCount = args.length ? args.split(",").length : params.includes(")") ? 0 : 1; // Need a positive paramsCount when objectscript.multilineMethodArgs is true
+      }
 
-        const methodName = name + (kind == "Query" ? "Func" : "");
+      // Loop through the class member symbols
+      symbols[0].children.forEach((symbol, idx) => {
+        const type = symbol.detail.toLowerCase();
+        if (!["xdata", "method", "classmethod", "query", "trigger"].includes(type)) return;
+        let symbolLine: number;
+        if (languageServer) {
+          symbolLine = symbol.selectionRange.start.line;
+        } else {
+          // This extension's symbol provider doesn't have a range
+          // that always maps to the first line of the member definition
+          for (let l = symbol.range.start.line; l < document.lineCount; l++) {
+            symbolLine = l;
+            if (!document.lineAt(l).text.startsWith("///")) break;
+          }
+        }
+        switch (type) {
+          case "xdata": {
+            if (api.active) {
+              let cmd: vscode.Command;
+              if (symbol.name == "BPL" && superclasses.includes("Ens.BusinessProcessBPL")) {
+                cmd = {
+                  title: "Open Low-Code Editor in Browser",
+                  command: "vscode-objectscript.openPathInBrowser",
+                  tooltip: "Open low-code editor in an external browser",
+                  arguments: [`/EnsPortal.BPLEditor.zen?BP=${className}.BPL`, document.uri],
+                };
+              } else if (
+                (symbol.name == "RuleDefinition" &&
+                  superclasses.includes("Ens.Rule.Definition") &&
+                  gte(api.config.serverVersion, "2023.1.0")) ||
+                (symbol.name == "DTL" &&
+                  superclasses.includes("Ens.DataTransformDTL") &&
+                  gte(api.config.serverVersion, "2025.1.0"))
+              ) {
+                cmd = {
+                  title: "Reopen in Low-Code Editor",
+                  command: "vscode-objectscript.reopenInLowCodeEditor",
+                  arguments: [document.uri],
+                  tooltip: "Replace text editor with low-code editor",
+                };
+              } else if (symbol.name == "KPI" && superclasses.includes("%DeepSee.KPI")) {
+                cmd = {
+                  title: "Test KPI in Browser",
+                  command: "vscode-objectscript.openPathInBrowser",
+                  tooltip: "Open testing page in an external browser",
+                  arguments: [`/${className}.cls`, document.uri],
+                };
+              }
+              if (cmd) result.push(new vscode.CodeLens(this.range(symbolLine), cmd));
+            }
+            break;
+          }
+          case "method":
+          case "classmethod":
+          case "trigger":
+          case "query": {
+            // Capture the entire text of the class member definition up to the implementation
+            const memberInfo = parseClassMemberDefinition(document, symbol, symbolLine);
+            if (!memberInfo) break;
+            const { definition, defEndLine, language, isPrivate } = memberInfo;
+            if (showPlan) {
+              if (type == "query") {
+                // Check if this is a %SQLQuery
+                const sqlQueryMatch = definition.match(sqlQueryRegex);
+                if (sqlQueryMatch) {
+                  // This is a %SQLQuery
+                  const selectMode = sqlQueryMatch[1]?.toUpperCase() ?? "RUNTIME";
+                  const sqlQuery = getSqlQuery(document, defEndLine + 1, 0, "}");
+                  if (sqlQuery) {
+                    result.push(
+                      new vscode.CodeLens(this.range(symbolLine), {
+                        title: "Show Plan",
+                        tooltip: "Show the plan for this query",
+                        command: "vscode-objectscript.showPlanWebview",
+                        arguments: [{ uri: document.uri, sqlQuery, selectMode, includes, imports, className }],
+                      })
+                    );
+                  }
+                }
+              } else if (["cache", "objectscript"].includes(language)) {
+                // Check for Embedded SQL queries
+                result.push(
+                  ...scanCodeBlock(
+                    document,
+                    defEndLine,
+                    idx == symbols[0].children.length - 1
+                      ? document.lineCount
+                      : symbols[0].children[idx + 1].range.start.line,
+                    className,
+                    includes,
+                    imports
+                  )
+                );
+              }
+            }
 
-        debugThisMethod &&
-          kind == "ClassMethod" &&
-          result.push(this.addDebugThisMethod(i, [`##class(${className}).${methodName}`, paramsCount > 0]));
-        copyToClipboard &&
-          result.push(
-            this.addCopyToClipboard(i, [`##class(${className}).${methodName}(${Array(paramsCount).join(",")})`])
-          );
+            const displayName = quoteClassMemberName(symbol.name);
+            if (
+              !isPrivate &&
+              copyToClipboard &&
+              (type == "classmethod" || (type == "query" && displayName[0] != '"'))
+            ) {
+              result.push(this.addCopyToClipboard(symbolLine, [`##class(${className}).${displayName}()`]));
+            }
+            if (
+              !isPrivate &&
+              debugThisMethod &&
+              ["cache", "objectscript"].includes(language) &&
+              type == "classmethod"
+            ) {
+              const argsMatch = definition.match(new RegExp(`${displayName}\\(([^)]*)\\)`));
+              result.push(
+                this.addDebugThisMethod(symbolLine, [
+                  `##class(${className}).${displayName}`,
+                  argsMatch && typeof argsMatch[1] == "string" && argsMatch[1].trim().length > 0,
+                ])
+              );
+            }
+          }
+        }
+      });
+    } else {
+      // Look for labels and public procedures
+      const routineName = file.name.split(".").slice(0, -1).join(".");
+      let labeledLine1 = false;
+      if (symbols && (debugThisMethod || copyToClipboard)) {
+        symbols.forEach((symbol) => {
+          const line = symbol.selectionRange.start.line;
+          const restOfLine = document.lineAt(line).text.slice(symbol.name.length);
+          let hasArgs = false,
+            isProc = false;
+          if (restOfLine[0] == "(") {
+            // Make sure this is a public procedure, and extract the argument list
+            const procMatch = restOfLine.match(rtnProcedureRegex);
+            if (procMatch) {
+              isProc = true;
+              hasArgs = procMatch[1].length > 0;
+            } else {
+              // This is not a syntactically valid public procedure
+              return;
+            }
+          }
+          if (line == 1) labeledLine1 = true;
+          if (debugThisMethod) result.push(this.addDebugThisMethod(line, [`${symbol.name}^${routineName}`, hasArgs]));
+          if (copyToClipboard) {
+            result.push(this.addCopyToClipboard(line, [`${symbol.name}^${routineName}${isProc ? "()" : ""}`]));
+          }
+        });
+      }
+
+      // Add CodeLenses at the top only if the first code line had no label
+      if (!labeledLine1) {
+        if (debugThisMethod) result.push(this.addDebugThisMethod(0, [`^${routineName}`, false]));
+        if (copyToClipboard) result.push(this.addCopyToClipboard(0, [`^${routineName}`]));
+      }
+      if (document.languageId == macLangId && showPlan) {
+        // Check for Embedded SQL queries
+        result.push(...scanCodeBlock(document, 0, document.lineCount));
       }
     }
     return result;
   }
 
-  private async routineLabels(document: vscode.TextDocument): Promise<vscode.CodeLens[]> {
-    const file = currentFile(document);
-    const result = new Array<vscode.CodeLens>();
-
-    const routineName = file.name.split(".").slice(0, -1).join(".");
-
-    const { debugThisMethod, copyToClipboard } = config("debug");
-    if (!debugThisMethod && !copyToClipboard) {
-      // Return early if both types are turned off
-      return result;
-    }
-
-    const symbols: vscode.DocumentSymbol[] = await vscode.commands.executeCommand(
-      "vscode.executeDocumentSymbolProvider",
-      document.uri
-    );
-
-    let labelledLine1 = false;
-    if (symbols) {
-      symbols
-        .filter((symbol) => symbol.kind === vscode.SymbolKind.Method)
-        .forEach((symbol) => {
-          const line = symbol.selectionRange.start.line;
-          const labelMatch = document.lineAt(line).text.match(/^(\w[^(\n\s]+)(?:\(([^)]*)\))?/i);
-          if (labelMatch) {
-            if (line === 1) {
-              labelledLine1 = true;
-            }
-            const [, name, parens] = labelMatch;
-            debugThisMethod &&
-              result.push(this.addDebugThisMethod(line, [`${name}^${routineName}`, parens && parens !== "()"]));
-            copyToClipboard && result.push(this.addCopyToClipboard(line, [`${name}^${routineName}`]));
-          }
-        });
-    }
-
-    // Add lenses at the top only if the first code line had no label
-    if (!labelledLine1) {
-      debugThisMethod && result.push(this.addDebugThisMethod(0, [`^${routineName}`, false]));
-      copyToClipboard && result.push(this.addCopyToClipboard(0, [`^${routineName}`]));
-    }
-    return result;
-  }
-
   private addDebugThisMethod(line: number, args: any[]) {
-    return new vscode.CodeLens(new vscode.Range(line, 0, line, 80), {
-      title: `Debug`,
+    return new vscode.CodeLens(this.range(line), {
+      title: "Debug",
       command: "vscode-objectscript.debug",
       arguments: args,
     });
   }
 
   private addCopyToClipboard(line: number, args: any[]) {
-    return new vscode.CodeLens(new vscode.Range(line, 0, line, 80), {
-      title: `Copy Invocation`,
+    return new vscode.CodeLens(this.range(line), {
+      title: "Copy Invocation",
       command: "vscode-objectscript.copyToClipboard",
       arguments: args,
     });
   }
 
-  private stripLineComments(text: string) {
-    text = text.replace(/\/\/.*$/, "");
-    text = text.replace(/#+;.*$/, "");
-    text = text.replace(/;.*$/, "");
-    return text;
+  private range(line: number): vscode.Range {
+    return new vscode.Range(line, 0, line, 80);
   }
 }


### PR DESCRIPTION
This PR adds a new `Show Plan` CodeLens. The CodeLens will appear above `%SQLQuery` Class Query definitions and Embedded SQL queries if the query can generate an execution plan, and a connection to IRIS 2024.1+ is active. When the CodeLens is clicked, the query text, select mode and imported packages are extracted from the document and sent to the server. The returned plan is then rendered as HTML in a webview. Only one Show Plan webview can be visible at any time. Include files are captured, and support for passing them to the server-side SQL plan code will come in a future IRIS release.
<img width="1037" alt="Screenshot 2025-03-10 at 8 23 41 AM" src="https://github.com/user-attachments/assets/32590dc6-0779-4e16-8bda-170db90dba63" />
