### PR TITLE
Add `objectscript.unitTest.enabled` setting for better coexistence with other testing extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1526,6 +1526,11 @@
           "type": "boolean",
           "default": true
         },
+        "objectscript.unitTest.enabled": {
+          "description": "Controls whether the unit testing features are available.",
+          "type": "boolean",
+          "default": true
+        },
         "objectscript.unitTest.relativeTestRoots": {
           "description": "Paths to where client-side test classes are stored. Relative to the workspace folder root.",
           "type": "array",

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -923,7 +923,27 @@ function configureHandler(): void {
 }
 
 /** Set up the `TestController` and all of its dependencies. */
-export function setUpTestController(): vscode.Disposable[] {
+export function setUpTestController(context: vscode.ExtensionContext): vscode.Disposable[] {
+  // If currently disabled, just create a mechanism to activate when the setting changes
+  if (vscode.workspace.getConfiguration("objectscript.unitTest").get("enabled") === false) {
+    const disposablesWhenDisabled = [
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration("objectscript.unitTest")) {
+          if (vscode.workspace.getConfiguration("objectscript.unitTest").get("enabled") === true) {
+            // Set myself up as active
+            const disposablesWhenEnabled = setUpTestController(context);
+            context.subscriptions.push(...disposablesWhenEnabled);
+            // Clean up after inactive state
+            disposablesWhenDisabled.forEach((disposable) => {
+              disposable.dispose();
+            });
+            return;
+          }
+        }
+      }),
+    ];
+    return disposablesWhenDisabled;
+  }
   // Create and set up the test controller
   const testController = vscode.tests.createTestController(extensionId, "ObjectScript");
   testController.resolveHandler = async (item?: vscode.TestItem) => {
@@ -1049,8 +1069,8 @@ export function setUpTestController(): vscode.Disposable[] {
     return result;
   };
 
-  // Register disposables
-  return [
+  // Gather disposables
+  const disposables = [
     testController,
     runProfile,
     debugProfile,
@@ -1129,5 +1149,25 @@ export function setUpTestController(): vscode.Disposable[] {
         if (await deleteItemForUri(file.oldUri)) addItemForClassUri(testController, file.newUri);
       })
     ),
+  ];
+
+  return [
+    ...disposables,
+    // Add a listener to disable myself if the setting changes
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration("objectscript.unitTest")) {
+        if (vscode.workspace.getConfiguration("objectscript.unitTest").get("enabled") === false) {
+          // Remove my active self and clean up
+          testController.dispose();
+          disposables.forEach((disposable) => {
+            disposable.dispose();
+          });
+          // Create a stub self that will reactivate when enabled again
+          const disposablesWhenEnabled = setUpTestController(context);
+          context.subscriptions.push(...disposablesWhenEnabled);
+          return;
+        }
+      }
+    }),
   ];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1856,7 +1856,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         }
       }
     }),
-    ...setUpTestController(),
+    ...setUpTestController(context),
     vscode.commands.registerCommand("vscode-objectscript.reopenInLowCodeEditor", (uri: vscode.Uri) => {
       if (vscode.window.activeTextEditor?.document.uri.toString() == uri.toString()) {
         vscode.commands

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1918,6 +1918,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     "config.autoPreviewXML": String(conf.get("autoPreviewXML")),
     "config.showGeneratedFileDecorations": String(conf.get("showGeneratedFileDecorations")),
     "config.showProposedApiPrompt": String(conf.get("showProposedApiPrompt")),
+    "config.unitTest.enabled": String(conf.get("unitTest.enabled")),
   });
   sendWsFolderTelemetryEvent(vscode.workspace.workspaceFolders);
 


### PR DESCRIPTION
Currently an ISFS-type workspace that wants to use my InterSystems Testing Manager extension also gets a superfluous root entry in the Test Explorer from this extension.

The new setting will allow this to be turned off at a per-workspace level or above.