### PR TITLE
`Overwrite from Server` command should always replace the entire class text

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -218,7 +218,16 @@ function updateOthers(others: string[], baseUri: vscode.Uri) {
   });
 }
 
-export async function loadChanges(files: (CurrentTextFile | CurrentBinaryFile)[]): Promise<any> {
+/**
+ * Pull changes due to save/compile from server and write them into the local file.
+ * Also used to refresh the local copy from the server outside of the save/compile workflow.
+ * Pass `forceRefreshClasses` to replace the entire text of classes regardless of the
+ * value of the `objectscript.refreshClassesOnSync` setting.
+ */
+export async function loadChanges(
+  files: (CurrentTextFile | CurrentBinaryFile)[],
+  forceRefreshClasses = false
+): Promise<any> {
   if (!files.length) {
     return;
   }
@@ -236,7 +245,8 @@ export async function loadChanges(files: (CurrentTextFile | CurrentBinaryFile)[]
           if (
             !(
               isClass(file.uri.path) &&
-              !vscode.workspace.getConfiguration("objectscript", file.uri).get("refreshClassesOnSync")
+              !vscode.workspace.getConfiguration("objectscript", file.uri).get("refreshClassesOnSync") &&
+              !forceRefreshClasses
             )
           ) {
             content = (await api.getDoc(file.name, file.uri)).result.content;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1142,7 +1142,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       const file = currentFile();
       if (!file) return;
       try {
-        await loadChanges([file]);
+        await loadChanges([file], true);
       } catch (error) {
         handleError(
           error,

--- a/src/providers/LowCodeEditorProvider.ts
+++ b/src/providers/LowCodeEditorProvider.ts
@@ -243,7 +243,7 @@ export class LowCodeEditorProvider implements vscode.CustomTextEditorProvider {
             });
           } else if (isClientSide) {
             // Load changes
-            loadChanges([file]);
+            loadChanges([file], true);
           }
           return;
         case "compiled":
@@ -253,7 +253,7 @@ export class LowCodeEditorProvider implements vscode.CustomTextEditorProvider {
             vscode.commands.executeCommand("workbench.action.files.revert");
           }
           // Load changes
-          if (isClientSide) loadChanges([file]);
+          if (isClientSide) loadChanges([file], true);
           return;
         case "userAction": {
           // Process the source control user action


### PR DESCRIPTION
This PR fixes #1757 