### PR TITLE
Better error handling when expanding InterSystems and Projects Explorers

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -274,9 +274,13 @@ Would you like to continue?`,
       return;
     }
   }
-  return Promise.all(nodes.map((node) => node.getItems4Export())).then((items) => {
-    return exportList(items.flat(), node.workspaceFolder, nodeNs).then(() => explorerProvider.refresh());
-  });
+  return Promise.all(nodes.map((node) => node.getItems4Export()))
+    .then((items) => {
+      return exportList(items.flat(), node.workspaceFolder, nodeNs).then(() => explorerProvider.refresh());
+    })
+    .catch((error) => {
+      handleError(error, "Error exporting Explorer items.");
+    });
 }
 
 export async function exportCurrentFile(): Promise<any> {


### PR DESCRIPTION
Inspired by the `Servers` tree, we now show items warning that a server connection is inactive or an error occurred when fetching children. In the error case, the tooltip contains the detailed error message. 

<img width="299" height="159" alt="Screenshot 2025-09-12 at 3 39 45 PM" src="https://github.com/user-attachments/assets/d2963a12-c615-41e4-966f-9c204a3c30d1" />
