### PR TITLE
An alternative for autoAdjustName

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "3.0.0-SNAPSHOT",
+  "version": "3.0.3-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "3.0.0-SNAPSHOT",
+      "version": "3.0.3-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1476,9 +1476,19 @@
           "default": false
         },
         "objectscript.autoAdjustName": {
-          "markdownDescription": "Automatically modify the class name or ROUTINE header of a file in a client-side workspace folder to match the file's path when copying or moving a file. Uses the `#objectscript.export#` settings to determine the new name.",
-          "type": "boolean",
-          "default": false
+          "markdownDescription": "Automatically modify the class name or ROUTINE header of a file in a client-side workspace folder to match the file's path when: (Uses the `#objectscript.export#` settings to determine the new name.)",
+          "type": "string",
+          "enum": [
+              "Never",
+              "Create",
+              "Create, Copy and Move"
+            ],
+            "enumDescriptions": [
+              "Do not automatically adjust the name.",
+              "Create a matching class name / ROUTINE header when the file is first created.",
+              "Create or update an existing class name / ROUTINE header when the file is created, copied or moved."
+            ],
+          "default": "Create"
         },
         "objectscript.compileOnSave": {
           "description": "Automatically compile an InterSystems file when saved in the editor.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1263,10 +1263,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
               return;
             }
             const sourceContent = await vscode.workspace.fs.readFile(uri);
-            if (
-              sourceContent.length &&
-              !vscode.workspace.getConfiguration("objectscript").get<boolean>("autoAdjustName")
-            ) {
+            if (!vscode.workspace.getConfiguration("objectscript").get<boolean>("autoAdjustName")) {
               // Don't modify a file with content unless the user opts in
               return;
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1262,9 +1262,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
               // No workspace folders are open
               return;
             }
-            const sourceContent = await vscode.workspace.fs.readFile(uri);
-            if (!vscode.workspace.getConfiguration("objectscript").get<boolean>("autoAdjustName")) {
+            if (vscode.workspace.getConfiguration("objectscript").get<string>("autoAdjustName") === "Never") {
               // Don't modify a file with content unless the user opts in
+              return;
+            }
+            const sourceContent = await vscode.workspace.fs.readFile(uri);
+            if (
+              sourceContent.length > 0 &&
+              vscode.workspace.getConfiguration("objectscript").get<string>("autoAdjustName") === "Create"
+            ) {
+              // It has content, but user opted to not modify existing files
               return;
             }
             const workspacePath = uriOfWorkspaceFolder(workspace).fsPath;


### PR DESCRIPTION
This PR fixes #1559

![image](https://github.com/user-attachments/assets/a0ce301d-aaf8-42ec-b032-4480a223aca9)

We could turn autoAdjustName into a selectable setting. 
The default option, Create, would adjust names only when a file is created—matching the current behavior when the flag is set to false. 
Choosing Create, Copy, and Move would mimic the behavior of true. 
Finally, selecting Never would leave files on disk exactly as they are, which is the outcome I personally prefer.

