### PR TITLE
Fix crash when opening a file with no workspace folder open

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1130,7 +1130,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<server
       }
     }),
     vscode.window.onDidChangeActiveTextEditor(async (editor) => {
-      if (vscode.workspace.workspaceFolders!.length > 1) {
+      if ((vscode.workspace.workspaceFolders?.length ?? 0) > 1) {
         const workspaceFolder = currentWorkspaceFolder();
         if (workspaceFolder && workspaceFolder != workspaceState.get<string>("workspaceFolder")) {
           await workspaceState.update("workspaceFolder", workspaceFolder);


### PR DESCRIPTION
## Summary
- Fixes #1833 and #1826 — `TypeError: Cannot read properties of undefined (reading 'length')` in the Extension Host log, causing the extension to fail to activate.
- `vscode.workspace.workspaceFolders` is `undefined` in that case, but the `onDidChangeActiveTextEditor` handler used a non-null assertion (`workspaceFolders!.length > 1`) on it.
- #1826 was reported as comment/uncomment keyboard shortcuts not working on a `.cls` file; the actual root cause was that the extension had failed to activate (this crash), not the language configuration.

## Test plan
- [x] Opened a single `.cls` file with no folder/workspace open in the Extension Development Host and confirmed the error no longer appears in the Extension Host output.
- [x] With no folder open, confirmed the comment/uncomment keyboard shortcuts on a `.cls` file now work.