### PR TITLE
Fix CSP files not being included in server side search results

### DIFF
--- a/src/providers/FileSystemProvider/TextSearchProvider.ts
+++ b/src/providers/FileSystemProvider/TextSearchProvider.ts
@@ -676,7 +676,7 @@ export class TextSearchProvider implements vscode.TextSearchProvider {
                 if (token.isCancellationRequested) {
                   return;
                 }
-                if (project != undefined && file.doc.includes("/")) {
+                if (project && file.doc.includes("/")) {
                   // Check if this web app file is in the project
                   if (!projectList.includes(file.doc.slice(1))) {
                     // This web app file isn't in the project, so ignore its matches


### PR DESCRIPTION
Bug with the expected value of "projects". This was leading to projectList being undefined and throwing an error. Earlier logic to populate projectList uses if (project) {, so using if (project && ... here keeps the checks consistent. isfsConfig() defaults project to "", which is why it is in this state. The following logic is used if apiVersion >= 6, which Cache is not: project: project ? project : undefined, // Needs to be undefined if project is an empty string. This means special handling is needed in this case