### PR TITLE
Insert file stub snippet when creating a blank client-side class or routine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1503,11 +1503,6 @@
           "type": "boolean",
           "default": false
         },
-        "objectscript.autoAdjustName": {
-          "markdownDescription": "Automatically modify the class name or ROUTINE header of a file in a client-side workspace folder to match the file's path when copying or moving a file. Uses the `#objectscript.export#` settings to determine the new name.",
-          "type": "boolean",
-          "default": false
-        },
         "objectscript.compileOnSave": {
           "description": "Automatically compile an InterSystems file when saved in the editor.",
           "type": "boolean",


### PR DESCRIPTION
This PR fixes #1667. The new behavior when a blank client-side class or routine is created is that a snippet containing a document stub is inserted into the document. The user can then type whatever name they like and then tab to a comment inside the empty body to start editing. The name does not have a default value, so the document won't be synced to the server with a potentially incorrect generated name. An example of how this works can be seen below. I also removed the `objectscript.autoAdjustName` setting so documents created with content already existing will never be modified to use a generated name. 

https://github.com/user-attachments/assets/609eb6d3-18cf-493c-8126-c14467b7a00f

