### PR TITLE
Don't show error when trying to trigger reload of any open `objectscript://` documents after importing a file

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -138,7 +138,7 @@ export async function importFile(
         undefined,
         true
       );
-      documentContentProvider.update(serverUri.with({ scheme: OBJECTSCRIPT_FILE_SCHEMA }));
+      if (serverUri) documentContentProvider.update(serverUri);
     })
     .catch((error) => {
       if (error?.statusCode == 409) {

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -257,7 +257,7 @@ export class DocumentContentProvider implements vscode.TextDocumentContentProvid
     }
   }
 
-  public update(uri: vscode.Uri, message?: string): void {
+  public update(uri: vscode.Uri): void {
     this.onDidChangeEvent.fire(uri);
   }
 }


### PR DESCRIPTION
This PR fixes #1743