### PR TITLE
Refactor Explorer code

### DIFF
--- a/package.json
+++ b/package.json
@@ -332,11 +332,6 @@
           "group": "navigation"
         },
         {
-          "command": "vscode-objectscript.explorer.project.openOtherServerNs",
-          "when": "view == ObjectScriptProjectsExplorer && vscode-objectscript.projectsExplorerRootCount > 0",
-          "group": "navigation"
-        },
-        {
           "command": "vscode-objectscript.openISCDocument",
           "when": "view == workbench.explorer.fileView && vscode-objectscript.connectActive && workspaceFolderCount != 0",
           "group": "navigation"
@@ -431,6 +426,11 @@
         {
           "command": "vscode-objectscript.explorer.project.closeOtherServerNs",
           "when": "view == ObjectScriptProjectsExplorer && viewItem == projectsServerNsNode:extra",
+          "group": "inline@10"
+        },
+        {
+          "command": "vscode-objectscript.explorer.project.openOtherServerNs",
+          "when": "view == ObjectScriptProjectsExplorer && viewItem == projectsServerNsNode",
           "group": "inline@10"
         },
         {
@@ -989,7 +989,7 @@
       {
         "category": "ObjectScript",
         "command": "vscode-objectscript.explorer.project.openOtherServerNs",
-        "title": "View Projects in Another Server Namespace",
+        "title": "View Projects in Another Namespace...",
         "icon": "$(add)"
       },
       {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -296,15 +296,8 @@ export class AtelierAPI {
   }
 
   public get connInfo(): string {
-    const { serverName, host, port, docker, dockerService } = this.config;
-    const ns = this.ns.toUpperCase();
-    return (
-      (docker
-        ? "docker" + (dockerService ? `:${dockerService}:${port}` : "")
-        : serverName
-          ? serverName
-          : `${host}:${port}`) + `[${ns}]`
-    );
+    const { port, docker, dockerService } = this.config;
+    return (docker ? "docker" + (dockerService ? `:${dockerService}:${port}` : "") : this.serverId) + `[${this.ns}]`;
   }
 
   /** Return the server's name in `intersystems.servers` if it exists, else its `host:port/pathPrefix` */

--- a/src/commands/addServerNamespaceToWorkspace.ts
+++ b/src/commands/addServerNamespaceToWorkspace.ts
@@ -17,7 +17,7 @@ import { isfsConfig, IsfsUriParam } from "../utils/FileProviderUtil";
  * @param message The prefix of the message to show when the server manager API can't be found.
  * @returns An object containing `serverName` and `namespace`, or `undefined`.
  */
-export async function pickServerAndNamespace(message?: string): Promise<{ serverName: string; namespace: string }> {
+async function pickServerAndNamespace(message?: string): Promise<{ serverName: string; namespace: string }> {
   if (!serverManagerApi) {
     vscode.window.showErrorMessage(
       `${

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -434,10 +434,10 @@ export async function importFolder(uri: vscode.Uri, noCompile = false): Promise<
 }
 
 export async function compileExplorerItems(nodes: NodeBase[]): Promise<any> {
-  const { workspaceFolderUri, namespace } = nodes[0];
-  const conf = vscode.workspace.getConfiguration("objectscript", workspaceFolderUri);
-  const api = new AtelierAPI(workspaceFolderUri);
-  api.setNamespace(namespace);
+  const { wsFolder, namespace } = nodes[0];
+  const conf = vscode.workspace.getConfiguration("objectscript", wsFolder);
+  const api = new AtelierAPI(wsFolder.uri);
+  if (namespace) api.setNamespace(namespace);
   const docs = [];
   for (const node of nodes) {
     if (node instanceof PackageNode) {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -2,23 +2,21 @@ import * as vscode from "vscode";
 
 import { AtelierAPI } from "../api";
 import { FILESYSTEM_SCHEMA, explorerProvider } from "../extension";
-import { outputChannel, uriOfWorkspaceFolder } from "../utils";
+import { outputChannel } from "../utils";
 import { OtherStudioAction, fireOtherStudioAction } from "./studio";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 import { UserAction } from "../api/atelier";
 import { NodeBase, PackageNode, RootNode } from "../explorer/nodes";
 
-function deleteList(items: string[], workspaceFolder: string, namespace: string): Promise<any> {
+function deleteList(items: string[], wsFolder: vscode.WorkspaceFolder, namespace?: string): Promise<any> {
   if (!items || !items.length) {
-    vscode.window.showWarningMessage("Nothing to delete");
+    vscode.window.showWarningMessage("No documents to delete.", "Dismiss");
   }
-
-  const wsFolderUri = uriOfWorkspaceFolder(workspaceFolder);
-  const api = new AtelierAPI(workspaceFolder);
-  api.setNamespace(namespace);
+  const api = new AtelierAPI(wsFolder.uri);
+  if (namespace) api.setNamespace(namespace);
   return Promise.all(items.map((item) => api.deleteDoc(item))).then((files) => {
     files.forEach((file) => {
-      if (file.result.ext && wsFolderUri?.scheme == FILESYSTEM_SCHEMA) {
+      if (file.result.ext && wsFolder.uri.scheme == FILESYSTEM_SCHEMA) {
         // Only process source control output if we're in an isfs folder
         const uri = DocumentContentProvider.getUri(file.result.name);
         fireOtherStudioAction(OtherStudioAction.DeletedDocument, uri, <UserAction>file.result.ext);
@@ -29,7 +27,7 @@ function deleteList(items: string[], workspaceFolder: string, namespace: string)
 }
 
 export async function deleteExplorerItems(nodes: NodeBase[]): Promise<any> {
-  const { workspaceFolder, namespace } = nodes[0];
+  const { wsFolder, namespace } = nodes[0];
   const nodesPromiseList: Promise<NodeBase[]>[] = [];
   for (const node of nodes) {
     nodesPromiseList.push(node instanceof RootNode ? node.getChildren(node) : Promise.resolve([node]));
@@ -56,7 +54,7 @@ export async function deleteExplorerItems(nodes: NodeBase[]): Promise<any> {
           // Don't delete without confirmation
           return;
         }
-        deleteList(items, workspaceFolder, namespace);
+        deleteList(items, wsFolder, namespace);
         explorerProvider.refresh();
       }
     });

--- a/src/explorer/nodes.ts
+++ b/src/explorer/nodes.ts
@@ -1,43 +1,21 @@
 import * as vscode from "vscode";
 import { AtelierAPI } from "../api";
-import { cspApps, currentWorkspaceFolder, stringifyError, uriOfWorkspaceFolder } from "../utils";
+import { cspApps, stringifyError } from "../utils";
 import { StudioActions, OtherStudioAction } from "../commands/studio";
 import { workspaceState } from "../extension";
 import { DocumentContentProvider } from "../providers/DocumentContentProvider";
 
 interface NodeOptions {
-  extraNode?: boolean;
   generated?: boolean;
   system?: boolean;
   namespace?: string;
-  workspaceFolder?: string;
-  workspaceFolderUri?: vscode.Uri;
+  wsFolder: vscode.WorkspaceFolder;
   project?: string;
 }
 
 /** Get the URI for this leaf node */
-function getLeafNodeUri(node: NodeBase, forceServerCopy = false): vscode.Uri {
-  if (node.workspaceFolder == undefined) {
-    // Should only be the case for leaf nodes in the projects explorer
-    // that are children of an extra server namespace node
-    return DocumentContentProvider.getUri(
-      node.fullName,
-      undefined,
-      undefined,
-      true,
-      node.workspaceFolderUri,
-      forceServerCopy
-    );
-  } else {
-    return DocumentContentProvider.getUri(
-      node.fullName,
-      node.workspaceFolder,
-      node.namespace,
-      undefined,
-      undefined,
-      forceServerCopy
-    );
-  }
+function getLeafNodeUri(node: NodeBase): vscode.Uri {
+  return DocumentContentProvider.getUri(node.fullName, undefined, node?.namespace, false, node.wsFolder.uri, true);
 }
 
 const inactiveMsg = "Server connection is inactive";
@@ -46,35 +24,21 @@ export class NodeBase {
   public readonly options: NodeOptions;
   public readonly label: string;
   public readonly fullName: string;
-  public readonly workspaceFolder: string;
-  public readonly conn: any;
-  public readonly extraNode: boolean;
-  public readonly namespace: string;
-  public readonly workspaceFolderUri: vscode.Uri;
+  /** The workspace folder this node is tied to */
+  public readonly wsFolder: vscode.WorkspaceFolder;
+  /** The namespace for this node, if it differs from the workspace folder's */
+  public readonly namespace?: string;
 
   protected constructor(label: string, fullName: string, options: NodeOptions) {
     this.options = {
       generated: false,
-      extraNode: false,
       ...options,
     };
     this.label = label;
     this.fullName = fullName;
-    const { workspaceFolder, namespace, extraNode, workspaceFolderUri } = options;
-    if (workspaceFolderUri) {
-      // Used by Projects tree
-      this.workspaceFolderUri = workspaceFolderUri;
-      this.workspaceFolder = vscode.workspace.getWorkspaceFolder(workspaceFolderUri)?.name;
-      const api = new AtelierAPI(workspaceFolderUri);
-      this.conn = api.config;
-    } else {
-      this.workspaceFolder = workspaceFolder || currentWorkspaceFolder();
-      this.workspaceFolderUri = uriOfWorkspaceFolder(this.workspaceFolder);
-      const api = new AtelierAPI(workspaceFolder);
-      this.conn = api.config;
-    }
-    this.namespace = namespace || this.conn.ns;
-    this.extraNode = extraNode;
+    const { namespace, wsFolder } = options;
+    this.wsFolder = wsFolder;
+    this.namespace = namespace?.toUpperCase();
   }
 
   public getTreeItem(): vscode.TreeItem {
@@ -88,7 +52,7 @@ export class NodeBase {
     return [];
   }
 
-  public async getItems4Export(): Promise<string[]> {
+  public async getItemsForExport(): Promise<string[]> {
     return [this.fullName];
   }
 }
@@ -174,7 +138,9 @@ export class RootNode extends NodeBase {
           .filter((el) => el !== null)
       )
       .catch((error) => [
-        error == inactiveMsg ? new InactiveNode("", "", {}) : new ErrorNode(stringifyError(error), "", {}),
+        error == inactiveMsg
+          ? new InactiveNode("", "", { wsFolder: this.wsFolder })
+          : new ErrorNode(stringifyError(error), "", { wsFolder: this.wsFolder }),
       ]);
   }
 
@@ -216,9 +182,9 @@ export class RootNode extends NodeBase {
 
     const systemFiles = this.options.system || this.namespace === "%SYS" ? "1" : "0";
 
-    const api = new AtelierAPI(this.workspaceFolder);
+    const api = new AtelierAPI(this.wsFolder.uri);
     if (!api.active) throw inactiveMsg;
-    api.setNamespace(this.namespace);
+    if (this.namespace) api.setNamespace(this.namespace);
     if (category == "CSP" && path == "") {
       // Use the results from the getCSPApps() API
       const cspAppsKey =
@@ -257,7 +223,7 @@ export class RootNode extends NodeBase {
     }
   }
 
-  public getItems4Export(): Promise<string[]> {
+  public getItemsForExport(): Promise<string[]> {
     const path = this instanceof PackageNode || this.isCsp ? this.fullName + "/" : "";
     const cat = this.isCsp ? "CSP" : "ALL";
     return this.getList(path, cat, true).then((data) => data.map((el) => el.Name));
@@ -272,7 +238,7 @@ export class ClassNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
-    const serverCopyUri = getLeafNodeUri(this, true);
+    const serverCopyUri = getLeafNodeUri(this);
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -296,7 +262,7 @@ export class CSPFileNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
-    const serverCopyUri = getLeafNodeUri(this, true);
+    const serverCopyUri = getLeafNodeUri(this);
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -341,7 +307,7 @@ export class RoutineNode extends NodeBase {
 
   public getTreeItem(): vscode.TreeItem {
     const displayName: string = this.label;
-    const serverCopyUri = getLeafNodeUri(this, true);
+    const serverCopyUri = getLeafNodeUri(this);
 
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.None,
@@ -362,7 +328,7 @@ export class WorkspaceNode extends NodeBase {
   public uniqueId: string;
   public constructor(label: string, eventEmitter: vscode.EventEmitter<NodeBase>, options: NodeOptions) {
     super(label, label, options);
-    this.uniqueId = `serverNode:${this.namespace}:${this.extraNode ? ":extra:" : ""}`;
+    this.uniqueId = `serverNode:${this.namespace}:${this.namespace ? ":extra:" : ""}`;
     this.options.generated = workspaceState.get(`ExplorerGenerated:${this.uniqueId}`);
     this.options.system = workspaceState.get(`ExplorerSystem:${this.uniqueId}`);
     this.eventEmitter = eventEmitter;
@@ -372,23 +338,24 @@ export class WorkspaceNode extends NodeBase {
     const flags = [];
     this.options.generated && flags.push(":generated:");
     this.options.system && flags.push(":system:");
-    const { host, port, docker, dockerService } = this.conn;
-    const serverInfo = docker
-      ? "docker" + (dockerService ? `:${dockerService}:${port}` : "")
-      : `${host}${port ? ":" + port : ""}`;
-    const connInfo = this.extraNode
-      ? `[${this.namespace}] on ${serverInfo}`
-      : `${this.label} (${serverInfo}[${this.namespace}])`;
+    const api = new AtelierAPI(this.wsFolder.uri);
+    let label: string;
+    if (this.namespace) {
+      api.setNamespace(this.namespace);
+      label = api.connInfo;
+    } else {
+      label = `${this.label} (${api.connInfo})`;
+    }
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
       contextValue: `${this.uniqueId}${flags.join("")}`,
-      label: connInfo,
-      iconPath: new vscode.ThemeIcon(this.extraNode ? "database" : "server-environment"),
+      label,
+      iconPath: new vscode.ThemeIcon(this.namespace ? "database" : "server-environment"),
     };
   }
 
   public async getChildren(_element: NodeBase): Promise<NodeBase[]> {
-    if (!new AtelierAPI(this.workspaceFolder).active) return [new InactiveNode("", "", {})];
+    if (!new AtelierAPI(this.wsFolder.uri).active) return [new InactiveNode("", "", { wsFolder: this.wsFolder })];
     const children = [];
     let node: RootNode;
 
@@ -463,8 +430,8 @@ export class ProjectNode extends NodeBase {
     let node: ProjectRootNode;
 
     // Technically a project is a "document", so tell the server that we're opening it
-    const api = new AtelierAPI(this.workspaceFolderUri);
-    api.setNamespace(this.namespace);
+    const api = new AtelierAPI(this.wsFolder.uri);
+    if (this.namespace) api.setNamespace(this.namespace);
     await new StudioActions().fireProjectUserAction(api, this.label, OtherStudioAction.OpenedDocument).catch(() => {
       // Swallow error because showing it is more disruptive than using a potentially outdated project definition
     });
@@ -537,16 +504,16 @@ export class ProjectNode extends NodeBase {
     };
   }
 
-  public getItems4Export(): Promise<string[]> {
+  public getItemsForExport(): Promise<string[]> {
     return Promise.resolve([]);
   }
 }
 
 export class ProjectRootNode extends RootNode {
-  public async getChildren(element: NodeBase): Promise<NodeBase[]> {
-    const api = new AtelierAPI(this.workspaceFolderUri);
-    if (!api.active) return [new InactiveNode("", "", {})];
-    api.setNamespace(this.namespace);
+  public async getChildren(): Promise<NodeBase[]> {
+    const api = new AtelierAPI(this.wsFolder.uri);
+    if (!api.active) return [new InactiveNode("", "", { wsFolder: this.wsFolder })];
+    if (this.namespace) api.setNamespace(this.namespace);
     let query: string;
     let parameters: string[];
     if (this.fullName.length) {
@@ -638,9 +605,9 @@ export class ProjectRootNode extends RootNode {
           }
         })
       )
-      .catch((error) => [new ErrorNode(stringifyError(error), "", {})]);
+      .catch((error) => [new ErrorNode(stringifyError(error), "", { wsFolder: this.wsFolder })]);
   }
-  public getItems4Export(): Promise<string[]> {
+  public getItemsForExport(): Promise<string[]> {
     return Promise.resolve([]);
   }
 }
@@ -648,28 +615,30 @@ export class ProjectRootNode extends RootNode {
 export class ProjectsServerNsNode extends NodeBase {
   public eventEmitter: vscode.EventEmitter<NodeBase>;
 
-  public constructor(label: string, eventEmitter: vscode.EventEmitter<NodeBase>, wsUri: vscode.Uri, extra = false) {
-    super(label, label, { workspaceFolderUri: wsUri, extraNode: extra });
+  public constructor(
+    label: string,
+    eventEmitter: vscode.EventEmitter<NodeBase>,
+    wsFolder: vscode.WorkspaceFolder,
+    namespace?: string
+  ) {
+    super(label, label, { wsFolder, namespace });
     this.eventEmitter = eventEmitter;
   }
 
   public getTreeItem(): vscode.TreeItem {
-    const { host, port, pathPrefix, serverName } = this.conn;
     return {
       collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
-      contextValue: `projectsServerNsNode${this.extraNode ? ":extra" : ""}`,
-      label: `${
-        serverName && serverName.length ? serverName : `${host}:${port}${pathPrefix}`
-      }:${this.namespace.toUpperCase()}`,
+      contextValue: `projectsServerNsNode${this.namespace ? ":extra" : ""}`,
+      label: this.label,
       iconPath: new vscode.ThemeIcon("server-environment"),
       tooltip: "Explore projects in this server namespace",
     };
   }
 
-  public async getChildren(element: NodeBase): Promise<NodeBase[]> {
-    const api = new AtelierAPI(this.workspaceFolderUri);
-    if (!api.active) return [new InactiveNode("", "", {})];
-    api.setNamespace(this.namespace);
+  public async getChildren(): Promise<NodeBase[]> {
+    const api = new AtelierAPI(this.wsFolder.uri);
+    if (!api.active) return [new InactiveNode("", "", { wsFolder: this.wsFolder })];
+    if (this.namespace) api.setNamespace(this.namespace);
     return api
       .actionQuery("SELECT Name, Description FROM %Studio.Project", [])
       .then((data) =>
@@ -677,7 +646,7 @@ export class ProjectsServerNsNode extends NodeBase {
           (project) => new ProjectNode(project.Name, { project: project.Name, ...this.options }, project.Description)
         )
       )
-      .catch((error) => [new ErrorNode(stringifyError(error), "", {})]);
+      .catch((error) => [new ErrorNode(stringifyError(error), "", { wsFolder: this.wsFolder })]);
   }
 }
 
@@ -694,7 +663,7 @@ class InactiveNode extends NodeBase {
       iconPath: new vscode.ThemeIcon("warning", new vscode.ThemeColor("problemsWarningIcon.foreground")),
     };
   }
-  public getItems4Export(): Promise<string[]> {
+  public getItemsForExport(): Promise<string[]> {
     return Promise.resolve([]);
   }
 }
@@ -713,7 +682,7 @@ class ErrorNode extends NodeBase {
       iconPath: new vscode.ThemeIcon("error", new vscode.ThemeColor("problemsErrorIcon.foreground")),
     };
   }
-  public getItems4Export(): Promise<string[]> {
+  public getItemsForExport(): Promise<string[]> {
     return Promise.resolve([]);
   }
 }


### PR DESCRIPTION
This PR implements a refactoring of the Explorer and Projects Explorer codebases. When I added the Projects Explorer, I tried to make minimal changes to the existing Explorer. This led to a lot of conditional code and little shared code. I refactored the code so the Explorers will be easier to maintain in the future. There are three small UI changes that resulted from this work:

1. Server connection information shown in Explorer and Projects Explorer root items will be formatted the same was as the connection Status Bar item (`server[NS]`)
1. The `+` button to add a root for another namespace has been added to existing roots of the Projects Explorer instead of the view title bar to match the Explorer.
1. Users can now only add additional Projects Explorer roots for namespaces on currently opened servers, not any server connection. This aligns it with Explorer.