### PR TITLE
Add error message on invalid api connection

### DIFF
--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -13,7 +13,13 @@ export async function previewXMLAsUDL(textEditor: vscode.TextEditor, auto = fals
   if (notIsfs(uri) && uri.path.toLowerCase().endsWith("xml") && textEditor.document.lineCount > 2) {
     if (exportHeader.test(textEditor.document.lineAt(1).text)) {
       const api = new AtelierAPI(uri);
-      if (!api.active) return;
+      if (!api.active) {
+        vscode.window.showErrorMessage(
+          "Unsuccessful connection to the server. Please check your server connection settings.",
+          "Dismiss"
+        );
+        return;
+      }
       try {
         // Convert the file
         const udlDocs: { name: string; content: string[] }[] = await api


### PR DESCRIPTION
Show an error if the api is not active when selecting "Preview XML as UDL" and the file is not connected to the remote server.