### PR TITLE
Improve the accuracy of Storage update

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });


### PR DESCRIPTION
This PR improves accuracy by more carefully matching storage members.

Previously, we treated `}` as the end of a storage definition. However, this check is incorrect when a storage contains `{%%PARENT}` (see `DataLocation (Storage Keyword)` in the IRIS documentation).

This PR improves accuracy by requiring a preceding `>` (allowing intervening whitespace or newlines) before the closing `}` to identify the end of a storage definition.