### PR TITLE
Adopt new VS Code APIs to improve QuickPicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-objectscript",
-  "version": "3.4.0-SNAPSHOT",
+  "version": "3.4.1-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-objectscript",
-      "version": "3.4.0-SNAPSHOT",
+      "version": "3.4.1-SNAPSHOT",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -31,7 +31,7 @@
         "@types/mocha": "^7.0.2",
         "@types/node": "20.17.6",
         "@types/semver": "7.5.4",
-        "@types/vscode": "1.104.0",
+        "@types/vscode": "1.109.0",
         "@types/ws": "8.18.0",
         "@types/xmldom": "^0.1.34",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -57,7 +57,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.104.0"
+        "vscode": "^1.109.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -739,9 +739,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.104.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.104.0.tgz",
-      "integrity": "sha512-0KwoU2rZ2ecsTGFxo4K1+f+AErRsYW0fsp6A0zufzGuhyczc2IoKqYqcwXidKXmy2u8YB2GsYsOtiI9Izx3Tig==",
+      "version": "1.109.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.109.0.tgz",
+      "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     }
   ],
   "engines": {
-    "vscode": "^1.104.0"
+    "vscode": "^1.109.0"
   },
   "enabledApiProposals": [
     "fileSearchProvider",
@@ -1775,7 +1775,7 @@
     "test": "node ./out/test/runTest.js",
     "lint": "eslint src/**",
     "lint-fix": "eslint --fix src/**",
-    "download-api": "dts dev 1.104.0",
+    "download-api": "dts dev 1.109.0",
     "postinstall": "npm run download-api"
   },
   "devDependencies": {
@@ -1786,7 +1786,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "20.17.6",
     "@types/semver": "7.5.4",
-    "@types/vscode": "1.104.0",
+    "@types/vscode": "1.109.0",
     "@types/ws": "8.18.0",
     "@types/xmldom": "^0.1.34",
     "@typescript-eslint/eslint-plugin": "^8.15.0",

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -239,7 +239,7 @@ export async function exportAll(): Promise<any> {
       files = await vscode.window.showQuickPick(files, {
         canPickMany: true,
         ignoreFocusOut: true,
-        placeHolder: "Uncheck a file to exclude it. Press 'Escape' to cancel export.",
+        prompt: "Uncheck a file to exclude it. Press 'Escape' to cancel export.",
         title: "Files to Export",
       });
       if (files === undefined) {
@@ -355,7 +355,7 @@ export async function exportDocumentsToXMLFile(): Promise<void> {
     const confirmed = await new Promise<boolean>((resolve) => {
       const quickPick = vscode.window.createQuickPick();
       quickPick.title = `Export the following ${documents.length > 1 ? `${documents.length} documents` : "document"}?`;
-      quickPick.placeholder = "Click any item to confirm, or 'Escape' to cancel";
+      quickPick.prompt = "Click any item to confirm, or 'Escape' to cancel";
       quickPick.ignoreFocusOut = true;
       quickPick.onDidAccept(() => {
         resolve(true);

--- a/src/commands/project.ts
+++ b/src/commands/project.ts
@@ -427,14 +427,24 @@ async function pickAdditions(
   return new Promise<string[]>((resolve) => {
     let result: string[] = [];
     const quickPick = vscode.window.createQuickPick<PickAdditionsItem>();
-    quickPick.title = `Select items in namespace '${api.ns.toUpperCase()}' to add to project '${project}'.`;
+    quickPick.title = `Select items in namespace '${api.ns}' to add to project '${project}'.`;
     quickPick.ignoreFocusOut = true;
     quickPick.canSelectMany = true;
     quickPick.keepScrollPosition = true;
     quickPick.matchOnDescription = true;
     quickPick.buttons = [
-      { iconPath: new vscode.ThemeIcon("library"), tooltip: "Show system items" },
-      { iconPath: new vscode.ThemeIcon("server-process"), tooltip: "Show generated items" },
+      {
+        iconPath: new vscode.ThemeIcon("library"),
+        tooltip: "System",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
+      {
+        iconPath: new vscode.ThemeIcon("server-process"),
+        tooltip: "Generated",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
     ];
 
     const getCSPRootItems = (): Promise<PickAdditionsItem[]> => {
@@ -548,67 +558,26 @@ async function pickAdditions(
     });
     quickPick.onDidTriggerButton((button) => {
       quickPick.busy = true;
-      if (button.tooltip.charAt(0) == "S") {
-        if (button.tooltip.includes("system")) {
-          // Update the button
-          quickPick.buttons = [
-            { iconPath: new vscode.ThemeIcon("library"), tooltip: "Hide system items" },
-            quickPick.buttons[1],
-          ];
-          // Change value of correct parameter in array
-          sys = "1";
-          if (["RTN", "INC", "OTH"].includes(category)) {
-            parameters[0] = sys;
-          } else if (category != undefined) {
-            parameters[1] = sys;
-          } else {
-            parameters[0] = sys;
-            parameters[4] = sys;
-          }
+      // Change value of correct parameter in array
+      if (button.tooltip == "System") {
+        sys = button.toggle.checked ? "1" : "0";
+        if (["RTN", "INC", "OTH"].includes(category)) {
+          parameters[0] = sys;
+        } else if (category != undefined) {
+          parameters[1] = sys;
         } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: new vscode.ThemeIcon("server-process"), tooltip: "Hide generated items" },
-          ];
-          gen = "1";
-          if (["RTN", "INC", "OTH"].includes(category)) {
-            parameters[1] = gen;
-          } else if (category != undefined) {
-            parameters[2] = gen;
-          } else {
-            parameters[1] = gen;
-            parameters[5] = gen;
-          }
+          parameters[0] = sys;
+          parameters[4] = sys;
         }
       } else {
-        if (button.tooltip.includes("system")) {
-          quickPick.buttons = [
-            { iconPath: new vscode.ThemeIcon("library"), tooltip: "Show system items" },
-            quickPick.buttons[1],
-          ];
-          sys = "0";
-          if (["RTN", "INC", "OTH"].includes(category)) {
-            parameters[0] = sys;
-          } else if (category != undefined) {
-            parameters[1] = sys;
-          } else {
-            parameters[0] = sys;
-            parameters[4] = sys;
-          }
+        gen = button.toggle.checked ? "1" : "0";
+        if (["RTN", "INC", "OTH"].includes(category)) {
+          parameters[1] = gen;
+        } else if (category != undefined) {
+          parameters[2] = gen;
         } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: new vscode.ThemeIcon("server-process"), tooltip: "Show generated items" },
-          ];
-          gen = "0";
-          if (["RTN", "INC", "OTH"].includes(category)) {
-            parameters[1] = gen;
-          } else if (category != undefined) {
-            parameters[2] = gen;
-          } else {
-            parameters[1] = gen;
-            parameters[5] = gen;
-          }
+          parameters[1] = gen;
+          parameters[5] = gen;
         }
       }
       // Refresh the items list

--- a/src/commands/showAllClassMembers.ts
+++ b/src/commands/showAllClassMembers.ts
@@ -125,7 +125,7 @@ SELECT Name, Origin, 'x' AS MemberType, Parent, Internal, 0 AS NotInheritable, M
       }),
       {
         title: `All members of ${cls}`,
-        placeHolder: "Pick a member to show it in the editor",
+        prompt: "Pick a member to show it in the editor",
       }
     );
     if (!member) return;

--- a/src/commands/unitTest.ts
+++ b/src/commands/unitTest.ts
@@ -405,7 +405,7 @@ async function runHandler(
         {
           matchOnDetail: true,
           title: `Cannot ${action} tests from multiple roots at once`,
-          placeHolder: `Pick a root to ${action} tests from`,
+          prompt: `Pick a root to ${action} tests from`,
         }
       );
       if (picked) {

--- a/src/commands/xmlToUdl.ts
+++ b/src/commands/xmlToUdl.ts
@@ -157,7 +157,7 @@ export async function extractXMLFileContents(xmlUri?: vscode.Uri): Promise<void>
         canPickMany: true,
         ignoreFocusOut: true,
         title: "Pick the documents to extract",
-        placeHolder: "Files are created using your 'objectscript.export' settings",
+        prompt: "Files are created using your 'objectscript.export' settings",
       }
     );
     if (docsToExtract == undefined || docsToExtract.length == 0) {

--- a/src/utils/documentPicker.ts
+++ b/src/utils/documentPicker.ts
@@ -89,9 +89,6 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
   let gen: "0" | "1" = "0";
   let map: "0" | "1" = "1";
   const query = "SELECT Name, Type FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,?,0,0,?,,0,?)";
-  const sysBtn = new vscode.ThemeIcon("library");
-  const genBtn = new vscode.ThemeIcon("server-process");
-  const mapBtn = new vscode.ThemeIcon("references");
   const webApps = cspAppsForApi(api);
   const webAppRootItems = webApps.map((app: string) => {
     return {
@@ -117,9 +114,24 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
     quickPick.keepScrollPosition = true;
     quickPick.matchOnDescription = true;
     quickPick.buttons = [
-      { iconPath: sysBtn, tooltip: "Show system documents" },
-      { iconPath: genBtn, tooltip: "Show generated documents" },
-      { iconPath: mapBtn, tooltip: "Hide mapped documents" },
+      {
+        iconPath: new vscode.ThemeIcon("library"),
+        tooltip: "System",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
+      {
+        iconPath: new vscode.ThemeIcon("server-process"),
+        tooltip: "Generated",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
+      {
+        iconPath: new vscode.ThemeIcon("references"),
+        tooltip: "Mapped",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: true },
+      },
     ];
 
     const getRootItems = (): Promise<void> => {
@@ -187,52 +199,12 @@ export async function pickDocuments(api: AtelierAPI, prompt?: string): Promise<s
     quickPick.onDidTriggerButton((button) => {
       quickPick.busy = true;
       quickPick.enabled = false;
-      if (button.tooltip.charAt(0) == "S") {
-        if (button.tooltip.includes("system")) {
-          quickPick.buttons = [
-            { iconPath: sysBtn, tooltip: "Hide system documents" },
-            quickPick.buttons[1],
-            quickPick.buttons[2],
-          ];
-          sys = "1";
-        } else if (button.tooltip.includes("generated")) {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: genBtn, tooltip: "Hide generated documents" },
-            quickPick.buttons[2],
-          ];
-          gen = "1";
-        } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            quickPick.buttons[1],
-            { iconPath: mapBtn, tooltip: "Hide mapped documents" },
-          ];
-          map = "1";
-        }
+      if (button.tooltip == "System") {
+        sys = button.toggle.checked ? "1" : "0";
+      } else if (button.tooltip == "Generated") {
+        gen = button.toggle.checked ? "1" : "0";
       } else {
-        if (button.tooltip.includes("system")) {
-          quickPick.buttons = [
-            { iconPath: sysBtn, tooltip: "Show system documents" },
-            quickPick.buttons[1],
-            quickPick.buttons[2],
-          ];
-          sys = "0";
-        } else if (button.tooltip.includes("generated")) {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: genBtn, tooltip: "Show generated documents" },
-            quickPick.buttons[2],
-          ];
-          gen = "0";
-        } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            quickPick.buttons[1],
-            { iconPath: mapBtn, tooltip: "Show mapped documents" },
-          ];
-          map = "0";
-        }
+        map = button.toggle.checked ? "1" : "0";
       }
       // Refresh the items list
       getRootItems();
@@ -320,9 +292,6 @@ export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<st
   let gen: "0" | "1" = "0";
   let map: "0" | "1" = "1";
   const query = "SELECT Name, Type FROM %Library.RoutineMgr_StudioOpenDialog(?,1,1,?,0,0,?,,0,?)";
-  const sysBtn = new vscode.ThemeIcon("library");
-  const genBtn = new vscode.ThemeIcon("server-process");
-  const mapBtn = new vscode.ThemeIcon("references");
   const webApps = cspAppsForApi(api);
   const webAppRootItems = webApps.map((app: string) => {
     return {
@@ -336,9 +305,24 @@ export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<st
     quickPick.title = `${prompt ? prompt : "Select a document"} in namespace '${api.ns}' on server '${api.serverId}'`;
     quickPick.ignoreFocusOut = true;
     quickPick.buttons = [
-      { iconPath: sysBtn, tooltip: "Show system documents" },
-      { iconPath: genBtn, tooltip: "Show generated documents" },
-      { iconPath: mapBtn, tooltip: "Hide mapped documents" },
+      {
+        iconPath: new vscode.ThemeIcon("library"),
+        tooltip: "System",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
+      {
+        iconPath: new vscode.ThemeIcon("server-process"),
+        tooltip: "Generated",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: false },
+      },
+      {
+        iconPath: new vscode.ThemeIcon("references"),
+        tooltip: "Mapped",
+        location: vscode.QuickInputButtonLocation.Input,
+        toggle: { checked: true },
+      },
     ];
 
     const getRootItems = (): Promise<void> => {
@@ -372,52 +356,12 @@ export async function pickDocument(api: AtelierAPI, prompt?: string): Promise<st
     quickPick.onDidTriggerButton((button) => {
       quickPick.busy = true;
       quickPick.enabled = false;
-      if (button.tooltip.charAt(0) == "S") {
-        if (button.tooltip.includes("system")) {
-          quickPick.buttons = [
-            { iconPath: sysBtn, tooltip: "Hide system documents" },
-            quickPick.buttons[1],
-            quickPick.buttons[2],
-          ];
-          sys = "1";
-        } else if (button.tooltip.includes("generated")) {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: genBtn, tooltip: "Hide generated documents" },
-            quickPick.buttons[2],
-          ];
-          gen = "1";
-        } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            quickPick.buttons[1],
-            { iconPath: mapBtn, tooltip: "Hide mapped documents" },
-          ];
-          map = "1";
-        }
+      if (button.tooltip == "System") {
+        sys = button.toggle.checked ? "1" : "0";
+      } else if (button.tooltip == "Generated") {
+        gen = button.toggle.checked ? "1" : "0";
       } else {
-        if (button.tooltip.includes("system")) {
-          quickPick.buttons = [
-            { iconPath: sysBtn, tooltip: "Show system documents" },
-            quickPick.buttons[1],
-            quickPick.buttons[2],
-          ];
-          sys = "0";
-        } else if (button.tooltip.includes("generated")) {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            { iconPath: genBtn, tooltip: "Show generated documents" },
-            quickPick.buttons[2],
-          ];
-          gen = "0";
-        } else {
-          quickPick.buttons = [
-            quickPick.buttons[0],
-            quickPick.buttons[1],
-            { iconPath: mapBtn, tooltip: "Show mapped documents" },
-          ];
-          map = "0";
-        }
+        map = button.toggle.checked ? "1" : "0";
       }
       // Refresh the items list
       getRootItems();


### PR DESCRIPTION
This PR adopts new VS Code APIs to improve some of our QuickPicks. The biggest change is the adoption of "toggle" buttons. Old version:
<img width="601" height="85" alt="old" src="https://github.com/user-attachments/assets/74592668-60db-4501-acb2-3798bff14e86" />
New version:
<img width="602" height="93" alt="new" src="https://github.com/user-attachments/assets/53b43a42-427e-48fa-a9fe-09dcc17ae16e" />
