### PR TITLE
Small tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,15 +105,15 @@
         },
         {
           "command": "vscode-objectscript.compile",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.refreshLocalFile",
-          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.compileWithFlags",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.compileAll",
@@ -213,11 +213,11 @@
         },
         {
           "command": "vscode-objectscript.compileOnly",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.compileOnlyWithFlags",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.editOthers",
@@ -478,7 +478,7 @@
         },
         {
           "command": "vscode-objectscript.compile",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty",
           "group": "objectscript@3"
         },
         {
@@ -498,7 +498,7 @@
         },
         {
           "command": "vscode-objectscript.compileOnly",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive",
+          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty",
           "group": "objectscript@7"
         },
         {
@@ -545,7 +545,7 @@
         {
           "command": "vscode-objectscript.touchBar.compile",
           "group": "objectscript.compile",
-          "when": "editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive"
+          "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/ && vscode-objectscript.connectActive && !activeEditorIsDirty"
         },
         {
           "command": "vscode-objectscript.touchBar.viewOthers",
@@ -1183,7 +1183,7 @@
         "command": "vscode-objectscript.compile",
         "key": "Ctrl+F7",
         "mac": "Cmd+F7",
-        "when": "editorLangId =~ /^objectscript/"
+        "when": "!(resourceScheme =~ /^isfs(-readonly)?$/) && editorLangId =~ /^objectscript/"
       },
       {
         "command": "vscode-objectscript.compileAll",

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
 import { iscIcon } from "../extension";
-import { outputChannel, outputConsole, notIsfs, handleError, openCustomEditors } from "../utils";
+import { outputChannel, outputConsole, notIsfs, handleError, openLowCodeEditors } from "../utils";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { UserAction } from "../api/atelier";
 import { isfsDocumentName } from "../providers/FileSystemProvider/FileSystemProvider";
@@ -547,7 +547,7 @@ export async function fireOtherStudioAction(
   const studioActions = new StudioActions(uri);
   return (
     studioActions &&
-    !openCustomEditors.includes(uri.toString()) && // The custom editor will handle all server-side source control interactions
+    !openLowCodeEditors.has(uri.toString()) && // The low-code editor will handle all server-side source control interactions
     studioActions.fireOtherStudioAction(action, userAction)
   );
 }

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -13,13 +13,12 @@ import {
   outputChannel,
   handleError,
   redirectDotvscodeRoot,
-  workspaceFolderOfUri,
   stringifyError,
   base64EncodeContent,
-  openCustomEditors,
+  openLowCodeEditors,
   compileErrorMsg,
 } from "../../utils";
-import { FILESYSTEM_READONLY_SCHEMA, FILESYSTEM_SCHEMA, intLangId, macLangId, workspaceState } from "../../extension";
+import { FILESYSTEM_READONLY_SCHEMA, FILESYSTEM_SCHEMA, intLangId, macLangId } from "../../extension";
 import { addIsfsFileToProject, modifyProject } from "../../commands/project";
 import { DocumentContentProvider } from "../DocumentContentProvider";
 import { Document, UserAction } from "../../api/atelier";
@@ -225,17 +224,12 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
 
   // Used by import and compile to make sure we notice its changes
   public fireFileChanged(uri: vscode.Uri): void {
-    // Remove entry from our cache
-    this._lookupParentDirectory(uri).then((parent) => {
-      const name = path.basename(uri.path);
-      parent.entries.delete(name);
-    });
-    // Queue the event
     this._fireSoon({ type: vscode.FileChangeType.Changed, uri });
   }
 
   public async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-    if (!new AtelierAPI(uri).active) throw vscode.FileSystemError.Unavailable("Server connection is inactive");
+    const api = new AtelierAPI(uri);
+    if (!api.active) throw vscode.FileSystemError.Unavailable("Server connection is inactive");
     let entryPromise: Promise<Entry>;
     let result: Entry;
     const redirectedUri = redirectDotvscodeRoot(uri);
@@ -263,7 +257,6 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     }
 
     if (result instanceof File) {
-      const api = new AtelierAPI(uri);
       const serverName = isfsDocumentName(uri);
       if (serverName.slice(-4).toLowerCase() == ".cls") {
         if (await isClassDeployed(serverName, api)) {
@@ -420,12 +413,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   public async readFile(uri: vscode.Uri): Promise<Uint8Array> {
     // Use _lookup() instead of _lookupAsFile() so we send
     // our cached mtime with the GET /doc request if we have it
-    return this._lookup(uri, true).then((file: File) => {
-      // Update cache entry
-      const uniqueId = `${workspaceFolderOfUri(uri)}:${file.fileName}`;
-      workspaceState.update(`${uniqueId}:mtime`, file.mtime);
-      return file.data;
-    });
+    return this._lookup(uri, true).then((file: File) => file.data);
   }
 
   public writeFile(
@@ -446,17 +434,14 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       return;
     }
     const api = new AtelierAPI(uri);
+    let created = false;
     // Use _lookup() instead of _lookupAsFile() so we send
     // our cached mtime with the GET /doc request if we have it
     return this._lookup(uri)
       .then(
-        async () => {
+        async (entry: File) => {
           // Check cases for which we should fail the write and leave the document dirty if changed
           if (!csp && fileName.split(".").pop().toLowerCase() == "cls") {
-            // Check if the class is deployed
-            if (await isClassDeployed(fileName, api)) {
-              throw new Error("Cannot overwrite a deployed class");
-            }
             // Check if the class name and file name match
             let clsname = "";
             const match = new TextDecoder().decode(content).match(classNameRegex);
@@ -469,11 +454,15 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
             if (fileName.slice(0, -4) != clsname) {
               throw new Error("Cannot save an isfs class where the class name and file name do not match");
             }
-          }
-          if (openCustomEditors.includes(uri.toString())) {
-            // This class is open in a graphical editor, so any
-            // updates to the class will be handled by that editor
-            return;
+            if (openLowCodeEditors.has(uri.toString())) {
+              // This class is open in a low-code editor, so any
+              // updates to the class will be handled by that editor
+              return;
+            }
+            // Check if the class is deployed
+            if (await isClassDeployed(fileName, api)) {
+              throw new Error("Cannot overwrite a deployed class");
+            }
           }
           const contentBuffer = Buffer.from(content);
           const putContent = isText(uri.path.split("/").pop(), contentBuffer)
@@ -496,12 +485,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
               },
               true
             )
-            .then((data) => {
-              workspaceState.update(
-                `${workspaceFolderOfUri(uri)}:${fileName}:mtime`,
-                Number(new Date(data.result.ts + "Z"))
-              );
-            })
+            .then(() => entry)
             .catch((error) => {
               // Throw all failures
               throw vscode.FileSystemError.Unavailable(stringifyError(error) || uri);
@@ -541,15 +525,22 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
                 addIsfsFileToProject(project, fileName, api);
               }
               // Create an entry in our cache for the document
-              this._lookupAsFile(uri);
+              return this._lookupAsFile(uri).then((entry) => {
+                created = true;
+                this._fireSoon({ type: vscode.FileChangeType.Created, uri });
+                return entry;
+              });
             });
         }
       )
-      .then(() => {
+      .then((entry) => {
         // Compile the document if required
-        if (vscode.workspace.getConfiguration("objectscript", uri).get("compileOnSave")) {
-          this.compile(uri);
-        } else {
+        if (
+          !uri.path.includes("/_vscode/") &&
+          vscode.workspace.getConfiguration("objectscript", uri).get("compileOnSave")
+        ) {
+          this.compile(uri, entry);
+        } else if (!created) {
           this._fireSoon({ type: vscode.FileChangeType.Changed, uri });
         }
       });
@@ -703,6 +694,11 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       if (!options.overwrite) {
         // If it does and we can't overwrite it, throw an error
         throw vscode.FileSystemError.FileExists(newUri);
+      } else if (newFileStat.permissions & vscode.FilePermission.Readonly) {
+        // If the file is read-only, throw an error
+        // This can happen if the target class is deployed,
+        // or the document is marked read-only by source control
+        throw vscode.FileSystemError.NoPermissions(newUri);
       }
     } catch (error) {
       if (error instanceof vscode.FileSystemError && error.code == "FileExists") {
@@ -736,7 +732,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
       })
       .then(async (response) => {
         // New file has been written
-        if (newFileStat != undefined && response && response.result.ext && response.result.ext[0]) {
+        if (!newFileStat && response && response.result.ext && response.result.ext[0]) {
           // We created a file
           fireOtherStudioAction(OtherStudioAction.CreatedNewDocument, newUri, response.result.ext[0]);
           fireOtherStudioAction(OtherStudioAction.FirstTimeDocumentSave, newUri, response.result.ext[1]);
@@ -748,7 +744,10 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
         }
         // Sanity check that we find it there, then make client side update things
         this._lookupAsFile(newUri).then(() => {
-          this._fireSoon({ type: vscode.FileChangeType.Changed, uri: newUri });
+          this._fireSoon({
+            type: newFileStat ? vscode.FileChangeType.Changed : vscode.FileChangeType.Created,
+            uri: newUri,
+          });
         });
       });
     // Delete the old file
@@ -758,13 +757,14 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
   /**
    * If `uri` is a file, compile it.
    * If `uri` is a directory, compile its contents.
+   * `file` is passed if called from `writeFile()`.
    */
-  public async compile(uri: vscode.Uri): Promise<void> {
+  public async compile(uri: vscode.Uri, file?: File): Promise<void> {
     if (!uri || uri.scheme != FILESYSTEM_SCHEMA) return;
     uri = redirectDotvscodeRoot(uri);
     const compileList: string[] = [];
     try {
-      const entry = await this._lookup(uri, true);
+      const entry = file || (await this._lookup(uri, true));
       if (!entry) return;
       if (entry instanceof Directory) {
         // Get the list of files to compile
@@ -786,6 +786,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
     if (!compileList.length) return;
     const api = new AtelierAPI(uri);
     const conf = vscode.workspace.getConfiguration("objectscript");
+    const filesToUpdate: Set<string> = new Set(compileList);
     // Compile the files
     await vscode.window.withProgress(
       {
@@ -803,38 +804,34 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
             } else if (!conf.get("suppressCompileMessages")) {
               vscode.window.showInformationMessage(`${info}Compilation succeeded.`, "Dismiss");
             }
+            data.result.content.forEach((f) => filesToUpdate.add(f.name));
           })
           .catch(() => compileErrorMsg(conf))
     );
-    // Tell the client to update all "other" files affected by compilation
-    const workspaceFolder = workspaceFolderOfUri(uri);
-    const otherList: string[] = await api
-      .actionIndex(compileList)
-      .then((data) =>
-        data.result.content.flatMap((idx) => {
-          if (!idx.status.length) {
-            // Update the timestamp for this file
-            const mtime = Number(new Date(idx.ts + "Z"));
-            workspaceState.update(`${workspaceFolder}:${idx.name}:mtime`, mtime > 0 ? mtime : undefined);
-            // Tell the client that it changed
-            this.fireFileChanged(DocumentContentProvider.getUri(idx.name, undefined, undefined, undefined, uri));
-            // Return the list of "other" documents
-            return idx.others;
-          } else {
-            // The server failed to index the document. This should never happen.
-            return [];
-          }
+    // Fire file changed events for all files affected by compilation, including "other" files
+    this._fireSoon(
+      ...filesToUpdate.values().map((f) => {
+        return {
+          type: vscode.FileChangeType.Changed,
+          uri: DocumentContentProvider.getUri(f, undefined, undefined, undefined, uri),
+        };
+      })
+    );
+    (
+      await api
+        .actionIndex(Array.from(filesToUpdate))
+        .then((data) => data.result.content.flatMap((idx) => (!idx.status.length ? idx.others : [])))
+        .catch(() => {
+          // Index API returned an error. This should never happen.
+          return [];
         })
-      )
-      .catch(() => {
-        // Index API returned an error. This should never happen.
-        return [];
-      });
-    // Only fire the event for files that weren't in the compile list
-    otherList.forEach(
+    ).forEach(
       (f) =>
-        !compileList.includes(f) &&
-        this.fireFileChanged(DocumentContentProvider.getUri(f, undefined, undefined, undefined, uri))
+        !filesToUpdate.has(f) &&
+        this._fireSoon({
+          type: vscode.FileChangeType.Changed,
+          uri: DocumentContentProvider.getUri(f, undefined, undefined, undefined, uri),
+        })
     );
   }
 

--- a/src/utils/documentIndex.ts
+++ b/src/utils/documentIndex.ts
@@ -9,7 +9,7 @@ import {
   isClassOrRtn,
   isImportableLocalFile,
   notIsfs,
-  openCustomEditors,
+  openLowCodeEditors,
   outputChannel,
 } from ".";
 import { isText } from "istextorbinary";
@@ -191,7 +191,7 @@ export async function indexWorkspaceFolder(wsFolder: vscode.WorkspaceFolder): Pr
     const uriString = uri.toString();
     const lastFileChangeTime = lastFileChangeTimes.get(uriString) ?? 0;
     lastFileChangeTimes.set(uriString, Date.now());
-    if (openCustomEditors.includes(uriString)) {
+    if (openLowCodeEditors.has(uriString)) {
       // This class is open in a low-code editor, so its name will not change
       // and any updates to the class will be handled by that editor
       touchedByVSCode.delete(uriString);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,9 +35,9 @@ export const cspApps: Map<string, string[]> = new Map();
 export const otherDocExts: Map<string, string[]> = new Map();
 
 /**
- * The URI strings for all documents that are open in a custom editor.
+ * The URI strings for all documents that are open in a low-code editor.
  */
-export const openCustomEditors: string[] = [];
+export const openLowCodeEditors: Set<string> = new Set();
 
 /**
  * Set of stringified `Uri`s that have been exported.


### PR DESCRIPTION
This PR arose during my investigation of #1537 for server-side editing.

- Fire file change events for related documents that were updated by compilation.
- Remove unneeded cache clearing before firing file change events and refresh of server-side class that's open in a low-code editor. VS Code's calling of `stat()` will cause the file to update in these cases.
- Remove unneeded `workspaceState` updates from FileSystemProvider. This is a client-side feature.
- Fire file create events when creating files via `writeFile()`or `rename()`.
- Don't allow `rename()` to overwrite a file that's marked read-only by source control or due to being deployed.
- Don't allow using client-side "import and compile" commands with server-side files.
- Hide some commands when the active text editor is dirty.

@gjsjohnmurray I've tested this a bunch but I would appreciate you playing with it for a little bit just to make sure it's good.