### PR TITLE
Log all compile error messages to Output channel

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -376,8 +376,8 @@ export async function compile(docs: (CurrentTextFile | CurrentBinaryFile)[], ask
             }
             return docs;
           })
-          .catch(() => {
-            compileErrorMsg();
+          .catch((error) => {
+            compileErrorMsg(error);
             // Always fetch server changes, even when compile failed or got cancelled
             return docs;
           })
@@ -550,7 +550,7 @@ export async function compileExplorerItems(nodes: NodeBase[]): Promise<any> {
             throw new Error(`${info}Compile error`);
           }
         })
-        .catch(() => compileErrorMsg())
+        .catch((error) => compileErrorMsg(error))
   );
 }
 
@@ -637,7 +637,7 @@ async function promptForCompile(imported: string[], api: AtelierAPI, isIsfs: boo
                     throw new Error(`${info}Compile error`);
                   }
                 })
-                .catch(() => compileErrorMsg())
+                .catch((error) => compileErrorMsg(error))
                 .finally(() => {
                   if (isIsfs) {
                     // Refresh the files explorer to show the new files

--- a/src/providers/FileSystemProvider/FileSystemProvider.ts
+++ b/src/providers/FileSystemProvider/FileSystemProvider.ts
@@ -914,7 +914,7 @@ export class FileSystemProvider implements vscode.FileSystemProvider {
             }
             data.result.content.forEach((f) => filesToUpdate.push(f.name));
           })
-          .catch(() => compileErrorMsg())
+          .catch((error) => compileErrorMsg(error))
     );
     if (file && (update || filesToUpdate.includes(file.fileName))) {
       // This file was just written and the write may have changed its contents or the

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -76,11 +76,11 @@ export function stringifyError(error): string {
       )
         .trim()
         // Unescape any HTML-escpaed characters
-        .replaceAll("&amp;", "&")
         .replaceAll("&lt;", "<")
         .replaceAll("&gt;", ">")
         .replaceAll("&quot;", '"')
         .replaceAll("&#39;", "'")
+        .replaceAll("&amp;", "&")
     );
   } catch {
     // Need to catch errors from JSON.stringify()

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1027,12 +1027,11 @@ export async function replaceFile(uri: vscode.Uri, content: string | string[] | 
 
 /** Show the compilation failure error message if required. */
 export function compileErrorMsg(error: any): void {
-  if (error instanceof Error && error.message.endsWith("Compile error")) {
-    // Don't log the generic placeholder error
-    handleError("", "Compilaton failed.");
-  } else {
-    handleError(error, "Compilaton failed.");
-  }
+  handleError(
+    // Don't log the generic placeholder error if that's all we have
+    error instanceof Error && error.message.endsWith("Compile error") ? "" : error,
+    "Compilaton failed."
+  );
 }
 
 /** Return a string containing the displayable form of `uri` */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -72,7 +72,14 @@ export function stringifyError(error): string {
             : error instanceof Error
               ? error.toString()
               : JSON.stringify(error)
-    ).trim();
+    )
+      .trim()
+      // Unescape any HTML-escpaed characters
+      .replaceAll("&amp;", "&")
+      .replaceAll("&lt;", "<")
+      .replaceAll("&gt;", ">")
+      .replaceAll("&quot;", '"')
+      .replaceAll("&#39;", "'");
   } catch {
     // Need to catch errors from JSON.stringify()
     return "";
@@ -1017,7 +1024,11 @@ export async function replaceFile(uri: vscode.Uri, content: string | string[] | 
 }
 
 /** Show the compilation failure error message if required. */
-export function compileErrorMsg(): void {
+export function compileErrorMsg(error: any): void {
+  if (!(error instanceof Error && error.message.endsWith("Compile error"))) {
+    // Don't log the generic placeholder error
+    handleError(error);
+  }
   vscode.window
     .showErrorMessage(
       "Compilation failed. Check 'ObjectScript' Output channel for details.",

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -63,23 +63,25 @@ export function stringifyError(error): string {
       return errs.length ? `AggregateError:\n- ${errs.join("\n- ")}` : "";
     }
     return (
-      error == undefined
-        ? ""
-        : error.errorText
-          ? <string>error.errorText
-          : typeof error == "string"
-            ? error
-            : error instanceof Error
-              ? error.toString()
-              : JSON.stringify(error)
-    )
-      .trim()
-      // Unescape any HTML-escpaed characters
-      .replaceAll("&amp;", "&")
-      .replaceAll("&lt;", "<")
-      .replaceAll("&gt;", ">")
-      .replaceAll("&quot;", '"')
-      .replaceAll("&#39;", "'");
+      (
+        error == undefined
+          ? ""
+          : error.errorText
+            ? <string>error.errorText
+            : typeof error == "string"
+              ? error
+              : error instanceof Error
+                ? error.toString()
+                : JSON.stringify(error)
+      )
+        .trim()
+        // Unescape any HTML-escpaed characters
+        .replaceAll("&amp;", "&")
+        .replaceAll("&lt;", "<")
+        .replaceAll("&gt;", ">")
+        .replaceAll("&quot;", '"')
+        .replaceAll("&#39;", "'")
+    );
   } catch {
     // Need to catch errors from JSON.stringify()
     return "";
@@ -1025,21 +1027,12 @@ export async function replaceFile(uri: vscode.Uri, content: string | string[] | 
 
 /** Show the compilation failure error message if required. */
 export function compileErrorMsg(error: any): void {
-  if (!(error instanceof Error && error.message.endsWith("Compile error"))) {
+  if (error instanceof Error && error.message.endsWith("Compile error")) {
     // Don't log the generic placeholder error
-    handleError(error);
+    handleError("", "Compilaton failed.");
+  } else {
+    handleError(error, "Compilaton failed.");
   }
-  vscode.window
-    .showErrorMessage(
-      "Compilation failed. Check 'ObjectScript' Output channel for details.",
-      !vscode.window.visibleTextEditors.some((e) => e.document.languageId == outputLangId) ? "Show" : undefined,
-      "Dismiss"
-    )
-    .then((action) => {
-      if (action == "Show") {
-        outputChannel.show(true);
-      }
-    });
 }
 
 /** Return a string containing the displayable form of `uri` */


### PR DESCRIPTION
This PR fixes #1749. It also HTML-unescapes error strings before they are written to the Output channel so they are easier to read.