### PR TITLE
Fix issue where `Undo` after a save deletes the file being edited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.1] 04-Apr-2025
 - Fixes
   - Fix issue where `Undo` after a save deletes the file being edited (#1524)
+  - Fix endless save loop when one local workspace folder is a subfolder of another (#1525)
 
 ## [3.0.0] 02-Apr-2025
 - Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [3.0.1] 04-Apr-2025
+- Fixes
+  - Fix issue where `Undo` after a save deletes the file being edited (#1524)
+
 ## [3.0.0] 02-Apr-2025
 - Enhancements
   - Client-side editing overhaul (#1401, #1470, #1515, #1520):

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ To unlock these features (optional):
 
 1. Download and install a beta version from GitHub. This is necessary because Marketplace does not allow publication of extensions that use proposed APIs.
 	- Go to https://github.com/intersystems-community/vscode-objectscript/releases
-	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `3.0.0`, look for `3.0.1-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
-	- Download the VSIX file (for example `vscode-objectscript-3.0.1-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
+	- Locate the beta immediately above the release you installed from Marketplace. For instance, if you installed `3.0.1`, look for `3.0.2-beta.1`. This will be functionally identical to the Marketplace version apart from being able to use proposed APIs.
+	- Download the VSIX file (for example `vscode-objectscript-3.0.2-beta.1.vsix`) and install it. One way to install a VSIX is to drag it from your download folder and drop it onto the list of extensions in the Extensions view of VS Code.
 
 2. From [Command Palette](https://code.visualstudio.com/docs/getstarted/tips-and-tricks#_command-palette) choose `Preferences: Configure Runtime Arguments`.
 3. In the argv.json file that opens, add this line (required for both Stable and Insiders versions of VS Code):

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -30,7 +30,6 @@ import {
   notNull,
   outputChannel,
   RateLimiter,
-  replaceFile,
   routineNameTypeRegex,
 } from "../utils";
 import { StudioActions } from "./studio";
@@ -228,12 +227,14 @@ export async function loadChanges(files: (CurrentTextFile | CurrentBinaryFile)[]
         if (notIsfs(file.uri)) {
           const content = await api.getDoc(file.name).then((data) => data.result.content);
           exportedUris.add(file.uri.toString()); // Set optimistically
-          await replaceFile(file.uri, content).catch((e) => {
-            // Save failed, so remove this URI from the set
-            exportedUris.delete(file.uri.toString());
-            // Re-throw the error
-            throw e;
-          });
+          await vscode.workspace.fs
+            .writeFile(file.uri, Buffer.isBuffer(content) ? content : new TextEncoder().encode(content.join("\n")))
+            .then(undefined, (e) => {
+              // Save failed, so remove this URI from the set
+              exportedUris.delete(file.uri.toString());
+              // Re-throw the error
+              throw e;
+            });
           if (isClassOrRtn(file.uri)) {
             // Update the document index
             updateIndexForDocument(file.uri, undefined, undefined, content);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,7 +104,6 @@ import {
   isClassOrRtn,
   addWsServerRootFolderData,
   getWsFolder,
-  replaceFile,
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentLinkProvider } from "./providers/DocumentLinkProvider";
@@ -1272,7 +1271,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
             // Generate the new content
             const newContent = generateFileContent(uri, fileName, sourceContent);
             // Write the new content to the file
-            return replaceFile(uri, newContent.content);
+            const wsEdit = new vscode.WorkspaceEdit();
+            wsEdit.replace(
+              uri,
+              new vscode.Range(0, 0, newContent.content.length + 1, 0),
+              newContent.content.join("\n"),
+              {
+                label: "ObjectScript autoAdjustName",
+                needsConfirmation: false,
+              }
+            );
+            await vscode.workspace.applyEdit(wsEdit);
           })
       );
     }),


### PR DESCRIPTION
This PR fixes #1522. The issue is that we "recreate" the file when loading changes from the compiler, so Undo undoes this "creation" and deletes the file. I fixed the issue by going back to the `fs.writeFile()` API. This issue is pretty bad, so I'm considering bumping version as part of the PR and doing the 3.0.1 release immediately. 