### PR TITLE
Add logging for file change events synced to the server in client-side folders

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -181,13 +181,9 @@ What do you want to do?`,
                 // Overwrite
                 return importFile(file, true, true);
               case "Pull Server Changes":
-                outputChannel.appendLine(`${file.name}: Loading changes from server`);
-                outputChannel.show(true);
                 loadChanges([file]);
                 return Promise.reject();
               case "Cancel":
-                outputChannel.appendLine(`${file.name}: Import and Compile canceled by user`);
-                outputChannel.show(true);
                 return Promise.reject();
             }
             return Promise.reject();

--- a/src/commands/connectFolderToServerNamespace.ts
+++ b/src/commands/connectFolderToServerNamespace.ts
@@ -7,7 +7,7 @@ import {
   serverManagerApi,
   resolveUsernameAndPassword,
 } from "../extension";
-import { handleError, isUnauthenticated, notIsfs } from "../utils";
+import { handleError, isUnauthenticated, notIsfs, displayableUri } from "../utils";
 
 interface ConnSettings {
   server: string;
@@ -131,8 +131,8 @@ export async function connectFolderToServerNamespace(): Promise<void> {
     // the server may be configured at the workspace folder level.
     const answer = await vscode.window.showQuickPick(
       [
-        { label: `Workspace Folder ${folder.name}`, detail: folder.uri.toString(true) },
-        { label: "Workspace File", detail: vscode.workspace.workspaceFile.toString(true) },
+        { label: `Workspace Folder ${folder.name}`, detail: displayableUri(folder.uri) },
+        { label: "Workspace File", detail: displayableUri(vscode.workspace.workspaceFile) },
       ],
       { title: "Store the server connection at the workspace or folder level?" }
     );

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -11,6 +11,7 @@ import {
   lastUsedLocalUri,
   notNull,
   outputChannel,
+  displayableUri,
   RateLimiter,
   replaceFile,
   stringifyError,
@@ -96,7 +97,7 @@ async function exportFile(wsFolderUri: vscode.Uri, namespace: string, name: stri
   let fileUri = vscode.Uri.file(fileName);
   if (wsFolderUri.scheme != "file") fileUri = wsFolderUri.with({ path: fileUri.path });
   const log = (status: string) =>
-    outputChannel.appendLine(`Export '${name}' to '${fileUri.toString(true)}' - ${status}`);
+    outputChannel.appendLine(`Export '${name}' to '${displayableUri(fileUri)}' - ${status}`);
 
   try {
     const data = await api.getDoc(name, wsFolderUri);
@@ -380,7 +381,7 @@ export async function exportDocumentsToXMLFile(): Promise<void> {
       const xmlContent = await api.actionXMLExport(documents).then((data) => data.result.content);
       // Save the file
       await replaceFile(uri, xmlContent);
-      outputChannel.appendLine(`Exported to ${uri.scheme == "file" ? uri.fsPath : uri.toString(true)}`);
+      outputChannel.appendLine(`Exported to ${displayableUri(uri)}`);
     }
   } catch (error) {
     handleError(error, "Error executing 'Export Documents to XML File...' command.");

--- a/src/commands/newFile.ts
+++ b/src/commands/newFile.ts
@@ -3,7 +3,7 @@ import path = require("path");
 import { AtelierAPI } from "../api";
 import { FILESYSTEM_SCHEMA } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
-import { replaceFile, getWsFolder, handleError } from "../utils";
+import { replaceFile, getWsFolder, handleError, displayableUri } from "../utils";
 import { getFileName } from "./export";
 import { getUrisForDocument } from "../utils/documentIndex";
 
@@ -949,7 +949,7 @@ Parameter ENSPURGE As BOOLEAN = 1;
         const inputBox = vscode.window.createInputBox();
         inputBox.ignoreFocusOut = true;
         inputBox.buttons = [{ iconPath: new vscode.ThemeIcon("save-as"), tooltip: "Show 'Save As' dialog" }];
-        inputBox.prompt = `The path is relative to the workspace folder root (${wsFolder.uri.toString(true)}). Intermediate folders that do not exist will be created. Click the 'Save As' icon to open the standard save dialog instead.`;
+        inputBox.prompt = `The path is relative to the workspace folder root (${displayableUri(wsFolder.uri)}). Intermediate folders that do not exist will be created. Click the 'Save As' icon to open the standard save dialog instead.`;
         inputBox.title = "Enter a file path for the new class";
         inputBox.value = localUri.path.slice(wsFolder.uri.path.length);
         inputBox.valueSelection = [inputBox.value.length, inputBox.value.length];

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -6,6 +6,7 @@ import {
   handleError,
   methodOffsetToLine,
   notIsfs,
+  displayableUri,
   stripClassMemberNameQuotes,
   uriIsParentOf,
 } from "../utils";
@@ -396,7 +397,7 @@ async function runHandler(
         roots.map((i) => {
           return {
             label: i.label,
-            detail: i.uri.toString(true),
+            detail: displayableUri(i.uri),
             item: i,
           };
         }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -108,6 +108,7 @@ import {
   addWsServerRootFolderData,
   getWsFolder,
   exportedUris,
+  displayableUri,
 } from "./utils";
 import { ObjectScriptDiagnosticProvider } from "./providers/ObjectScriptDiagnosticProvider";
 import { DocumentLinkProvider } from "./providers/DocumentLinkProvider";
@@ -1163,7 +1164,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       } catch (error) {
         handleError(
           error,
-          `Failed to overwrite contents of file '${file.uri.toString(true)}' with server copy of '${file.fileName}'.`
+          `Failed to overwrite contents of file '${displayableUri(file.uri)}' with server copy of '${file.fileName}'.`
         );
       }
     }),

--- a/src/utils/documentIndex.ts
+++ b/src/utils/documentIndex.ts
@@ -11,6 +11,7 @@ import {
   notIsfs,
   openLowCodeEditors,
   outputChannel,
+  displayableUri,
 } from ".";
 import { isText } from "istextorbinary";
 import { AtelierAPI } from "../api";
@@ -67,11 +68,11 @@ async function getCurrentFile(
     // or a TypeError from decode(). Don't log TypeError
     // since the file may be a non-text file that has
     // an extension that we interpret as text (like cls or mac).
-    // Also don't log "FileNotFound" errors, which are probably
-    // caused by concurrency issues. We should ignore such files
-    // rather than alerting the user.
-    if (error instanceof vscode.FileSystemError && error.code != "FileNotFound") {
-      outputChannel.appendLine(`Failed to read contents of '${uri.toString(true)}': ${error.toString()}`);
+    // Don't log "FileNotFound" errors, which are probably
+    // caused by concurrency issues, or "FileIsADirectory"
+    // issues, since we don't care about directories.
+    if (error instanceof vscode.FileSystemError && !["FileNotFound", "FileIsADirectory"].includes(error.code)) {
+      outputChannel.appendLine(`Failed to read contents of '${displayableUri(uri)}': ${error.toString()}`);
     }
   }
 }
@@ -114,17 +115,9 @@ function generateDeleteFn(wsFolderUri: vscode.Uri): (doc: string) => void {
       docs.length = 0;
       api.deleteDocs(docsCopy).then((data) => {
         let failed = 0;
+        const ts = tsString();
         for (const doc of data.result) {
-          if (doc.status != "" && !doc.status.includes("#16005:")) {
-            // The document was not deleted, so log the error.
-            // Error 16005 means we tried to delete a document
-            // that didn't exist. Since the purpose of this
-            // call was to delete the document, and at the
-            // end the document isn't there, we should ignore
-            // this error so the user doesn't get confused.
-            failed++;
-            outputChannel.appendLine(`${failed == 1 ? "\n" : ""}${doc.status}`);
-          }
+          failed += outputDelete(doc.name, doc.status, ts);
         }
         if (failed > 0) {
           outputChannel.show(true);
@@ -149,6 +142,37 @@ export function storeTouchedByVSCode(uri: vscode.Uri): void {
   if (wsFolder && notIsfs(wsFolder.uri) && uri.scheme == wsFolder.uri.scheme) {
     touchedByVSCode.add(uri.toString());
   }
+}
+
+/** Create a timestamp string for use in a log entry */
+function tsString(): string {
+  const date = new Date();
+  return `${date.toISOString().split("T").shift()} ${date.toLocaleTimeString(undefined, { hour12: false })}`;
+}
+
+/** Output a log entry */
+function output(docName: string, msg: string, ts?: string): void {
+  outputChannel.appendLine(`${ts ?? tsString()} [${docName}] ${msg}`);
+}
+
+/** Output a log entry for a successful import */
+function outputImport(docName: string, uri: vscode.Uri): void {
+  output(docName, `Imported from '${displayableUri(uri)}'`);
+}
+
+/**
+ * Output a log entry for a successful or failed delete.
+ * Does not output a log entry if the file did not exist on the server.
+ * Returns `1` if the deleton failed, else `0`.
+ */
+function outputDelete(docName: string, status: string, ts: string): number {
+  if (status == "") {
+    output(docName, "Deleted", ts);
+  } else if (!status.includes("#16005:")) {
+    output(docName, `Deletion failed: ${status}`, ts);
+    return 1;
+  }
+  return 0;
 }
 
 /** Create index of `wsFolder` and set up a `FileSystemWatcher` to keep the index up to date */
@@ -184,6 +208,10 @@ export async function indexWorkspaceFolder(wsFolder: vscode.WorkspaceFolder): Pr
       // for both watchers, but VS Code will correctly report that the file
       // is in the subfolder workspace folder, so the parent watcher can
       // safely ignore the event.
+      return;
+    }
+    if (!uri.path.split("/").pop().includes(".")) {
+      // Ignore creation and change events for folders
       return;
     }
     const uriString = uri.toString();
@@ -237,6 +265,7 @@ export async function indexWorkspaceFolder(wsFolder: vscode.WorkspaceFolder): Pr
       // Create or update the document on the server
       importFile(change.addedOrChanged)
         .then(() => {
+          outputImport(change.addedOrChanged.name, uri);
           if (conf.get("compileOnSave")) {
             // Compile right away if this document is in the active text editor.
             // This is needed to avoid noticeable latency when a user is editing

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -966,7 +966,7 @@ export async function getWsFolder(
   return vscode.window
     .showQuickPick(
       folders.map((f) => {
-        return { label: f.name, detail: f.uri.toString(true), f };
+        return { label: f.name, detail: displayableUri(f.uri), f };
       }),
       {
         canPickMany: false,
@@ -1006,7 +1006,7 @@ export async function replaceFile(uri: vscode.Uri, content: string | string[] | 
       : new TextEncoder().encode(Array.isArray(content) ? content.join("\n") : content),
   });
   const success = await vscode.workspace.applyEdit(wsEdit);
-  if (!success) throw `Failed to create or replace contents of file '${uri.toString(true)}'`;
+  if (!success) throw `Failed to create or replace contents of file '${displayableUri(uri)}'`;
 }
 
 /** Show the compilation failure error message if required. */
@@ -1023,6 +1023,11 @@ export function compileErrorMsg(conf: vscode.WorkspaceConfiguration): void {
         outputChannel.show(true);
       }
     });
+}
+
+/** Return a string containing the displayable form of `uri` */
+export function displayableUri(uri: vscode.Uri): string {
+  return uri.scheme == "file" ? uri.fsPath : uri.toString(true);
 }
 
 class Semaphore {


### PR DESCRIPTION
- Add logging for file change events in client-side folders. This will log whenever a file is changed or deleted on the server due to a local file system change. Log entries are not triggered by unrelated user-initiated changes like a manual import.
- Add a utility function for creating a displayable form of a `Uri`.
- Prevent errors being logged for folder creation or change events.

Example logs:
```
intersystems-community.vscode-objectscript version 3.0.6-SNAPSHOT activating with proposed APIs available.

2025-09-02 18:04:37 [/csp/user/menu.csp] Imported from '/Users/bsaviano/Desktop/l/csp/user/menu.csp'

Compilation started on 09/02/2025 18:04:37 with qualifiers 'ck'
Compiling file /csp/user/menu.csp
Compiling class csp.menu
Compiling routine csp.menu.1
Compilation finished successfully in 0.044s.
2025-09-02 18:04:49 [/csp/user/b.csp] Imported from '/Users/bsaviano/Desktop/l/csp/user/b.csp'

Compilation started on 09/02/2025 18:04:49 with qualifiers 'ck'
Compiling file /csp/user/b.csp
Compiling class csp.b
Compiling routine csp.b.1
Compilation finished successfully in 0.013s.
2025-09-02 18:05:03 [/csp/user/b.csp] Deleted
```