### PR TITLE
Show server-side source control menus when right-clicking on a project workspace folder root

### DIFF
--- a/package.json
+++ b/package.json
@@ -571,12 +571,12 @@
         },
         {
           "command": "vscode-objectscript.serverCommands.contextSourceControl",
-          "when": "resourceScheme == isfs && vscode-objectscript.connectActive && resourcePath && !(resourcePath =~ /^\\/?$/) && !(explorerResourceIsFolder && resource =~ /\\?csp(%3D1|$)/) && !listMultiSelection",
+          "when": "resourceScheme == isfs && vscode-objectscript.connectActive && ((resourcePath && !(resourcePath =~ /^\\/?$/)) || resource =~ /project%3D/) && !(explorerResourceIsFolder && resource =~ /\\?csp(%3D1|$)/) && !listMultiSelection",
           "group": "objectscript_servercommand@1"
         },
         {
           "command": "vscode-objectscript.serverCommands.contextOther",
-          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive && resourcePath && !(resourcePath =~ /^\\/?$/) && !(explorerResourceIsFolder && resource =~ /\\?csp(%3D1|$)/) && !listMultiSelection",
+          "when": "resourceScheme =~ /^isfs(-readonly)?$/ && vscode-objectscript.connectActive && ((resourcePath && !(resourcePath =~ /^\\/?$/)) || resource =~ /project%3D/) && !(explorerResourceIsFolder && resource =~ /\\?csp(%3D1|$)/) && !listMultiSelection",
           "group": "objectscript_servercommand@2"
         },
         {

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -204,6 +204,12 @@ export function isCSP(uri: vscode.Uri): boolean {
 
 /** Get the document name of the file in `uri`. */
 export function isfsDocumentName(uri: vscode.Uri, csp?: boolean, pkg = false): string {
+  const { project } = isfsConfig(uri);
+  if (pkg && project && ["", "/"].includes(uri.path)) {
+    // pkg is only true when opening a context server-side source control menu.
+    // When called on a project workspace root folder, show the menu for the project.
+    return `${project}.PRJ`;
+  }
   if (csp == undefined) csp = isCSP(uri);
   const doc = csp ? uri.path : uri.path.slice(1).replace(/\//g, ".");
   // Add the .PKG extension to non-web folders if called from StudioActions


### PR DESCRIPTION
This PR fixes #1547 