### PR TITLE
Improve bracket pair colorization of Embedded SQL

### DIFF
--- a/syntaxes/objectscript.tmLanguage.json
+++ b/syntaxes/objectscript.tmLanguage.json
@@ -60,16 +60,31 @@
     "embeddedSQL": {
       "patterns": [
         {
-          "begin": "(?i)(&sql)(\\()",
+          "begin": "(?i)((?:&|##)sql)(\\()",
+          "end": "\\)",
           "beginCaptures": {
             "1": { "name": "keyword.special.sql.objectscript" },
             "2": { "name": "punctuation.objectscript" }
           },
-          "patterns": [{ "include": "source.sql" }],
+          "endCaptures": { "0": { "name": "punctuation.objectscript" } },
           "contentName": "meta.embedded.block.sql",
-          "end": "\\)"
+          "applyEndPatternLast": 1,
+          "patterns": [
+            { "include": "#embeddedSQL-brackets" },
+            { "include": "source.sql" }
+          ]
         }
-      ]
+      ],
+      "repository": {
+        "embeddedSQL-brackets": {
+          "begin": "(?<=\\()(?!\\G)",
+          "end": "\\)",
+          "patterns": [
+            { "include": "#embeddedSQL-brackets" },
+            { "include": "source.sql" }
+          ]
+        }
+      }
     },
     "embeddedJS": {
       "patterns": [


### PR DESCRIPTION
This PR implements the suggested fix from https://github.com/microsoft/vscode/issues/248823#issuecomment-2883653569. This will not affect the semantic token-based coloring provided by the Language Server.