### PR TITLE
Update release CI script to use `softprops/action-gh-release@v3` for Node 24 compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,7 +145,7 @@ jobs:
           npx vsce package -o ${{ steps.set-version.outputs.name }}.vsix
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: ${{ steps.set-version.outputs.name }}.vsix


### PR DESCRIPTION
This PR prepares for June 16 switch of GH-hosted runners to use Node 24.

@isc-bsaviano I don't know how to test this other than merge it in time for our next release, then cross fingers.