### PR TITLE
`serverForUri` should preserve passwords stored in `settings.json["objectscript.conn"]`

### DIFF
--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -283,11 +283,12 @@ function updateStorage(content: string[], storage: string[]): string[] {
   let contentString = content.join("\n");
   contentString = contentString
     // update existing Storages
-    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)([^}]*?)(\s*})/gim, (_match, beforeXML, name, _oldXML, afterXML) => {
-      const newXML = storageMap.get(name);
+    .replaceAll(/\n(\s*storage\s+(\w+)\s*{\s*)(.*?)(>\s*})/gis, (_match, beforeXML, name, _oldXML, afterXML) => {
+      let newXML = storageMap.get(name);
       if (newXML === undefined) {
         return "";
       }
+      newXML = newXML.slice(0, newXML.length - 1);
       storageMap.delete(name);
       return "\n" + beforeXML + newXML + afterXML;
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2014,24 +2014,22 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
   // which will require explicit user consent to divulge the password to the requesting extension.
   const { serverName, active, host, https, port, superserverPort, pathPrefix, auth, ns, apiVersion, serverVersion } =
     api.config;
-  // The auth is resolved if and only if a password is provided by settings.json["objectscript.conn"]
-  if (! auth.resolved()) {
-    const password: string | undefined =
-      serverName &&
-      vscode.workspace
-        .getConfiguration(
-          `intersystems.servers.${serverName.toLowerCase()}`,
-          // objectscript(xml):// URIs are not in any workspace folder,
-          // so make sure we resolve the server definition with the proper
-          // granularity. This is needed to prevent other extensions like
-          // Language Server prompting for a passwoord when it's not needed.
-          [OBJECTSCRIPT_FILE_SCHEMA, OBJECTSCRIPTXML_FILE_SCHEMA].includes(uri.scheme)
-            ? vscode.workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == configNameLower)?.uri
-            : uri
-        )
-        .get("password");
-    password && auth.resolve({ accessToken: password });
-  }
+  auth.clear() as void;
+  const password =
+    config("conn", configName).password ||
+    vscode.workspace
+      .getConfiguration(
+        `intersystems.servers.${serverName.toLowerCase()}`,
+        // objectscript(xml):// URIs are not in any workspace folder,
+        // so make sure we resolve the server definition with the proper
+        // granularity. This is needed to prevent other extensions like
+        // Language Server prompting for a passwoord when it's not needed.
+        [OBJECTSCRIPT_FILE_SCHEMA, OBJECTSCRIPTXML_FILE_SCHEMA].includes(uri.scheme)
+          ? vscode.workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == configNameLower)?.uri
+          : uri
+      )
+      .get<string>("password");
+  password && auth.resolve({ accessToken: password });
   return {
     serverName,
     active,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2014,22 +2014,24 @@ function serverForUri(uri: vscode.Uri): serverManager.ServerForUri {
   // which will require explicit user consent to divulge the password to the requesting extension.
   const { serverName, active, host, https, port, superserverPort, pathPrefix, auth, ns, apiVersion, serverVersion } =
     api.config;
-  auth.clear() as void;
-  const password: string | undefined =
-    serverName &&
-    vscode.workspace
-      .getConfiguration(
-        `intersystems.servers.${serverName.toLowerCase()}`,
-        // objectscript(xml):// URIs are not in any workspace folder,
-        // so make sure we resolve the server definition with the proper
-        // granularity. This is needed to prevent other extensions like
-        // Language Server prompting for a passwoord when it's not needed.
-        [OBJECTSCRIPT_FILE_SCHEMA, OBJECTSCRIPTXML_FILE_SCHEMA].includes(uri.scheme)
-          ? vscode.workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == configNameLower)?.uri
-          : uri
-      )
-      .get("password");
-  password && auth.resolve({ accessToken: password });
+  // The auth is resolved if and only if a password is provided by settings.json["objectscript.conn"]
+  if (! auth.resolved()) {
+    const password: string | undefined =
+      serverName &&
+      vscode.workspace
+        .getConfiguration(
+          `intersystems.servers.${serverName.toLowerCase()}`,
+          // objectscript(xml):// URIs are not in any workspace folder,
+          // so make sure we resolve the server definition with the proper
+          // granularity. This is needed to prevent other extensions like
+          // Language Server prompting for a passwoord when it's not needed.
+          [OBJECTSCRIPT_FILE_SCHEMA, OBJECTSCRIPTXML_FILE_SCHEMA].includes(uri.scheme)
+            ? vscode.workspace.workspaceFolders?.find((f) => f.name.toLowerCase() == configNameLower)?.uri
+            : uri
+        )
+        .get("password");
+    password && auth.resolve({ accessToken: password });
+  }
   return {
     serverName,
     active,


### PR DESCRIPTION
Fix https://github.com/intersystems/language-server/issues/415, which I believe is a regression introduced by 5d4083016933f48bbe5a5bc08b38e12fdc86a2cc

This PR might be related to https://github.com/intersystems-community/intersystems-servermanager/issues/353