### PR TITLE
Reduce REST traffic for server-side folders

### DIFF
--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -680,11 +680,6 @@ export async function modifyProject(
   if (!args) return;
   const { node, api, project } = args;
 
-  // Technically a project is a "document", so tell the server that we're opening it
-  await new StudioActions().fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument).catch(() => {
-    // Swallow error because showing it is more disruptive than using a potentially outdated project definition
-  });
-
   let items: ProjectItem[] = await api
     .actionQuery("SELECT Name, Type FROM %Studio.Project_ProjectItemsList(?,?) WHERE Type != 'GBL'", [project, "1"])
     .then((data) => data.result.content);
@@ -1148,11 +1143,6 @@ export async function modifyProjectMetadata(nodeOrUri: NodeBase | vscode.Uri | u
   });
   if (!args) return;
   const { api, project } = args;
-
-  // Technically a project is a "document", so tell the server that we're opening it
-  await new StudioActions().fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument).catch(() => {
-    // Swallow error because showing it is more disruptive than using a potentially outdated project definition
-  });
 
   try {
     const oldDesc: string = await api

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -234,6 +234,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
+    if (!new AtelierAPI(uri).active) throw vscode.FileSystemError.Unavailable("Server connection is inactive");
     let entryPromise: Promise<Entry>;
     let result: Entry;
     const redirectedUri = redirectDotvscodeRoot(uri);

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -400,9 +400,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public createDirectory(uri: vscode.Uri): void | Thenable<void> {
-    if (uri.path.includes(".vscode/")) {
-      throw vscode.FileSystemError.NoPermissions("Cannot create a subdirectory of the /.vscode directory");
-    }
+    uri = redirectDotvscodeRoot(uri);
     const basename = path.posix.basename(uri.path);
     const dirname = uri.with({ path: path.posix.dirname(uri.path) });
     return this._lookupAsDirectory(dirname).then((parent) => {
@@ -695,9 +693,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     }
     if (vscode.workspace.getWorkspaceFolder(oldUri) != vscode.workspace.getWorkspaceFolder(newUri)) {
       throw vscode.FileSystemError.NoPermissions("Cannot rename a file across workspace folders");
-    }
-    if (oldUri.path.includes(".vscode/") || newUri.path.includes(".vscode/")) {
-      throw vscode.FileSystemError.NoPermissions("Cannot rename a file in the /.vscode directory");
     }
     // Check if the destination exists
     let newFileStat: vscode.FileStat;

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -234,9 +234,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-    if (uri.path.includes(".vscode/") && !uri.path.endsWith("/settings.json")) {
-      throw vscode.FileSystemError.NoPermissions("Only settings.json is allowed within the /.vscode directory");
-    }
     let entryPromise: Promise<Entry>;
     let result: Entry;
     const redirectedUri = redirectDotvscodeRoot(uri);
@@ -421,9 +418,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async readFile(uri: vscode.Uri): Promise<Uint8Array> {
-    if (uri.path.includes(".vscode/") && !uri.path.endsWith("/settings.json")) {
-      throw vscode.FileSystemError.NoPermissions("Only settings.json is allowed within the /.vscode directory");
-    }
     // Use _lookup() instead of _lookupAsFile() so we send
     // our cached mtime with the GET /doc request if we have it
     return this._lookup(uri, true).then((file: File) => {
@@ -442,9 +436,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       overwrite: boolean;
     }
   ): void | Thenable<void> {
-    if (uri.path.includes(".vscode/") && !uri.path.endsWith("/settings.json")) {
-      throw vscode.FileSystemError.NoPermissions("Only settings.json is allowed within the /.vscode directory");
-    }
     uri = redirectDotvscodeRoot(uri);
     if (uri.path.startsWith("/.")) {
       throw vscode.FileSystemError.NoPermissions("dot-folders not supported by server");
@@ -612,9 +603,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   }
 
   public async delete(uri: vscode.Uri, options: { recursive: boolean }): Promise<void> {
-    if (uri.path.includes(".vscode/") && !uri.path.endsWith("/settings.json")) {
-      throw vscode.FileSystemError.NoPermissions("Only settings.json is allowed within the /.vscode directory");
-    }
     uri = redirectDotvscodeRoot(uri);
     const { project } = isfsConfig(uri);
     const csp = isCSP(uri);


### PR DESCRIPTION
This PR was prompted by my investigation into #1523.

- Don't call `GET /api/atelier/` every tie we try to read the root folder.
- Only call the `OpenedDocument` UserAction once per workspace folder.