### PR TITLE
`serverForUri` should either set ns or be undefined

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -58,7 +58,7 @@ export interface ConnectionSettings {
   port: number;
   superserverPort?: number;
   pathPrefix?: string;
-  ns: string | undefined;
+  ns?: string;
   auth: Authorization;
   docker?: boolean;
   dockerService?: string;
@@ -254,7 +254,7 @@ export class AtelierAPI {
       serverName = "";
     }
 
-    const ns = namespace ? namespace.toUpperCase() : conn.ns ? (conn.ns as string).toUpperCase() : undefined;
+    const ns = namespace?.toUpperCase() || conn.ns?.toUpperCase();
     if (serverName !== "") {
       const {
         webServer: { scheme, host, port, pathPrefix = "" },

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2004,7 +2004,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<server
 
 // This function is exported as one of our API functions but is also used internally
 // for example to implement the async variant capable of resolving docker port number.
-function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
+function serverForUri(uri: vscode.Uri): serverManager.ServerForUri | undefined {
   const { apiTarget, configName } = connectionTarget(uri);
   const configNameLower = configName.toLowerCase();
   const api = new AtelierAPI(apiTarget);
@@ -2030,27 +2030,32 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
       )
       .get("password");
   password && auth.resolve({ accessToken: password });
-  return {
-    serverName,
-    active,
-    ...(https ? ({ https: true, scheme: "https" } as const) : ({ scheme: "http" } as const)),
-    host,
-    port,
-    superserverPort,
-    pathPrefix: pathPrefix!,
-    auth,
-    username: auth.username,
-    password: auth.password,
-    namespace: ns!,
-    apiVersion: (active ? apiVersion : undefined)!,
-    serverVersion: (active ? serverVersion : undefined)!,
-  };
+  if (ns) {
+    return {
+      serverName,
+      active,
+      ...(https ? ({ https: true, scheme: "https" } as const) : ({ scheme: "http" } as const)),
+      host,
+      port,
+      superserverPort,
+      pathPrefix: pathPrefix || "",
+      auth,
+      username: auth.username,
+      password: auth.password,
+      namespace: ns,
+      apiVersion: (active ? apiVersion : undefined)!,
+      serverVersion: (active ? serverVersion : undefined)!,
+    };
+  }
 }
 
 // An async variant capable of resolving docker port number.
 // It is exported as one of our API functions but is also used internally.
-async function asyncServerForUri(uri: vscode.Uri): Promise<serverManager.ServerForUri> {
+async function asyncServerForUri(uri: vscode.Uri): Promise<serverManager.ServerForUri | undefined> {
   const server = serverForUri(uri);
+  if (!server) {
+    return;
+  }
   if (!server.port) {
     let { apiTarget } = connectionTarget(uri);
     if (apiTarget instanceof vscode.Uri) {

--- a/src/providers/DocumentContentProvider.ts
+++ b/src/providers/DocumentContentProvider.ts
@@ -9,8 +9,8 @@ import { getUrisForDocument } from "../utils/documentIndex";
 import { isfsConfig, IsfsUriParam } from "../utils/FileProviderUtil";
 
 export function compareConns(
-  conn1: { ns: any; server?: any; host: any; port: any; "docker-compose"?: any },
-  conn2: { ns: any; server?: any; host: any; port: any; "docker-compose"?: any }
+  conn1: { ns?: string; server?: any; host: any; port: any; "docker-compose"?: any },
+  conn2: { ns?: string; server?: any; host: any; port: any; "docker-compose"?: any }
 ): boolean {
   if (conn1.ns === conn2.ns) {
     // Same namespace name


### PR DESCRIPTION
While working on [language-server#414](https://github.com/intersystems/language-server/pull/414), I found that `serverForUri` can return a `ServerForUri` with `namespace` (typed as required `string`) actually `undefined` at runtime.

**Root cause**: [`AtelierAPI.setConnection`](https://github.com/intersystems-community/vscode-objectscript/blob/5ca339123fad9cacc0e2151ec914b01b8e273df8/src/api/index.ts#L257) computes `ns` as `undefined` when neither an explicit namespace nor `objectscript.conn.ns` is set. That flows through `_config`/`config()` and gets asserted non-null where [`serverForUri` destructures it](https://github.com/intersystems-community/vscode-objectscript/blob/5ca339123fad9cacc0e2151ec914b01b8e273df8/src/extension.ts#L2015-L2016).

**Fix**: return `undefined` from `serverForUri` instead of lying with `!`.

I am not sure if we want to instead default the namespace to `USER`.