### PR TITLE
Better telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "vscode-objectscript",
-  "version": "3.0.0-SNAPSHOT",
+  "version": "3.0.5-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "3.0.0-SNAPSHOT",
+      "version": "3.0.5-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@vscode/debugadapter": "^1.68.0",
         "@vscode/debugprotocol": "^1.68.0",
+        "@vscode/extension-telemetry": "^1.0.0",
         "@xmldom/xmldom": "^0.9.8",
         "axios": "^1.8.4",
         "core-js": "^3.41.0",
@@ -20,7 +21,6 @@
         "minimatch": "^10.0.1",
         "node-cmd": "^5.0.0",
         "vscode-cache": "^0.3.0",
-        "vscode-extension-telemetry": "^0.1.6",
         "ws": "^8.18.1"
       },
       "devDependencies": {
@@ -423,6 +423,130 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@microsoft/1ds-core-js": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.9.tgz",
+      "integrity": "sha512-T8s5qROH7caBNiFrUpN8vgC6wg7QysVPryZKprgl3kLQQPpoMFM6ffIYvUWD74KM9fWWLU7vzFFNBWDBsrTyWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.3.9",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/1ds-post-js": {
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.9.tgz",
+      "integrity": "sha512-BvxI4CW8Ws+gfXKy+Y/9pmEXp88iU1GYVjkUfqXP7La59VHARTumlG5iIgMVvaifOrvSW7G6knvQM++0tEfMBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "4.3.9",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.9.tgz",
+      "integrity": "sha512-/yEgSe6vT2ycQJkXu6VF04TB5XBurk46ECV7uo6KkNhWyDEctAk1VDWB7EqXYdwLhKMbNOYX1pvz7fj43fGNqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-common": "3.3.9",
+        "@microsoft/applicationinsights-core-js": "3.3.9",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.9.tgz",
+      "integrity": "sha512-IgruOuDBxmBK9jYo7SqLJG7Z9OwmAmlvHET49srpN6pqQlEjRpjD1nfA3Ps4RSEbF89a/ad2phQaBp8jvm122g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.3.9",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.9.tgz",
+      "integrity": "sha512-xliiE9H09xCycndlua4QjajN8q5k/ET6VCv+e0Jjodxr9+cmoOP/6QY9dun9ptokuwR8TK0qOaIJ8z4fgslVSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-basic": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.9.tgz",
+      "integrity": "sha512-8tLaAgsCpWjoaxit546RqeuECnHQPBLnOZhzTYG76oPG1ku7dNXaRNieuZLbO+XmAtg/oxntKLAVoPND8NRgcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-channel-js": "3.3.9",
+        "@microsoft/applicationinsights-common": "3.3.9",
+        "@microsoft/applicationinsights-core-js": "3.3.9",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.4 < 2.x",
+        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+      "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.4.tgz",
+      "integrity": "sha512-IBTyj29GwGlxfzXw2NPnzty+w0Adx61Eze1/lknH/XIVdxtF9UnOpk76tnrHXWa6j84a1RR9hsOcHQPFv9qJjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.11.6 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.5.tgz",
+      "integrity": "sha512-JPQZWPKQJjj7kAftdEZL0XDFfbMgXCGiUAZe0d7EhLC3QlXTlZdSckGqqRIQ2QNl0VTEZyZUvRBw6Ednw089Fw==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -852,6 +976,20 @@
         "dts": "index.js"
       }
     },
+    "node_modules/@vscode/extension-telemetry": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.0.0.tgz",
+      "integrity": "sha512-vaTZE65zigWwSWYB6yaZUAyVC/Ux+6U82hnzy/ejuS/KpFifO+0oORNd5yAoPeIRnYjvllM6ES3YlX4K5tUuww==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/1ds-core-js": "^4.3.4",
+        "@microsoft/1ds-post-js": "^4.3.4",
+        "@microsoft/applicationinsights-web-basic": "^3.3.4"
+      },
+      "engines": {
+        "vscode": "^1.75.0"
+      }
+    },
     "node_modules/@vscode/test-electron": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.4.1.tgz",
