### PR TITLE
Deprecate configuring a server host/port/credentials in `objectscript.conn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1196,6 +1196,7 @@
             "port": {
               "type": "integer",
               "description": "TCP port number the web server listens on.",
+              "deprecationMessage": "It is recommended to define a server connection in `#intersystems.servers#` instead of here.",
               "minimum": 1,
               "maximum": 65535
             },


### PR DESCRIPTION
This PR adds a deprecation message that will be shown whenever a user configures a server directly in `objectscript.conn`. This legacy mechanism is leftover from before Server Manager existed and shouldn't be used anymore. I only added the message to the `port` property so the user won't see four messages if they have all four properties defined, and since `port` has non default it must always be set to be usable.