### PR TITLE
Retry once and delete cookies on failed

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -577,8 +577,9 @@ export class AtelierAPI {
         outputChannel.appendLine(`${JSON.stringify(error, null, 2)}`);
         outputChannel.appendLine(`+- END ----------------------------------------------`);
       }
-      // always discard the cached authentication promise
+      // always discard the cached authentication promise and cookies
       authRequestMap.delete(mapKey);
+      cookiesMap.delete(mapKey);
 
       // In some cases schedule an automatic retry.
       // ENOTFOUND occurs if, say, the VPN to the server's network goes down.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -466,6 +466,12 @@ export class AtelierAPI {
         authRequestMap.delete(mapKey);
         cookiesMap.delete(mapKey);
         if (this.wsOrFile && !checkingConnection) {
+          if (!options?._retriedAfter401) {
+            return this.request(minVersion, method, originalPath, body, params, headers, {
+              ...options,
+              _retriedAfter401: true,
+            });
+          }
           setTimeout(() => {
             checkConnection(
               this.config.auth.resolved(),
@@ -577,13 +583,15 @@ export class AtelierAPI {
         outputChannel.appendLine(`${JSON.stringify(error, null, 2)}`);
         outputChannel.appendLine(`+- END ----------------------------------------------`);
       }
-      // always discard the cached authentication promise and cookies
+      // always discard the cached authentication promise
       authRequestMap.delete(mapKey);
-      cookiesMap.delete(mapKey);
 
       // In some cases schedule an automatic retry.
       // ENOTFOUND occurs if, say, the VPN to the server's network goes down.
       if (["ECONNREFUSED", "ENOTFOUND", "ECONNABORTED", "ERR_CANCELED"].includes(error.code)) {
+        // The cached cookie is unusable once the connection itself has failed; discard it
+        // so the next request re-authenticates instead of resending a stale cookie.
+        cookiesMap.delete(mapKey);
         panel.text = `${this.connInfo} $(debug-disconnect)`;
         panel.tooltip = "Disconnected";
         workspaceState.update(this.configName.toLowerCase() + ":host", undefined);

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });


### PR DESCRIPTION
This PR fixes #1829

- On a connection failure (`ECONNREFUSED`/`ENOTFOUND`/`ECONNABORTED`/`ERR_CANCELED`), discard the cached session cookie so the next request re-authenticates instead of resending one that's no longer usable.
- On a `401`, retry the request once automatically after re-authenticating. A `401` is rejected before any server-side request logic runs, so retrying is safe — no risk of duplicating a side effect.

## Test plan

1. In the Management Portal, set the Atelier session timeout to a short value (5s in my testing).
2. Open a server-side document.
3. Wait longer than the timeout (10s, to be safe).
4. Open a different server-side document.

**Before this PR:** step 4 fails with an error.
**After this PR:** step 4 succeeds with no error.