@@ -1213,17 +1351,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/applicationinsights": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
-      "dependencies": {
-        "cls-hooked": "^4.2.2",
-        "continuation-local-storage": "^3.2.1",
-        "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.3"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1358,37 +1485,6 @@
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true
-    },
-    "node_modules/async-hook-jl": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
-      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
-      "dependencies": {
-        "stack-chain": "^1.3.7"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3"
-      }
-    },
-    "node_modules/async-listener": {
-      "version": "0.6.10",
-      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
-      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
-      "dependencies": {
-        "semver": "^5.3.0",
-        "shimmer": "^1.1.0"
-      },
-      "engines": {
-        "node": "<=0.11.8 || >0.11.10"
-      }
-    },
-    "node_modules/async-listener/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1767,27 +1863,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/cls-hooked": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
-      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
-      "dependencies": {
-        "async-hook-jl": "^1.7.6",
-        "emitter-listener": "^1.0.1",
-        "semver": "^5.4.1"
-      },
-      "engines": {
-        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
-      }
-    },
-    "node_modules/cls-hooked/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1834,15 +1909,6 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
-    },
-    "node_modules/continuation-local-storage": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
-      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
-      "dependencies": {
-        "async-listener": "^0.6.0",
-        "emitter-listener": "^1.1.1"
-      }
     },
     "node_modules/core-js": {
       "version": "3.41.0",
@@ -2009,30 +2075,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/diagnostic-channel": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.2.0.tgz",
-      "integrity": "sha1-zJmvlhLCP7H/8TYSxy8sv6qNWhc=",
-      "dependencies": {
-        "semver": "^5.3.0"
-      }
-    },
-    "node_modules/diagnostic-channel-publishers": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.5.tgz",
-      "integrity": "sha512-AOIjw4T7Nxl0G2BoBPhkQ6i7T4bUd9+xvdYizwvG7vVAM1dvr+SDrcUudlmzwH0kbEwdR2V1EcnKT0wAeYLQNQ==",
-      "peerDependencies": {
-        "diagnostic-channel": "*"
-      }
-    },
-    "node_modules/diagnostic-channel/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
-      }
-    },
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -2054,14 +2096,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.63.tgz",
       "integrity": "sha512-ddeXKuY9BHo/mw145axlyWjlJ1UBt4WK3AlvkT7W2AbqfRQoacVoRUCF6wL3uIx/8wT9oLKXzI+rFqHHscByaA==",
       "dev": true
-    },
-    "node_modules/emitter-listener": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
-      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
-      "dependencies": {
-        "shimmer": "^1.2.0"
-      }
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5244,11 +5278,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
@@ -5297,11 +5326,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/stack-chain": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
-      "integrity": "sha1-0ZLJ/06moiyUxN1FkXHj8AzqEoU="
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
@@ -5664,8 +5688,7 @@
     "node_modules/tslib": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
-      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "dev": true
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5835,17 +5858,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/vscode-cache/-/vscode-cache-0.3.0.tgz",
       "integrity": "sha1-fMOWZOvZnTcDAwaLibxMlWFGZ8A="
-    },
-    "node_modules/vscode-extension-telemetry": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.7.tgz",
-      "integrity": "sha512-pZuZTHO9OpsrwlerOKotWBRLRYJ53DobYb7aWiRAXjlqkuqE+YJJaP+2WEy8GrLIF1EnitXTDMaTAKsmLQ5ORQ==",
-      "dependencies": {
-        "applicationinsights": "1.7.4"
-      },
-      "engines": {
-        "vscode": "^1.5.0"
-      }
     },
     "node_modules/watchpack": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "InterSystems ObjectScript language support for Visual Studio Code",
   "version": "3.0.5-SNAPSHOT",
   "icon": "images/logo.png",
