### PR TITLE
Allow `objectscript.multilineMethodArgs` to be set per workspace folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1488,6 +1488,7 @@
         "objectscript.multilineMethodArgs": {
           "markdownDescription": "List method arguments on multiple lines, if the server supports it. **NOTE:** Only supported on IRIS 2019.1.2, 2020.1.1+, 2021.1.0+ and subsequent versions! On all other versions, this setting will have no effect.",
           "type": "boolean",
+          "scope": "resource",
           "default": false
         },
         "objectscript.openClassContracted": {

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -64,7 +64,7 @@ export async function checkChangedOnServer(file: CurrentTextFile | CurrentBinary
   const mtime =
     workspaceState.get(`${file.uniqueId}:mtime`, null) ||
     (await api
-      .getDoc(file.name)
+      .getDoc(file.name, file.uri)
       .then((data) => data.result)
       .then(async ({ ts, content }) => {
         const serverTime = Number(new Date(ts + "Z"));
@@ -225,7 +225,7 @@ export async function loadChanges(files: (CurrentTextFile | CurrentBinaryFile)[]
         const mtime = Number(new Date(doc.ts + "Z"));
         workspaceState.update(`${file.uniqueId}:mtime`, mtime > 0 ? mtime : undefined);
         if (notIsfs(file.uri)) {
-          const content = await api.getDoc(file.name).then((data) => data.result.content);
+          const content = await api.getDoc(file.name, file.uri).then((data) => data.result.content);
           exportedUris.add(file.uri.toString()); // Set optimistically
           await vscode.workspace.fs
             .writeFile(file.uri, Buffer.isBuffer(content) ? content : new TextEncoder().encode(content.join("\n")))

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -99,7 +99,7 @@ async function exportFile(wsFolderUri: vscode.Uri, namespace: string, name: stri
     outputChannel.appendLine(`Export '${name}' to '${fileUri.toString(true)}' - ${status}`);
 
   try {
-    const data = await api.getDoc(name);
+    const data = await api.getDoc(name, wsFolderUri);
     if (!data || !data.result) {
       throw new Error("Received malformed JSON object from server fetching document");
     }

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -249,7 +249,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     const { csp, ns } = isfsConfig(uri);
     const fileName = csp ? uri.path.slice(1) : uri.path.split("/").slice(1).join(".");
     if (ns) api.setNamespace(ns);
-    const data = await api.getDoc(fileName);
+    const data = await api.getDoc(fileName, api.configName);
     if (Buffer.isBuffer(data.result.content)) {
       return "\nThis is a binary file.\n\nTo access its contents, export it to the local file system.";
     } else {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -939,7 +939,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     const fileName = isfsDocumentName(uri, csp);
     const api = new AtelierAPI(uri);
     return api
-      .getDoc(fileName, undefined, cachedFile?.mtime)
+      .getDoc(fileName, uri, cachedFile?.mtime)
       .then((data) => data.result)
       .then(
         ({ ts, content }) =>


### PR DESCRIPTION
This PR fixes #1533