### PR TITLE
Support only syncing local changes made form VS Code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1602,9 +1602,19 @@
           "default": "command"
         },
         "objectscript.syncLocalChanges": {
-          "description": "Controls whether files in client-side workspace folders that are created, deleted, or changed are automatically synced to the server. Synching will occur whether changes are made due to user actions in VS Code (for example, saving a file that's being actively edited) or outside of VS Code (for example, deleting a file from the OS file explorer while VS Code has its folder open).",
-          "type": "boolean",
-          "default": true
+          "description": "Controls the sources of file events (changes, creation, deletion) in client-side workspace folders that trigger automatic synchronization with the server.",
+          "type": "string",
+          "enum": [
+            "all",
+            "vscodeOnly",
+            "none"
+          ],
+          "enumDescriptions": [
+            "All file events are automatically synced to the server, whether made due to user actions in VS Code (for example, saving a file that's being actively edited) or outside of VS Code (for example, deleting a file from the OS file explorer while VS Code has its folder open).",
+            "Only file events made due to user actions in VS Code are automatically synced to the server.",
+            "No file events are automatically synced to the server."
+          ],
+          "default": "all"
         },
         "objectscript.outputRESTTraffic": {
           "description": "If true, REST requests and responses to and from InterSystems servers will be logged to the ObjectScript Output channel. This should only be enabled when debugging a potential issue.",

--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -3,7 +3,7 @@ import path = require("path");
 import { AtelierAPI } from "../api";
 import { FILESYSTEM_SCHEMA } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
-import { getWsFolder, handleError } from "../utils";
+import { replaceFile, getWsFolder, handleError } from "../utils";
 import { getFileName } from "./export";
 import { getUrisForDocument } from "../utils/documentIndex";
 
@@ -847,8 +847,8 @@ ClassMethod %OnDashboardAction(pAction As %String, pContext As %ZEN.proxyObject)
     }
 
     if (clsUri && clsContent) {
-      // Write the file content
-      await vscode.workspace.fs.writeFile(clsUri, new TextEncoder().encode(clsContent.trimStart()));
+      // Create the file
+      await replaceFile(clsUri, clsContent.trimStart());
       // Show the file
       vscode.window.showTextDocument(clsUri, { preview: false });
     }

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import path = require("path");
 import { config, OBJECTSCRIPTXML_FILE_SCHEMA, xmlContentProvider } from "../extension";
 import { AtelierAPI } from "../api";
-import { fileExists, getWsFolder, handleError, notIsfs, outputChannel } from "../utils";
+import { replaceFile, fileExists, getWsFolder, handleError, notIsfs, outputChannel } from "../utils";
 import { getFileName } from "./export";
 
 const exportHeader = /^\s*<Export generator="(Cache|IRIS)" version="\d+"/;
@@ -169,7 +169,6 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
     const { atelier, folder, addCategory, map } = config("export", wsFolder.name);
     const rootFolder =
       wsFolder.uri.path + (typeof folder == "string" && folder.length ? `/${folder.replaceAll(path.sep, "/")}` : "");
-    const textEncoder = new TextEncoder();
     let errs = 0;
     for (const udlDoc of udlDocs) {
       if (!docWhitelist.includes(udlDoc.name)) continue; // This file wasn't selected
@@ -180,7 +179,7 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
         continue;
       }
       try {
-        await vscode.workspace.fs.writeFile(fileUri, textEncoder.encode(udlDoc.content.join("\n")));
+        await replaceFile(fileUri, udlDoc.content);
       } catch (error) {
         outputChannel.appendLine(
           typeof error == "string" ? error : error instanceof Error ? error.toString() : JSON.stringify(error)


### PR DESCRIPTION
This PR fixes an issue reported on [the Developer Community](https://community.intersystems.com/post/do-you-use-client-side-editing-vs-code-if-so-we-want-your-feedback#comment-280079). The `objectscript.syncLocalChanges` setting is now an `enum` instead of a `boolean`. The `"all"` value corresponds to the previous `true` value, `"none"` corresponds to `false`, and `"vscodeOnly"` restores the pre-#1401 behavior.