### PR TITLE
Show error message when `Preview XML as UDL` is run without an active server connection

### DIFF
--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -14,10 +14,7 @@ export async function previewXMLAsUDL(textEditor: vscode.TextEditor, auto = fals
     if (exportHeader.test(textEditor.document.lineAt(1).text)) {
       const api = new AtelierAPI(uri);
       if (!api.active) {
-        vscode.window.showErrorMessage(
-          "'Preview XML as UDL' command requires an active server connection.",
-          "Dismiss"
-        );
+        vscode.window.showErrorMessage("'Preview XML as UDL' command requires an active server connection.", "Dismiss");
         return;
       }
       try {

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -13,7 +13,13 @@ export async function previewXMLAsUDL(textEditor: vscode.TextEditor, auto = fals
   if (notIsfs(uri) && uri.path.toLowerCase().endsWith("xml") && textEditor.document.lineCount > 2) {
     if (exportHeader.test(textEditor.document.lineAt(1).text)) {
       const api = new AtelierAPI(uri);
-      if (!api.active) return;
+      if (!api.active) {
+        vscode.window.showErrorMessage(
+          "Unsuccessful connection to the server. Please check your server connection settings.",
+          "Dismiss"
+        );
+        return;
+      }
       try {
         // Convert the file
         const udlDocs: { name: string; content: string[] }[] = await api

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -15,7 +15,7 @@ export async function previewXMLAsUDL(textEditor: vscode.TextEditor, auto = fals
       const api = new AtelierAPI(uri);
       if (!api.active) {
         vscode.window.showErrorMessage(
-          "Unsuccessful connection to the server. Please check your server connection settings.",
+          "'Preview XML as UDL' command requires an active server connection.",
           "Dismiss"
         );
         return;


### PR DESCRIPTION
Show an error if the API is not active when selecting "Preview XML as UDL" on a file that is not connected to the remote server.