### PR TITLE
Prevent users from accidentally opening multiple copies of the same class or routine

### DIFF
--- a/src/utils/documentPicker.ts
+++ b/src/utils/documentPicker.ts
@@ -427,9 +427,18 @@ export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<st
       quickPick.enabled = false;
       const item = quickPick.selectedItems[0];
       if (!item || item.label.startsWith("$(")) {
-        const doc = item?.fullName ?? quickPick.value.trim();
+        let doc = item?.fullName ?? quickPick.value.trim();
         if (!item) {
           // The document name came from the value text, so validate it first
+          // Normalize the file extension case for classes and routines
+          doc = [".cls", ".mac", ".int", ".inc"].includes(doc.slice(-4).toLowerCase())
+            ? doc.slice(0, -3) + doc.slice(-3).toLowerCase()
+            : doc;
+          // Expand the short form of %Library classes to the long form
+          doc =
+            doc.startsWith("%") && doc.split(".").length == 2 && doc.slice(-4) == ".cls"
+              ? `%Library.${doc.slice(1)}`
+              : doc;
           api
             .headDoc(doc)
             .then(() => resolve(doc))


### PR DESCRIPTION
This PR fixes an issue reported internally. A developer used `Cmd-O` to open a %Library class using the short alias. This opened a document with a different URI than if he opened it from the files explorer. This confused server-side source control and can confuse users if multiple copies are open at once. This PR fixes the issue by adding validation in our `FileSystemProvider` to reject "non-canonical" URIs. I also modified the `Open InterSystems Document...` command to be more flexible in what it accepts so opening a %Library class using its short alias is accepted and returns the "canonical" URI.