### PR TITLE
Show error message when a server-side file fails to open

### DIFF
--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -960,7 +960,9 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       )
       .catch((error) => {
         if (error?.statusCode == 304 && cachedFile) return cachedFile;
-        throw vscode.FileSystemError.FileNotFound(stringifyError(error) || uri);
+        const errArg = stringifyError(error) || uri;
+        if (error?.statusCode == 404) throw vscode.FileSystemError.FileNotFound(errArg);
+        throw vscode.FileSystemError.Unavailable(errArg);
       });
   }
 


### PR DESCRIPTION
See https://github.com/intersystems-community/intersystems-servermanager/issues/266 and https://community.intersystems.com/post/sourcecontrol-errors
<img width="296" alt="Screenshot 2025-04-21 at 7 31 54 AM" src="https://github.com/user-attachments/assets/2eb7f8e0-8044-42ef-a0b4-266f6263dd32" />
