### PR TITLE
Always overwrite entire class for `Pull Server Changes` when there's a conflict between the local copy and server copy

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -186,7 +186,7 @@ What do you want to do?`,
           // Overwrite
           return importFile(file, willCompile, true, true);
         case "Pull Server Changes":
-          loadChanges([file]);
+          loadChanges([file], true);
           return Promise.reject();
         case "Cancel":
           return Promise.reject();


### PR DESCRIPTION
This PR fixes an issue reported internally