### PR TITLE
Fix comparing of local and server versions of web app files

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -168,6 +168,7 @@ What do you want to do?`,
                     vscode.Uri.file(file.name).with({
                       scheme: OBJECTSCRIPT_FILE_SCHEMA,
                       authority: file.workspaceFolder,
+                      query: file.name.includes("/") ? "csp" : "",
                     }),
                     file.uri,
                     `Server • ${file.name} ↔ Local • ${file.fileName}`


### PR DESCRIPTION
This PR fixes an [issue reported on the DC](https://community.intersystems.com/post/vscode-csp-compare-server-failed).