### PR TITLE
Debugger improvements

### DIFF
--- a/src/utils/documentIndex.ts
+++ b/src/utils/documentIndex.ts
@@ -401,3 +401,8 @@ export function allDocumentsInWorkspace(wsFolder: vscode.WorkspaceFolder): strin
   const index = wsFolderIndex.get(wsFolder.uri.toString());
   return index ? Array.from(index.documents.keys()) : [];
 }
+
+/** Get the class/routine name of the document in `uri` */
+export function getDocumentForUri(uri: vscode.Uri): string {
+  return wsFolderIndex.get(vscode.workspace.getWorkspaceFolder(uri)?.uri.toString())?.uris.get(uri.toString());
+}


### PR DESCRIPTION
- Fix the automatic termination of REST and unit test debug sessions (issue reported to the WRC)
- Prevent VS Code from showing a `Create File` button for files that are deployed (issue reported to the WRC)
- Don't attempt to set a breakpoint that's from a file in a different workspace folder
- Fix debugging files in a client-side virtual workspace folder
- Explicitly report failure to set a breakpoint
- Use the document index to get determine the name of a document in a local file
- Cache the contents of files fetched during a debug session