### PR TITLE
Remember last used local folder for server-side import/export

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -25,6 +25,7 @@ import {
   handleError,
   isClassDeployed,
   isClassOrRtn,
+  lastUsedLocalUri,
   notIsfs,
   notNull,
   outputChannel,
@@ -649,7 +650,7 @@ export async function importLocalFilesToServerSideFolder(wsFolderUri: vscode.Uri
   }
   const api = new AtelierAPI(wsFolderUri);
   // Get the default URI and remove the file anme
-  let defaultUri = vscode.workspace.workspaceFile;
+  let defaultUri = lastUsedLocalUri() ?? vscode.workspace.workspaceFile;
   defaultUri = defaultUri.with({ path: defaultUri.path.split("/").slice(0, -1).join("/") });
   // Prompt the user for files to import
   let uris = await vscode.window.showOpenDialog({
@@ -674,6 +675,7 @@ export async function importLocalFilesToServerSideFolder(wsFolderUri: vscode.Uri
     vscode.window.showErrorMessage("No classes or routines were selected.", "Dismiss");
     return;
   }
+  lastUsedLocalUri(uris[0]);
   // Get the name and content of the files to import
   const textDecoder = new TextDecoder();
   const docs = await Promise.allSettled<{ name: string; content: string; uri: vscode.Uri }>(
@@ -777,7 +779,7 @@ export async function importXMLFiles(): Promise<any> {
     if (defaultUri.scheme == FILESYSTEM_SCHEMA) {
       // Need a default URI without the isfs scheme or the open dialog
       // will show the server-side files instead of local ones
-      defaultUri = vscode.workspace.workspaceFile;
+      defaultUri = lastUsedLocalUri() ?? vscode.workspace.workspaceFile;
       if (defaultUri.scheme != "file") {
         vscode.window.showErrorMessage(
           "'Import XML Files...' command is not supported for unsaved workspaces.",
@@ -809,6 +811,7 @@ export async function importXMLFiles(): Promise<any> {
       vscode.window.showErrorMessage("No XML files were selected.", "Dismiss");
       return;
     }
+    lastUsedLocalUri(uris[0]);
     // Read the XML files
     const fileTimestamps: Map<string, string> = new Map();
     const filesToList = await Promise.allSettled(

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -8,6 +8,7 @@ import {
   getWsFolder,
   handleError,
   isClassOrRtn,
+  lastUsedLocalUri,
   notNull,
   outputChannel,
   RateLimiter,
@@ -322,7 +323,7 @@ export async function exportDocumentsToXMLFile(): Promise<void> {
     if (schemas.includes(defaultUri.scheme)) {
       // Need a default URI without the isfs scheme or the save dialog
       // will show the virtual files from the workspace folder
-      defaultUri = vscode.workspace.workspaceFile;
+      defaultUri = lastUsedLocalUri() ?? vscode.workspace.workspaceFile;
       if (defaultUri.scheme != "file") {
         vscode.window.showErrorMessage(
           "'Export Documents to XML File...' command is not supported for unsaved workspaces.",
@@ -351,6 +352,7 @@ export async function exportDocumentsToXMLFile(): Promise<void> {
       defaultUri,
     });
     if (uri) {
+      lastUsedLocalUri(uri);
       // Get the XML content
       const xmlContent = await api.actionXMLExport(documents).then((data) => data.result.content);
       // Save the file

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -943,6 +943,14 @@ export function queryToFuzzyLike(query: string): string {
   return p;
 }
 
+let _lastUsedLocalUri: vscode.Uri;
+
+/** Get or set the uri of last used local file for XML import/export or local file import from an `isfs(-readonly)` workspace folder  */
+export function lastUsedLocalUri(newValue?: vscode.Uri): vscode.Uri {
+  if (newValue) _lastUsedLocalUri = newValue;
+  return _lastUsedLocalUri;
+}
+
 class Semaphore {
   /** Queue of tasks waiting to acquire the semaphore */
   private _tasks: (() => void)[] = [];


### PR DESCRIPTION
This PR fixes #1508. I tested this with a local folder that didn't exist and verified that the OS file explorer dialog is still shown.