### PR TITLE
Fix password disclosure via serverForUri and stale cookie reuse after logout/401

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -79,7 +79,8 @@ export class AtelierAPI {
   }
 
   public get config(): ConnectionSettings {
-    const { serverName, active = false, https = false, pathPrefix = "", auth } = this._config;
+    const { serverName, active = false, https = false, pathPrefix = "" } = this._config;
+    const auth = this._config.auth.clone();
     const ns = this.namespace || this._config.ns;
     const wsKey = this.configName.toLowerCase();
     const host = this.externalServer ? this._config.host : workspaceState.get(wsKey + ":host", this._config.host);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -36,6 +36,7 @@ export async function logoutOfSessions(sessions?: string[]): Promise<void> {
     (sessions ?? Array.from(cookiesMap.keys())).map((session) => {
       const cookie = cookiesMap.get(session);
       if (!cookie) return;
+      cookiesMap.delete(session);
       const url = session.slice(session.indexOf("@") + 1);
       return axios.head(`${url}/api/atelier/?CacheLogout=end`, {
         headers: {
@@ -463,6 +464,7 @@ export class AtelierAPI {
       }
       if (response.status === 401) {
         authRequestMap.delete(mapKey);
+        cookiesMap.delete(mapKey);
         if (this.wsOrFile && !checkingConnection) {
           setTimeout(() => {
             checkConnection(

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });

--- a/src/commands/connectFolderToServerNamespace.ts
+++ b/src/commands/connectFolderToServerNamespace.ts
@@ -62,7 +62,7 @@ export async function connectFolderToServerNamespace(): Promise<void> {
   // Prepare a displayable form of its connection spec as a hint to the user
   // This will never return the default value (second parameter) because we only just resolved the connection spec.
   const connSpec = getResolvedConnectionSpec(serverName, undefined);
-  const connDisplayString = `${connSpec!.webServer.scheme}://${connSpec!.webServer.host}:${connSpec!.webServer.port}/${connSpec!.webServer.pathPrefix}`;
+  const connDisplayString = `${connSpec!.webServer.scheme}://${connSpec!.webServer.host}:${connSpec!.webServer.port}${connSpec!.webServer.pathPrefix}`;
   // Connect and fetch namespaces
   const api = new AtelierAPI(vscode.Uri.parse(`isfs://${serverName}/?ns=%SYS`));
   const serverConf = vscode.workspace

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2005,8 +2005,9 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
   const { serverName, active, host, https, port, superserverPort, pathPrefix, auth, ns, apiVersion, serverVersion } =
     api.config;
   auth.clear() as void;
-  if (serverName !== "") {
-    const password = vscode.workspace
+  const password: string | undefined =
+    serverName &&
+    vscode.workspace
       .getConfiguration(
         `intersystems.servers.${serverName.toLowerCase()}`,
         // objectscript(xml):// URIs are not in any workspace folder,
@@ -2017,11 +2018,8 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
           ? vscode.workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == configNameLower)?.uri
           : uri
       )
-      .get("password") as string | undefined;
-    if (password !== undefined) {
-      auth.resolve({ accessToken: password });
-    }
-  }
+      .get("password");
+  password && auth.resolve({ accessToken: password });
   return {
     serverName,
     active,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2004,6 +2004,7 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
   // which will require explicit user consent to divulge the password to the requesting extension.
   const { serverName, active, host, https, port, superserverPort, pathPrefix, auth, ns, apiVersion, serverVersion } =
     api.config;
+  auth.clear() as void;
   if (serverName !== "") {
     const password = vscode.workspace
       .getConfiguration(


### PR DESCRIPTION
Fixes #1825 and #1823.

#1825 — serverForUri now clears the Authorization object before returning it, so it only carries a resolved password when one is set in plaintext in settings.json. AtelierAPI.config now clones the Authorization object before returning it, so callers invoking `.resolve()`/`.clear()` on the returned object can no longer mutate the shared, internal one.

#1823 — logoutOfSessions and the 401 handler in AtelierAPI.request() now delete the corresponding cookiesMap entry, so a stale/invalidated cookie can't keep being resent on subsequent requests.

Also included: a display-string fix for the connection URL shown when connecting a folder to a server namespace — it had an extra `/` hardcoded before pathPrefix, which produced a doubled slash since pathPrefix already includes its own leading `/`.