### PR TITLE
Fully stringify `AggregateError` when writing to the Output channel

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -57,6 +57,11 @@ export const identifierRegex = /^(?:%|\p{L})[\p{L}\d]*$/u;
  */
 export function stringifyError(error): string {
   try {
+    if (error instanceof AggregateError) {
+      // Need to stringify the inner errors
+      const errs = error.errors.map(stringifyError).filter((s) => s != "");
+      return errs.length ? `AggregateError:\n- ${errs.join("\n- ")}` : "";
+    }
     return (
       error == undefined
         ? ""


### PR DESCRIPTION
Users have seen `AggregateError` written to he Output channel, but without the inner errors this is useless. This PR adds the inner errors to the stringified representation of `AggregateError`s.