### PR TITLE
Fix creation of new file header when `objectscript.export.folder` is empty

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1284,7 +1284,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
             const filePathNoWorkspaceArr = uri.fsPath.replace(workspacePath + path.sep, "").split(path.sep);
             const { folder, addCategory } = config("export", workspace);
             const expectedFolder = typeof folder === "string" && folder.length ? folder : null;
-            const expectedFolderArr = expectedFolder.split(path.sep);
+            const expectedFolderArr = expectedFolder ? expectedFolder.split(path.sep) : [];
             if (
               expectedFolder !== null &&
               filePathNoWorkspaceArr.slice(0, expectedFolderArr.length).join(path.sep) === expectedFolder


### PR DESCRIPTION
This PR fixes the issue discovered in #1603