-  "aiKey": "9cd75d51-697c-406c-a929-2bcf46e97c64",
+  "aiKey": "InstrumentationKey=9cd75d51-697c-406c-a929-2bcf46e97c64;IngestionEndpoint=https://eastus2-4.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus2.livediagnostics.monitor.azure.com/;ApplicationId=a431c56f-8ccc-4b99-b5e9-fce3763215b1",
   "categories": [
     "Programming Languages",
     "Other",
@@ -1821,6 +1821,7 @@
   "dependencies": {
     "@vscode/debugadapter": "^1.68.0",
     "@vscode/debugprotocol": "^1.68.0",
+    "@vscode/extension-telemetry": "^1.0.0",
     "@xmldom/xmldom": "^0.9.8",
     "axios": "^1.8.4",
     "core-js": "^3.41.0",
@@ -1829,7 +1830,6 @@
     "minimatch": "^10.0.1",
     "node-cmd": "^5.0.0",
     "vscode-cache": "^0.3.0",
-    "vscode-extension-telemetry": "^0.1.6",
     "ws": "^8.18.1"
   },
   "extensionDependencies": [

--- a/src/commands/serverActions.ts
+++ b/src/commands/serverActions.ts
@@ -6,6 +6,7 @@ import {
   explorerProvider,
   filesystemSchemas,
   FILESYSTEM_SCHEMA,
+  sendStudioAddinTelemetryEvent,
 } from "../extension";
 import {
   connectionTarget,
@@ -246,6 +247,7 @@ export async function serverActions(): Promise<void> {
               title: `Pick a Studio Add-In to open for server: ${connInfo}`,
             });
             if (addin) {
+              sendStudioAddinTelemetryEvent(addin.label);
               const token = await getCSPToken(api, addin.id);
               let params = `Namespace=${nsEncoded}`;
               params += `&User=${encodeURIComponent(username)}`;

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as Atelier from "../api/atelier";
-import { clsLangId, extensionId, filesystemSchemas, lsExtensionId } from "../extension";
+import { clsLangId, extensionId, filesystemSchemas, lsExtensionId, sendUnitTestTelemetryEvent } from "../extension";
 import {
   getFileText,
   handleError,
@@ -416,6 +416,7 @@ async function runHandler(
       // Need a root to continue
       return;
     }
+    sendUnitTestTelemetryEvent(root.uri, debug);
 
     // Add the initial items to the queue to process
     const queue: vscode.TestItem[] = [];

--- a/src/commands/webSocketTerminal.ts
+++ b/src/commands/webSocketTerminal.ts
@@ -3,7 +3,7 @@ import WebSocket = require("ws");
 
 import { AtelierAPI } from "../api";
 import { connectionTarget, currentFile, getWsServerConnection, handleError, notIsfs, outputChannel } from "../utils";
-import { config, iscIcon, resolveConnectionSpec } from "../extension";
+import { config, iscIcon, resolveConnectionSpec, sendLiteTerminalTelemetryEvent } from "../extension";
 
 const NO_ELIGIBLE_CONNECTIONS =
   "Lite Terminal requires an active server connection to InterSystems IRIS version 2023.2 or above.";
@@ -745,6 +745,7 @@ function terminalConfigForUri(
     return;
   }
 
+  sendLiteTerminalTelemetryEvent(throwErrors ? "profile" : "command");
   return {
     name: api.config.serverName && api.config.serverName != "" ? api.config.serverName : "iris",
     location:

--- a/src/debug/debugSession.ts
+++ b/src/debug/debugSession.ts
@@ -17,7 +17,7 @@ import { DebugProtocol } from "@vscode/debugprotocol";
 import WebSocket = require("ws");
 import { AtelierAPI } from "../api";
 import * as xdebug from "./xdebugConnection";
-import { lsExtensionId, schemas } from "../extension";
+import { lsExtensionId, schemas, sendDebuggerTelemetryEvent } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { formatPropertyValue } from "./utils";
 import { isfsConfig } from "../utils/FileProviderUtil";
@@ -263,6 +263,7 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
       this._isLaunch = true;
       const debugTarget = `${this._namespace}:${args.program}`;
       await this._connection.sendFeatureSetCommand("debug_target", debugTarget, true);
+      sendDebuggerTelemetryEvent("launch");
     } catch (error) {
       this.sendErrorResponse(response, error);
       return;
@@ -300,6 +301,7 @@ export class ObjectScriptDebugSession extends LoggingDebugSession {
           stopped = await this._isStopped();
         }
       }
+      sendDebuggerTelemetryEvent(this._isCsp ? "rest" : this._isUnitTest ? "unittest" : "attach");
     } catch (error) {
       this.sendErrorResponse(response, error);
       return;

--- a/src/providers/LowCodeEditorProvider.ts
+++ b/src/providers/LowCodeEditorProvider.ts
@@ -3,7 +3,7 @@ import { lt } from "semver";
 import { AtelierAPI } from "../api";
 import { loadChanges } from "../commands/compile";
 import { StudioActions } from "../commands/studio";
-import { clsLangId } from "../extension";
+import { clsLangId, sendLowCodeTelemetryEvent } from "../extension";
 import { currentFile, notIsfs, openLowCodeEditors, outputChannel } from "../utils";
 
 export class LowCodeEditorProvider implements vscode.CustomTextEditorProvider {
@@ -79,6 +79,7 @@ export class LowCodeEditorProvider implements vscode.CustomTextEditorProvider {
       // Class exists but is not a rule or DTL class
       return this._errorMessage(`${className} is neither a rule definition class nor a DTL transformation class.`);
     }
+    sendLowCodeTelemetryEvent(webApp == this._rule ? "rule" : "dtl", document.uri.scheme);
 
     // Add this document to the Set of open low-code editors
     const documentUriString = document.uri.toString();

--- a/src/utils/documentIndex.ts
+++ b/src/utils/documentIndex.ts
@@ -15,6 +15,7 @@ import {
 import { isText } from "istextorbinary";
 import { AtelierAPI } from "../api";
 import { compile, importFile } from "../commands/compile";
+import { sendClientSideSyncTelemetryEvent } from "../extension";
 
 interface WSFolderIndex {
   /** The `FileSystemWatcher` for this workspace folder */
@@ -227,6 +228,7 @@ export async function indexWorkspaceFolder(wsFolder: vscode.WorkspaceFolder): Pr
       change = await updateIndexForDocument(uri, documents, uris);
     } else if (sync && isImportableLocalFile(uri)) {
       change.addedOrChanged = await getCurrentFile(uri);
+      sendClientSideSyncTelemetryEvent(change.addedOrChanged.fileName.split(".").pop().toLowerCase());
     }
     if (!sync || (!change.addedOrChanged && !change.removed)) return;
     if (change.addedOrChanged) {


### PR DESCRIPTION
Currently this extension collects very little telemetry. Better telemetry will help InterSystems identity and prioritize enhancements that will make the most impact for our users. The top level bullet points correspond to telemetry events, and the second level corresponds to the properties sent for that event.

- `extensionActivated` Sent when extension is activated.
  - `languageServerVersion` May be undefined.
  - `serverManagerVersion`
  - `config.explorer.alwaysShowServerCopy` These are all stringified booleans with the value of the corresponding setting.
  - `config.autoAdjustName`
  - `config.autoShowTerminal`
  - `config.suppressCompileMessages`
  - `config.suppressCompileErrorMessages`
  - `config.autoPreviewXML`
  - `config.showGeneratedFileDecorations`
  - `config.showProposedApiPrompt`
- `commandExecuted` Sent when almost any of our ~75 commands are executed
  - `commandId`
- `studioAddInOpened` Sent when a user opens a Studio Add-In from the Server Actions menu.
  - `addInName` The name of the Add-In
- `workspaceFolder` Sent for all workspace folders present at activation and any that are added later. All but `scheme`, `config.syncLocalChanges`, and `serverVersion` are stringified booleans.
  - `scheme` The scheme of the folder's Uri
  - `serverVersion` The semver-compatible version string of the server, if a connection is established ("2025.1.0"). Not the full `$ZVERSION` string.
  - `added` If the folder was added after activation
  - `isWeb` If this is a web application folder. Defined for server-side folders only.
  - `isProject` If this is a project folder. Defined for server-side folders only.
  - `hasNs` If this folder's Uri has a ns query parameter. Defined for server-side folders only.
  - `config.syncLocalChanges` The value of the `objectscript.syncLocalChanges` setting in this folder. Defined for client-side folders only.
  - `dockerCompose` If this folder uses docker compose for connection. Defined for client-side folders only.
- `unitTestRun `Sent when a unit test run is started
  - `scheme `The scheme of the root unit test's Uri
  - `debug` If the run is a debug run (stringified boolean)
  - `clientSideFileSynced` Sent when a non-class or routine client-side file is about to be synced to the server 
  - `fileExt` The file's extension (lowercase)
- `lowCodeEditorOpened` Sent when a low-code editor is opened.
  - `scheme` The scheme of the file's Uri
  - `editorType` "rule" or "dtl" for now.
- `debuggerStarted` Sent when the debugger is started.
  - `debugType` "launch", "attach", "rest", or "unittest"
- `liteTerminalStarted` Sent when the Lite Terminal is started.
  - `terminalOrigin` Where the terminal was opened from. "profile" or "command".
  - `config.webSocketTerminal.syntaxColoring` Stringified boolean containing the value of the `objectscript.webSocketTerminal.syntaxColoring` setting