### PR TITLE
Trigger server-side source control `OpenedDocument` UserAction after a project is modified

### DIFF
--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -888,6 +888,11 @@ export async function modifyProject(
       await api.actionQuery("UPDATE %Studio.Project SET LastModified = NOW() WHERE Name = ?", [project]).catch(() => {
         // Swallow error because VS Code doesn't care about the timestamp
       });
+      // "Re-open" the project to signal to the source control class that it should reconcile the server version
+      // with the version stored in the source control system. This effectively acts like OnAfterSave().
+      await new StudioActions().fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument).catch(() => {
+        // The modification has already been completed so there's no point in showing this error
+      });
     }
   } catch (error) {
     handleError(error, `Failed to modify project '${project}'.`);
@@ -1167,6 +1172,12 @@ export async function modifyProjectMetadata(nodeOrUri: NodeBase | vscode.Uri | u
       newDesc,
       project,
     ]);
+
+    // "Re-open" the project to signal to the source control class that it should reconcile the server version
+    // with the version stored in the source control system. This effectively acts like OnAfterSave().
+    await new StudioActions().fireProjectUserAction(api, project, OtherStudioAction.OpenedDocument).catch(() => {
+      // The modification has already been completed so there's no point in showing this error
+    });
 
     // Refesh the explorer
     projectsExplorerProvider.refresh();

--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -320,7 +320,8 @@ export class StudioActions {
           this.api
             .actionQuery(query, parameters)
             .then(async (data) => {
-              if (action.save && action.id != "6" && !this.name.endsWith(".PRJ") && this.uri) {
+              const isPrj = this.name.toUpperCase().endsWith(".PRJ");
+              if (action.save && action.id != "6" && !isPrj && this.uri) {
                 // Save the requested documents.
                 // Ignore the save flag if this is a project or bulk import action.
                 const bitString: string = action.save.toString().padStart(3, "0");
@@ -354,14 +355,14 @@ export class StudioActions {
               }
               const actionToProcess: UserAction = data.result.content.pop();
 
-              if (actionToProcess.reload) {
+              if (actionToProcess.reload && !isPrj) {
                 await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
               }
 
               const attemptedEditLabel = getOtherStudioActionLabel(OtherStudioAction.AttemptedEdit);
               if (afterUserAction && actionToProcess.errorText !== "") {
                 if (action.label === attemptedEditLabel) {
-                  if (this.name.toUpperCase().endsWith(".PRJ")) {
+                  if (isPrj) {
                     // Store the "answer" so the caller knows there was an error
                     this.projectEditAnswer = "-1";
                   } else if (this.uri) {
@@ -380,7 +381,7 @@ export class StudioActions {
                     // Only revert if we have a URI
                     await vscode.commands.executeCommand("workbench.action.files.revert", this.uri);
                   }
-                  if (this.name.toUpperCase().endsWith(".PRJ")) {
+                  if (isPrj) {
                     // Store the answer. No answer means "allow the edit".
                     this.projectEditAnswer = answer ?? "1";
                   }


### PR DESCRIPTION
This PR fixes #1684 by giving source control class authors a hook to reconcile the server version of a project with the version in the source control system after it has been modified by VS Code. It is not possible to call `OnAfterSave()` due to IRIS limitations.